### PR TITLE
[webhooks] add `sms:received` webhook registration notification

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/MainActivity.kt
+++ b/app/src/main/java/me/capcom/smsgateway/MainActivity.kt
@@ -1,5 +1,7 @@
 package me.capcom.smsgateway
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
@@ -40,6 +42,19 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }.attach()
+
+        processIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        processIntent(intent)
+    }
+
+    private fun processIntent(intent: Intent) {
+        val tabIndex = intent.getIntExtra(EXTRA_TAB_INDEX, TAB_INDEX_HOME)
+
+        binding.viewPager.currentItem = tabIndex
     }
 
     class FragmentsAdapter(activity: AppCompatActivity) :
@@ -55,5 +70,19 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+    }
+
+    companion object {
+        const val TAB_INDEX_HOME = 0
+        const val TAB_INDEX_MESSAGES = 1
+        const val TAB_INDEX_SETTINGS = 2
+
+        private const val EXTRA_TAB_INDEX = "tabIndex"
+
+        fun starter(context: Context, tabIndex: Int): Intent {
+            return Intent(context, MainActivity::class.java).apply {
+                putExtra(EXTRA_TAB_INDEX, tabIndex)
+            }
+        }
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebHooksService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebHooksService.kt
@@ -13,6 +13,7 @@ import me.capcom.smsgateway.modules.webhooks.db.WebHooksDao
 import me.capcom.smsgateway.modules.webhooks.domain.WebHookDTO
 import me.capcom.smsgateway.modules.webhooks.domain.WebHookEvent
 import me.capcom.smsgateway.modules.webhooks.domain.WebHookEventDTO
+import me.capcom.smsgateway.modules.webhooks.workers.ReviewWebhooksWorker
 import me.capcom.smsgateway.modules.webhooks.workers.SendWebhookWorker
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -29,9 +30,11 @@ class WebHooksService(
 
     fun start(context: Context) {
         eventsReceiver.start()
+        ReviewWebhooksWorker.start(context)
     }
 
     fun stop(context: Context) {
+        ReviewWebhooksWorker.stop(context)
         eventsReceiver.stop()
     }
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebHooksDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebHooksDao.kt
@@ -21,6 +21,9 @@ interface WebHooksDao {
     @Query("SELECT * FROM webHook WHERE source = :source")
     fun selectBySource(source: EntitySource): List<WebHook>
 
+    @Query("SELECT EXISTS (SELECT 1 FROM webHook WHERE id = :id AND source = :source)")
+    fun exists(source: EntitySource, id: String): Boolean
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun upsert(webHook: WebHook)
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/workers/ReviewWebhooksWorker.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/workers/ReviewWebhooksWorker.kt
@@ -1,0 +1,64 @@
+package me.capcom.smsgateway.modules.webhooks.workers
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import me.capcom.smsgateway.R
+import me.capcom.smsgateway.modules.notifications.NotificationsService
+import me.capcom.smsgateway.modules.webhooks.WebHooksService
+import me.capcom.smsgateway.modules.webhooks.domain.WebHookEvent
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.concurrent.TimeUnit
+
+class ReviewWebhooksWorker(appContext: Context, params: WorkerParameters) :
+    CoroutineWorker(appContext, params), KoinComponent {
+
+    private val webHooksService: WebHooksService by inject()
+    private val notificationsService: NotificationsService by inject()
+
+    override suspend fun doWork(): Result {
+        val webhooks = webHooksService.select(null)
+        val smsReceivedWebhooks = webhooks.filter { it.event == WebHookEvent.SmsReceived }
+        if (smsReceivedWebhooks.isEmpty()) {
+            return Result.success()
+        }
+
+        notificationsService.notify(
+            applicationContext,
+            NotificationsService.NOTIFICATION_ID_SMS_RECEIVED_WEBHOOK,
+            applicationContext.getString(
+                R.string.you_have_sms_received_webhooks_registered_please_review_them_to_avoid_any_security_risks,
+                smsReceivedWebhooks.size
+            )
+        )
+
+        return Result.success()
+    }
+
+    companion object {
+        private const val NAME = "ReviewWebhooksWorker"
+
+        fun start(context: Context) {
+            val work = PeriodicWorkRequestBuilder<ReviewWebhooksWorker>(
+                30,
+                TimeUnit.DAYS
+            )
+                .build()
+            WorkManager.getInstance(context)
+                .enqueueUniquePeriodicWork(
+                    NAME,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    work
+                )
+        }
+
+        fun stop(context: Context) {
+            WorkManager.getInstance(context)
+                .cancelUniqueWork(NAME)
+        }
+    }
+}

--- a/app/src/main/res/drawable/notif_webhook_registered.xml
+++ b/app/src/main/res/drawable/notif_webhook_registered.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z" />
+
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,16 +6,12 @@
     <string name="app_version_build">App version (build)</string>
     <string name="battery_optimization">Battery optimization</string>
     <string name="battery_optimization_already_disabled">Battery optimization already disabled</string>
-    <string name="battery_optimization_is_not_supported_on_this_device">Battery optimization is not
-        supported on this device</string>
+    <string name="battery_optimization_is_not_supported_on_this_device">Battery optimization is not supported on this device</string>
     <string name="btn_cancel">Cancel</string>
     <string name="btn_continue">Continue</string>
     <string name="by_code">By Code</string>
     <string name="can_affect_battery_life">can affect battery life</string>
-    <string
-        name="click_continue_to_create_an_account_no_personal_information_is_required_nby_continuing_you_agree_to_our_privacy_policy_at_https_docs_sms_gate_app_privacy_policy">Click
-        Continue to create an account. No personal information is required.\nBy continuing, you
-        agree to our Privacy Policy at https://docs.sms-gate.app/privacy/policy/</string>
+    <string name="click_continue_to_create_an_account_no_personal_information_is_required_nby_continuing_you_agree_to_our_privacy_policy_at_https_docs_sms_gate_app_privacy_policy">Click Continue to create an account. No personal information is required.\nBy continuing, you agree to our Privacy Policy at https://docs.sms-gate.app/privacy/policy/</string>
     <string name="cloud">Cloud</string>
     <string name="cloud_server">Cloud server</string>
     <string name="cloud_server_dotdotdot">Cloud server…</string>
@@ -39,8 +35,7 @@
     <string name="internet_connection_unavailable">Internet connection: unavailable</string>
     <string name="interval_seconds">Interval (seconds)</string>
     <string name="invalid_url">Invalid URL</string>
-    <string name="is_not_a_valid_port_must_be_between_1024_and_65535">%1$s is not a valid port. Must
-        be between 1024 and 65535</string>
+    <string name="is_not_a_valid_port_must_be_between_1024_and_65535">%1$s is not a valid port. Must be between 1024 and 65535</string>
     <string name="label_password">Password:</string>
     <string name="label_username">Username:</string>
     <string name="limits">Limits</string>
@@ -59,12 +54,12 @@
     <string name="minimum">Minimum</string>
     <string name="more_settings">More settings…</string>
     <string name="n_a">n/a</string>
+    <string name="new_sms_received_webhooks_registered">New SMS Received Webhooks registered</string>
     <string name="no_webhooks_found">No webhooks configured</string>
     <string name="not_registered">not registered</string>
     <string name="not_set">Not set</string>
     <string name="notification_title">SMS Gateway</string>
-    <string name="online_status_at_the_cost_of_battery_life">Online status at the cost of battery
-        life</string>
+    <string name="online_status_at_the_cost_of_battery_life">Online status at the cost of battery life</string>
     <string name="passphrase">Passphrase</string>
     <string name="password">Password</string>
     <string name="password_changed_successfully">Password changed successfully</string>
@@ -73,8 +68,7 @@
     <string name="period">Period</string>
     <string name="ping">Ping</string>
     <string name="ping_service_is_active">Ping service is active</string>
-    <string name="please_enter_one_time_code_displayed_on_already_registered_device">Please enter
-        one-time code displayed on already registered device</string>
+    <string name="please_enter_one_time_code_displayed_on_already_registered_device">Please enter one-time code displayed on already registered device</string>
     <string name="port">Port</string>
     <string name="port_credentials_etc">Port, credentials, etc.</string>
     <string name="private_token">Private Token</string>
@@ -89,8 +83,7 @@
     <string name="server_address">Server address:</string>
     <string name="set_maximum_value_to_activate">Set maximum value to activate</string>
     <string name="settings_address_is_sms_capcom_me">api.sms-gate.app</string>
-    <string name="settings_changed_via_api_restart_the_app_to_apply_changes">Settings changed via
-        API. Restart the app to apply changes.</string>
+    <string name="settings_changed_via_api_restart_the_app_to_apply_changes">Settings changed via API. Restart the app to apply changes.</string>
     <string name="settings_local_address_is">&lt;a href>%1$s:%2$d&lt;/a></string>
     <string name="settings_local_address_not_found">Not available</string>
     <string name="settings_local_server">Local server</string>
@@ -109,15 +102,11 @@
     <string name="tab_text_home">Home</string>
     <string name="tab_text_messages">MESSAGES</string>
     <string name="tab_text_settings">SETTINGS</string>
-    <string name="the_webhook_request_will_wait_for_an_internet_connection">The webhook request will
-        wait for an internet connection</string>
-    <string name="to_add_a_device_to_an_existing_account_please_fill_in_the_credentials_below">To
-        add a device to an existing account, please fill in the credentials below.</string>
-    <string name="to_apply_the_changes_restart_the_app_using_the_button_below">To apply the changes,
-        restart the app using the button below.</string>
+    <string name="the_webhook_request_will_wait_for_an_internet_connection">The webhook request will wait for an internet connection</string>
+    <string name="to_add_a_device_to_an_existing_account_please_fill_in_the_credentials_below">To add a device to an existing account, please fill in the credentials below.</string>
+    <string name="to_apply_the_changes_restart_the_app_using_the_button_below">To apply the changes, restart the app using the button below.</string>
     <string name="use_empty_to_disable">Use empty to disable</string>
-    <string name="use_this_code_to_sign_in_on_another_device">Use this code to sign in on another
-        device</string>
+    <string name="use_this_code_to_sign_in_on_another_device">Use this code to sign in on another device</string>
     <string name="username">Username</string>
     <string name="username_must_be_at_least_3_characters">Username must be at least 3 characters</string>
     <string name="view">View</string>
@@ -126,5 +115,5 @@
     <string name="webhook_list_title">Registered Webhooks</string>
     <string name="webhooks">Webhooks</string>
     <string name="webhooks_dotdotdot">Webhooks…</string>
-    <string name="new_sms_received_webhooks_registered">New SMS Received Webhooks registered</string>
+    <string name="you_have_sms_received_webhooks_registered_please_review_them_to_avoid_any_security_risks">You have %1$d SMS received webhooks registered. Please review them to avoid any security risks.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,12 +6,16 @@
     <string name="app_version_build">App version (build)</string>
     <string name="battery_optimization">Battery optimization</string>
     <string name="battery_optimization_already_disabled">Battery optimization already disabled</string>
-    <string name="battery_optimization_is_not_supported_on_this_device">Battery optimization is not supported on this device</string>
+    <string name="battery_optimization_is_not_supported_on_this_device">Battery optimization is not
+        supported on this device</string>
     <string name="btn_cancel">Cancel</string>
     <string name="btn_continue">Continue</string>
     <string name="by_code">By Code</string>
     <string name="can_affect_battery_life">can affect battery life</string>
-    <string name="click_continue_to_create_an_account_no_personal_information_is_required_nby_continuing_you_agree_to_our_privacy_policy_at_https_docs_sms_gate_app_privacy_policy">Click Continue to create an account. No personal information is required.\nBy continuing, you agree to our Privacy Policy at https://docs.sms-gate.app/privacy/policy/</string>
+    <string
+        name="click_continue_to_create_an_account_no_personal_information_is_required_nby_continuing_you_agree_to_our_privacy_policy_at_https_docs_sms_gate_app_privacy_policy">Click
+        Continue to create an account. No personal information is required.\nBy continuing, you
+        agree to our Privacy Policy at https://docs.sms-gate.app/privacy/policy/</string>
     <string name="cloud">Cloud</string>
     <string name="cloud_server">Cloud server</string>
     <string name="cloud_server_dotdotdot">Cloud server…</string>
@@ -35,7 +39,8 @@
     <string name="internet_connection_unavailable">Internet connection: unavailable</string>
     <string name="interval_seconds">Interval (seconds)</string>
     <string name="invalid_url">Invalid URL</string>
-    <string name="is_not_a_valid_port_must_be_between_1024_and_65535">%1$s is not a valid port. Must be between 1024 and 65535</string>
+    <string name="is_not_a_valid_port_must_be_between_1024_and_65535">%1$s is not a valid port. Must
+        be between 1024 and 65535</string>
     <string name="label_password">Password:</string>
     <string name="label_username">Username:</string>
     <string name="limits">Limits</string>
@@ -58,7 +63,8 @@
     <string name="not_registered">not registered</string>
     <string name="not_set">Not set</string>
     <string name="notification_title">SMS Gateway</string>
-    <string name="online_status_at_the_cost_of_battery_life">Online status at the cost of battery life</string>
+    <string name="online_status_at_the_cost_of_battery_life">Online status at the cost of battery
+        life</string>
     <string name="passphrase">Passphrase</string>
     <string name="password">Password</string>
     <string name="password_changed_successfully">Password changed successfully</string>
@@ -67,7 +73,8 @@
     <string name="period">Period</string>
     <string name="ping">Ping</string>
     <string name="ping_service_is_active">Ping service is active</string>
-    <string name="please_enter_one_time_code_displayed_on_already_registered_device">Please enter one-time code displayed on already registered device</string>
+    <string name="please_enter_one_time_code_displayed_on_already_registered_device">Please enter
+        one-time code displayed on already registered device</string>
     <string name="port">Port</string>
     <string name="port_credentials_etc">Port, credentials, etc.</string>
     <string name="private_token">Private Token</string>
@@ -82,7 +89,8 @@
     <string name="server_address">Server address:</string>
     <string name="set_maximum_value_to_activate">Set maximum value to activate</string>
     <string name="settings_address_is_sms_capcom_me">api.sms-gate.app</string>
-    <string name="settings_changed_via_api_restart_the_app_to_apply_changes">Settings changed via API. Restart the app to apply changes.</string>
+    <string name="settings_changed_via_api_restart_the_app_to_apply_changes">Settings changed via
+        API. Restart the app to apply changes.</string>
     <string name="settings_local_address_is">&lt;a href>%1$s:%2$d&lt;/a></string>
     <string name="settings_local_address_not_found">Not available</string>
     <string name="settings_local_server">Local server</string>
@@ -101,11 +109,15 @@
     <string name="tab_text_home">Home</string>
     <string name="tab_text_messages">MESSAGES</string>
     <string name="tab_text_settings">SETTINGS</string>
-    <string name="the_webhook_request_will_wait_for_an_internet_connection">The webhook request will wait for an internet connection</string>
-    <string name="to_add_a_device_to_an_existing_account_please_fill_in_the_credentials_below">To add a device to an existing account, please fill in the credentials below.</string>
-    <string name="to_apply_the_changes_restart_the_app_using_the_button_below">To apply the changes, restart the app using the button below.</string>
+    <string name="the_webhook_request_will_wait_for_an_internet_connection">The webhook request will
+        wait for an internet connection</string>
+    <string name="to_add_a_device_to_an_existing_account_please_fill_in_the_credentials_below">To
+        add a device to an existing account, please fill in the credentials below.</string>
+    <string name="to_apply_the_changes_restart_the_app_using_the_button_below">To apply the changes,
+        restart the app using the button below.</string>
     <string name="use_empty_to_disable">Use empty to disable</string>
-    <string name="use_this_code_to_sign_in_on_another_device">Use this code to sign in on another device</string>
+    <string name="use_this_code_to_sign_in_on_another_device">Use this code to sign in on another
+        device</string>
     <string name="username">Username</string>
     <string name="username_must_be_at_least_3_characters">Username must be at least 3 characters</string>
     <string name="view">View</string>
@@ -114,4 +126,5 @@
     <string name="webhook_list_title">Registered Webhooks</string>
     <string name="webhooks">Webhooks</string>
     <string name="webhooks_dotdotdot">Webhooks…</string>
+    <string name="new_sms_received_webhooks_registered">New SMS Received Webhooks registered</string>
 </resources>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to launch the app directly to a specific tab (Home, Messages, or Settings).
  - Introduced notifications for new SMS-received webhooks with high-priority alerts and direct navigation to the relevant tab.
  - Added a periodic background worker to remind users to review registered SMS-received webhooks for security.
- **Enhancements**
  - Improved notification handling with auto-cancel and customized intents for webhook-related alerts.
- **User Interface**
  - Added a new notification icon for webhook registration alerts.
  - Added new notification messages and string resources related to webhook status and security warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->