### PR TITLE
[webhooks] add read-only list UI

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/workers/WebhooksUpdateWorker.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/workers/WebhooksUpdateWorker.kt
@@ -40,6 +40,7 @@ class WebhooksUpdateWorker(appContext: Context, params: WorkerParameters) :
             id = id,
             url = url,
             event = event,
+            source = EntitySource.Cloud,
         )
     }
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebHooksService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebHooksService.kt
@@ -32,12 +32,16 @@ class WebHooksService(
         eventsReceiver.stop()
     }
 
-    fun select(source: EntitySource): List<WebHookDTO> {
-        return webHooksDao.selectBySource(source).map {
+    fun select(source: EntitySource?): List<WebHookDTO> {
+        return when (source) {
+            null -> webHooksDao.select()
+            else -> webHooksDao.selectBySource(source)
+        }.map {
             WebHookDTO(
                 id = it.id,
                 url = it.url,
                 event = it.event,
+                source = it.source,
             )
         }
     }
@@ -77,6 +81,7 @@ class WebHooksService(
             id = webHookEntity.id,
             url = webHookEntity.url,
             event = webHookEntity.event,
+            source = webHookEntity.source,
         )
     }
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebHooksDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebHooksDao.kt
@@ -12,6 +12,9 @@ import me.capcom.smsgateway.modules.webhooks.domain.WebHookEvent
 @Dao
 interface WebHooksDao {
 
+    @Query("SELECT * FROM webHook")
+    fun select(): List<WebHook>
+
     @Query("SELECT * FROM webHook WHERE event = :event")
     fun selectByEvent(event: WebHookEvent): List<WebHook>
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookDTO.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookDTO.kt
@@ -1,7 +1,10 @@
 package me.capcom.smsgateway.modules.webhooks.domain
 
+import me.capcom.smsgateway.domain.EntitySource
+
 data class WebHookDTO(
     val id: String?,
     val url: String,
     val event: WebHookEvent,
+    val source: EntitySource,
 )

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
@@ -2,19 +2,19 @@ package me.capcom.smsgateway.modules.webhooks.domain
 
 import com.google.gson.annotations.SerializedName
 
-enum class WebHookEvent {
+enum class WebHookEvent(val value: String) {
     @SerializedName("sms:received")
-    SmsReceived,
+    SmsReceived("sms:received"),
 
     @SerializedName("sms:sent")
-    SmsSent,
+    SmsSent("sms:sent"),
 
     @SerializedName("sms:delivered")
-    SmsDelivered,
+    SmsDelivered("sms:delivered"),
 
     @SerializedName("sms:failed")
-    SmsFailed,
+    SmsFailed("sms:failed"),
 
     @SerializedName("system:ping")
-    SystemPing,
+    SystemPing("system:ping"),
 }

--- a/app/src/main/java/me/capcom/smsgateway/ui/adapters/WebhookAdapter.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/adapters/WebhookAdapter.kt
@@ -1,0 +1,82 @@
+package me.capcom.smsgateway.ui.adapters
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import me.capcom.smsgateway.R
+import me.capcom.smsgateway.databinding.ItemWebhookBinding
+import me.capcom.smsgateway.modules.webhooks.domain.WebHookDTO
+
+class WebhookAdapter : ListAdapter<WebHookDTO, WebhookAdapter.ViewHolder>(WebhookDiffCallback()) {
+    class ViewHolder(private val binding: ItemWebhookBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(webhook: WebHookDTO) {
+            binding.apply {
+                idText.text = binding.root.context.getString(R.string.webhook_id_format, webhook.id)
+                urlText.text = webhook.url
+                eventText.text = webhook.event.value
+                sourceText.text = when (webhook.source) {
+                    me.capcom.smsgateway.domain.EntitySource.Local -> binding.root.context.getString(
+                        R.string.local
+                    )
+
+                    me.capcom.smsgateway.domain.EntitySource.Gateway,
+                    me.capcom.smsgateway.domain.EntitySource.Cloud -> binding.root.context.getString(
+                        R.string.cloud
+                    )
+                }
+                sourceIcon.setImageResource(
+                    when (webhook.source) {
+                        me.capcom.smsgateway.domain.EntitySource.Local -> R.drawable.ic_local_server
+                        me.capcom.smsgateway.domain.EntitySource.Cloud,
+                        me.capcom.smsgateway.domain.EntitySource.Gateway -> R.drawable.ic_cloud_server
+                    }
+                )
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemWebhookBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        val holder = ViewHolder(binding)
+
+        binding.root.setOnClickListener {
+            val position = holder.adapterPosition
+            if (position != RecyclerView.NO_POSITION) {
+                val webhook = getItem(position)
+                val context = binding.root.context
+                val clipboard =
+                    context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                val clip = ClipData.newPlainText("Webhook ID", webhook.id)
+                clipboard.setPrimaryClip(clip)
+                Toast.makeText(context, R.string.id_copied, Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        return holder
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class WebhookDiffCallback : DiffUtil.ItemCallback<WebHookDTO>() {
+        override fun areItemsTheSame(oldItem: WebHookDTO, newItem: WebHookDTO): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: WebHookDTO, newItem: WebHookDTO): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/ui/settings/WebhooksListFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/settings/WebhooksListFragment.kt
@@ -1,0 +1,57 @@
+package me.capcom.smsgateway.ui.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import me.capcom.smsgateway.databinding.FragmentWebhooksListBinding
+import me.capcom.smsgateway.modules.webhooks.WebHooksService
+import me.capcom.smsgateway.ui.adapters.WebhookAdapter
+import org.koin.android.ext.android.inject
+
+class WebhooksListFragment : Fragment() {
+    private var _binding: FragmentWebhooksListBinding? = null
+    private val binding get() = _binding!!
+
+    private val webhookService: WebHooksService by inject()
+    private val adapter: WebhookAdapter = WebhookAdapter()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentWebhooksListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
+        loadWebhooks()
+    }
+
+    private fun setupRecyclerView() {
+        binding.webhookList.apply {
+            layoutManager = LinearLayoutManager(context)
+            adapter = this@WebhooksListFragment.adapter
+            addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
+        }
+    }
+
+    private fun loadWebhooks() {
+        val webhooks = webhookService.select(null)
+        adapter.submitList(webhooks)
+        binding.emptyState.isVisible = webhooks.isEmpty()
+        binding.webhookList.isVisible = webhooks.isNotEmpty()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/drawable-notnight/ic_webhooks_list.xml
+++ b/app/src/main/res/drawable-notnight/ic_webhooks_list.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M4,10.5c-0.83,0 -1.5,0.67 -1.5,1.5s0.67,1.5 1.5,1.5 1.5,-0.67 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM4,4.5c-0.83,0 -1.5,0.67 -1.5,1.5S3.17,7.5 4,7.5 5.5,6.83 5.5,6 4.83,4.5 4,4.5zM4,16.5c-0.83,0 -1.5,0.68 -1.5,1.5s0.68,1.5 1.5,1.5 1.5,-0.68 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM7,19h14v-2L7,17v2zM7,13h14v-2L7,11v2zM7,5v2h14L21,5L7,5z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_webhooks_list.xml
+++ b/app/src/main/res/drawable/ic_webhooks_list.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4,10.5c-0.83,0 -1.5,0.67 -1.5,1.5s0.67,1.5 1.5,1.5 1.5,-0.67 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM4,4.5c-0.83,0 -1.5,0.67 -1.5,1.5S3.17,7.5 4,7.5 5.5,6.83 5.5,6 4.83,4.5 4,4.5zM4,16.5c-0.83,0 -1.5,0.68 -1.5,1.5s0.68,1.5 1.5,1.5 1.5,-0.68 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM7,19h14v-2L7,17v2zM7,13h14v-2L7,11v2zM7,5v2h14L21,5L7,5z" />
+
+</vector>

--- a/app/src/main/res/layout/fragment_webhooks_list.xml
+++ b/app/src/main/res/layout/fragment_webhooks_list.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/webhookList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:padding="8dp"
+        tools:listitem="@layout/item_webhook" />
+
+    <LinearLayout
+        android:id="@+id/emptyState"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <ImageView
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:src="@drawable/ic_webhook" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/no_webhooks_found"
+            android:textAppearance="?attr/textAppearanceCaption" />
+    </LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/item_webhook.xml
+++ b/app/src/main/res/layout/item_webhook.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/urlText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        tools:text="https://example.com" />
+
+    <TextView
+        android:id="@+id/idText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/sourceIcon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="8dp"
+            android:src="@drawable/ic_local_server" />
+
+        <TextView
+            android:id="@+id/sourceText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginHorizontal="8dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+            tools:text="source" />
+
+        <TextView
+            android:id="@+id/eventText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginHorizontal="8dp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+            tools:text="event" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,12 +6,15 @@
     <string name="app_version_build">App version (build)</string>
     <string name="battery_optimization">Battery optimization</string>
     <string name="battery_optimization_already_disabled">Battery optimization already disabled</string>
-    <string name="battery_optimization_is_not_supported_on_this_device">Battery optimization is not supported on this device</string>
+    <string name="battery_optimization_is_not_supported_on_this_device">Battery optimization is not
+        supported on this device</string>
     <string name="btn_cancel">Cancel</string>
     <string name="btn_continue">Continue</string>
     <string name="by_code">By Code</string>
     <string name="can_affect_battery_life">can affect battery life</string>
-    <string name="click_continue_to_create_an_account_no_personal_information_is_required_nby_continuing_you_agree_to_our_privacy_policy_at_https_docs_sms_gate_app_privacy_policy">Click Continue to create an account. No personal information is required.\nBy continuing, you agree to our Privacy Policy at https://docs.sms-gate.app/privacy/policy/</string>
+    <string name="click_continue_to_create_an_account_no_personal_information_is_required_nby_continuing_you_agree_to_our_privacy_policy_at_https_docs_sms_gate_app_privacy_policy">Click
+        Continue to create an account. No personal information is required.\nBy continuing, you
+        agree to our Privacy Policy at https://docs.sms-gate.app/privacy/policy/</string>
     <string name="cloud_server">Cloud server</string>
     <string name="cloud_server_dotdotdot">Cloud server…</string>
     <string name="copied_to_clipboard">Copied</string>
@@ -33,7 +36,8 @@
     <string name="internet_connection_unavailable">Internet connection: unavailable</string>
     <string name="interval_seconds">Interval (seconds)</string>
     <string name="invalid_url">Invalid URL</string>
-    <string name="is_not_a_valid_port_must_be_between_1024_and_65535">%1$s is not a valid port. Must be between 1024 and 65535</string>
+    <string name="is_not_a_valid_port_must_be_between_1024_and_65535">%1$s is not a valid port. Must
+        be between 1024 and 65535</string>
     <string name="label_password">Password:</string>
     <string name="label_username">Username:</string>
     <string name="limits">Limits</string>
@@ -54,7 +58,8 @@
     <string name="not_registered">not registered</string>
     <string name="not_set">Not set</string>
     <string name="notification_title">SMS Gateway</string>
-    <string name="online_status_at_the_cost_of_battery_life">Online status at the cost of battery life</string>
+    <string name="online_status_at_the_cost_of_battery_life">Online status at the cost of battery
+        life</string>
     <string name="passphrase">Passphrase</string>
     <string name="password">Password</string>
     <string name="password_changed_successfully">Password changed successfully</string>
@@ -63,7 +68,8 @@
     <string name="period">Period</string>
     <string name="ping">Ping</string>
     <string name="ping_service_is_active">Ping service is active</string>
-    <string name="please_enter_one_time_code_displayed_on_already_registered_device">Please enter one-time code displayed on already registered device</string>
+    <string name="please_enter_one_time_code_displayed_on_already_registered_device">Please enter
+        one-time code displayed on already registered device</string>
     <string name="port">Port</string>
     <string name="port_credentials_etc">Port, credentials, etc.</string>
     <string name="private_token">Private Token</string>
@@ -96,14 +102,27 @@
     <string name="tab_text_home">Home</string>
     <string name="tab_text_messages">MESSAGES</string>
     <string name="tab_text_settings">SETTINGS</string>
-    <string name="the_webhook_request_will_wait_for_an_internet_connection">The webhook request will wait for an internet connection</string>
-    <string name="to_add_a_device_to_an_existing_account_please_fill_in_the_credentials_below">To add a device to an existing account, please fill in the credentials below.</string>
-    <string name="to_apply_the_changes_restart_the_app_using_the_button_below">To apply the changes, restart the app using the button below.</string>
+    <string name="the_webhook_request_will_wait_for_an_internet_connection">The webhook request will
+        wait for an internet connection</string>
+    <string name="to_add_a_device_to_an_existing_account_please_fill_in_the_credentials_below">To
+        add a device to an existing account, please fill in the credentials below.</string>
+    <string name="to_apply_the_changes_restart_the_app_using_the_button_below">To apply the changes,
+        restart the app using the button below.</string>
     <string name="use_empty_to_disable">Use empty to disable</string>
-    <string name="use_this_code_to_sign_in_on_another_device">Use this code to sign in on another device</string>
+    <string name="use_this_code_to_sign_in_on_another_device">Use this code to sign in on another
+        device</string>
     <string name="username">Username</string>
     <string name="username_must_be_at_least_3_characters">Username must be at least 3 characters</string>
     <string name="view">View</string>
     <string name="webhooks">Webhooks</string>
     <string name="webhooks_dotdotdot">Webhooks...</string>
+
+    <string name="webhook_list_title">Registered Webhooks</string>
+    <string name="webhook_list_summary">View registered webhooks</string>
+
+    <string name="id_copied">Webhook ID copied to clipboard</string>
+    <string name="no_webhooks_found">No webhooks configured</string>
+    <string name="webhook_id_format">ID: %1$s</string>
+    <string name="local">Local</string>
+    <string name="cloud">Cloud</string>
 </resources>

--- a/app/src/main/res/xml/webhooks_preferences.xml
+++ b/app/src/main/res/xml/webhooks_preferences.xml
@@ -22,4 +22,9 @@
             app:title="@string/signing_key"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
+    <Preference
+        android:icon="@drawable/ic_webhooks_list"
+        app:fragment="me.capcom.smsgateway.ui.settings.WebhooksListFragment"
+        app:summary="@string/webhook_list_summary"
+        app:title="@string/webhook_list_title" />
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated Webhooks List screen displaying all registered webhooks with details such as ID, URL, event, and source.
  - Added a clickable preference in settings to access the Webhooks List.
  - Enabled copying of webhook IDs to the clipboard with a confirmation toast.
  - Added empty state messaging when no webhooks are present.

- **User Interface**
  - Added new icons and layouts for displaying webhook lists and items.
  - Improved visual distinction between local and cloud webhooks.

- **Localization**
  - Added new string resources for webhooks-related UI elements and messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->