### PR TITLE
[localserver] add support for data messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ SMS Gateway turns your Android smartphone into an SMS gateway. It's a lightweigh
 
 - 💳 **Multiple SIM card support:** Supports devices with [multiple SIM cards](https://docs.sms-gate.app/features/multi-sim/).
 - 📱📱 **Multiple device support:** Connect [multiple devices](https://docs.sms-gate.app/features/multi-device/) to the same account with Cloud or Private server. Messages sent via the server are distributed across all connected devices.
+- 📲 **Data SMS support:** Send and receive data SMS messages for app to app communication.
 
 🔌 Integration:
 
@@ -182,7 +183,7 @@ This mode is ideal for sending messages from a local network.
     ```sh
     curl -X POST -u <username>:<password> \
       -H "Content-Type: application/json" \
-      -d '{ "message": "Hello, doctors!", "phoneNumbers": ["+19162255887", "+19162255888"] }' \
+      -d '{ "textMessage": { "text": "Hello, doctors!" }, "phoneNumbers": ["+19162255887", "+19162255888"] }' \
       http://<device_local_ip>:8080/message
     ```
 
@@ -210,7 +211,7 @@ Use the cloud server mode when dealing with dynamic or shared device IP addresse
     ```sh
     curl -X POST -u <username>:<password> \
       -H "Content-Type: application/json" \
-      -d '{ "message": "Hello, doctors!", "phoneNumbers": ["+19162255887", "+19162255888"] }' \
+      -d '{ "textMessage": { "text": "Hello, doctors!" }, "phoneNumbers": ["+19162255887", "+19162255888"] }' \
       https://api.sms-gate.app/3rdparty/v1/message
     ```
 

--- a/app/schemas/me.capcom.smsgateway.data.AppDatabase/14.json
+++ b/app/schemas/me.capcom.smsgateway.data.AppDatabase/14.json
@@ -1,0 +1,389 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "b6d02f75a658aca5ece43d2a914dba57",
+    "entities": [
+      {
+        "tableName": "Message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `withDeliveryReport` INTEGER NOT NULL DEFAULT 1, `simNumber` INTEGER, `validUntil` TEXT, `isEncrypted` INTEGER NOT NULL DEFAULT 0, `skipPhoneValidation` INTEGER NOT NULL DEFAULT 0, `priority` INTEGER NOT NULL DEFAULT 0, `source` TEXT NOT NULL DEFAULT 'Local', `type` TEXT NOT NULL DEFAULT 'Text', `content` TEXT NOT NULL, `state` TEXT NOT NULL, `createdAt` INTEGER NOT NULL DEFAULT 0, `processedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "withDeliveryReport",
+            "columnName": "withDeliveryReport",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "simNumber",
+            "columnName": "simNumber",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "validUntil",
+            "columnName": "validUntil",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEncrypted",
+            "columnName": "isEncrypted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "skipPhoneValidation",
+            "columnName": "skipPhoneValidation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Local'"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Text'"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "processedAt",
+            "columnName": "processedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Message_state",
+            "unique": false,
+            "columnNames": [
+              "state"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Message_state` ON `${TABLE_NAME}` (`state`)"
+          },
+          {
+            "name": "index_Message_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Message_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_Message_processedAt",
+            "unique": false,
+            "columnNames": [
+              "processedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Message_processedAt` ON `${TABLE_NAME}` (`processedAt`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "MessageRecipient",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, `state` TEXT NOT NULL, `error` TEXT, PRIMARY KEY(`messageId`, `phoneNumber`), FOREIGN KEY(`messageId`) REFERENCES `Message`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "phoneNumber"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Message",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "RecipientState",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, `state` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`messageId`, `phoneNumber`, `state`), FOREIGN KEY(`messageId`, `phoneNumber`) REFERENCES `MessageRecipient`(`messageId`, `phoneNumber`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "phoneNumber",
+            "state"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "MessageRecipient",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId",
+              "phoneNumber"
+            ],
+            "referencedColumns": [
+              "messageId",
+              "phoneNumber"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "MessageState",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `state` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`messageId`, `state`), FOREIGN KEY(`messageId`) REFERENCES `Message`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "state"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Message",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "WebHook",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `event` TEXT NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "event",
+            "columnName": "event",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "logs_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`priority` TEXT NOT NULL, `module` TEXT NOT NULL, `message` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `context` TEXT, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "module",
+            "columnName": "module",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "context",
+            "columnName": "context",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_logs_entries_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_logs_entries_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b6d02f75a658aca5ece43d2a914dba57')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,12 @@
             <intent-filter>
                 <action android:name="android.provider.Telephony.SMS_RECEIVED" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.DATA_SMS_RECEIVED" />
+
+                <data android:scheme="sms" />
+                <data android:port="53739" />
+            </intent-filter>
         </receiver>
 
         <service

--- a/app/src/main/java/me/capcom/smsgateway/data/AppDatabase.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/AppDatabase.kt
@@ -24,7 +24,7 @@ import me.capcom.smsgateway.modules.webhooks.db.WebHooksDao
         WebHook::class,
         LogEntry::class,
     ],
-    version = 13,
+    version = 14,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -53,7 +53,10 @@ abstract class AppDatabase : RoomDatabase() {
                 AppDatabase::class.java,
                 "gateway"
             )
-                .addMigrations(MIGRATION_7_8)
+                .addMigrations(
+                    MIGRATION_7_8,
+                    MIGRATION_13_14,
+                )
                 .allowMainThreadQueries()
                 .build()
         }

--- a/app/src/main/java/me/capcom/smsgateway/data/Migrations.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/Migrations.kt
@@ -7,10 +7,80 @@ val MIGRATION_7_8 = object : Migration(7, 8) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL(
             """
-            UPDATE message 
-            SET validUntil = strftime('%FT%TZ', createdAt / 1000 + 86400, 'unixepoch') 
+            UPDATE message
+            SET validUntil = strftime('%FT%TZ', createdAt / 1000 + 86400, 'unixepoch')
             WHERE validUntil IS NULL AND state = 'Pending'
         """.trimIndent()
         )
+    }
+}
+
+val MIGRATION_13_14 = object : Migration(13, 14) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        // Create a new table with the desired schema (without the text column)
+        database.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS message_new (
+                `id` TEXT NOT NULL,
+                `withDeliveryReport` INTEGER NOT NULL DEFAULT 1,
+                `simNumber` INTEGER,
+                `validUntil` TEXT,
+                `isEncrypted` INTEGER NOT NULL DEFAULT 0,
+                `skipPhoneValidation` INTEGER NOT NULL DEFAULT 0,
+                `priority` INTEGER NOT NULL DEFAULT 0,
+                `type` TEXT NOT NULL DEFAULT 'Text',
+                `source` TEXT NOT NULL DEFAULT 'Local',
+                `content` TEXT NOT NULL,
+                `state` TEXT NOT NULL,
+                `createdAt` INTEGER NOT NULL DEFAULT 0,
+                `processedAt` INTEGER,
+                PRIMARY KEY(`id`)
+            )
+            """.trimIndent()
+        )
+
+        // Copy data from the old table to the new table
+        database.execSQL(
+            """
+            INSERT INTO message_new (
+                id,
+                withDeliveryReport,
+                simNumber,
+                validUntil,
+                isEncrypted,
+                skipPhoneValidation,
+                priority,
+                source,
+                type,
+                content,
+                state,
+                createdAt,
+                processedAt
+            ) SELECT
+                id,
+                withDeliveryReport,
+                simNumber,
+                validUntil,
+                isEncrypted,
+                skipPhoneValidation,
+                priority,
+                source,
+                'Text' AS type,
+                '{"text": "' || replace(replace(text, '\\', '\\\\'), '"', '\\"') || '"}' AS content,
+                state,
+                createdAt,
+                processedAt
+            FROM message
+        """.trimIndent()
+        )
+
+        // Drop the old table and rename the new table to the original name
+        database.execSQL("DROP TABLE IF EXISTS message")
+        database.execSQL("ALTER TABLE message_new RENAME TO message")
+
+        // Create indices
+        database.execSQL("CREATE INDEX IF NOT EXISTS index_Message_state ON message (state)")
+        database.execSQL("CREATE INDEX IF NOT EXISTS index_Message_createdAt ON message (createdAt)")
+        database.execSQL("CREATE INDEX IF NOT EXISTS index_Message_processedAt ON message (processedAt)")
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/data/entities/Message.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/entities/Message.kt
@@ -7,6 +7,11 @@ import me.capcom.smsgateway.domain.EntitySource
 import me.capcom.smsgateway.domain.ProcessingState
 import java.util.Date
 
+enum class MessageType {
+    Text,
+    Data,
+}
+
 @Entity(
     indices = [
         androidx.room.Index(value = ["state"]),
@@ -16,7 +21,7 @@ import java.util.Date
 )
 data class Message(
     @PrimaryKey val id: String,
-    val text: String,
+
     @ColumnInfo(defaultValue = "1")
     val withDeliveryReport: Boolean,
     val simNumber: Int?,
@@ -30,6 +35,11 @@ data class Message(
 
     @ColumnInfo(defaultValue = "Local")
     val source: EntitySource,
+
+    @ColumnInfo(defaultValue = "Text")
+    val type: MessageType = MessageType.Text,
+
+    val content: String,
 
     val state: ProcessingState = ProcessingState.Pending,
     @ColumnInfo(defaultValue = "0")

--- a/app/src/main/java/me/capcom/smsgateway/domain/MessageContent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/domain/MessageContent.kt
@@ -1,0 +1,15 @@
+package me.capcom.smsgateway.domain
+
+sealed class MessageContent {
+    data class Text(val text: String) : MessageContent() {
+        override fun toString(): String {
+            return text
+        }
+    }
+
+    data class Data(val data: String, val port: Short) : MessageContent() {
+        override fun toString(): String {
+            return "$data:$port"
+        }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
@@ -6,6 +6,7 @@ import io.ktor.client.plugins.ClientRequestException
 import io.ktor.http.HttpStatusCode
 import me.capcom.smsgateway.data.entities.MessageWithRecipients
 import me.capcom.smsgateway.domain.EntitySource
+import me.capcom.smsgateway.domain.MessageContent
 import me.capcom.smsgateway.modules.events.EventBus
 import me.capcom.smsgateway.modules.gateway.events.DeviceRegisteredEvent
 import me.capcom.smsgateway.modules.gateway.workers.PullMessagesWorker
@@ -204,7 +205,7 @@ class GatewayService(
             EntitySource.Cloud,
             me.capcom.smsgateway.modules.messages.data.Message(
                 message.id,
-                message.message,
+                MessageContent.Text(message.message),
                 message.phoneNumbers,
                 message.isEncrypted ?: false,
                 message.createdAt ?: Date(),

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/PostMessageRequest.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/PostMessageRequest.kt
@@ -3,14 +3,27 @@ package me.capcom.smsgateway.modules.localserver.domain
 import com.google.gson.annotations.SerializedName
 import java.util.Date
 
+data class DataMessage(
+    val data: String,  // Base64-encoded payload
+    val port: Int,      // Destination port (0-65535)
+)
+
+data class TextMessage(
+    val text: String,
+)
+
 data class PostMessageRequest(
     val id: String?,
-    val message: String,
+    @Deprecated("Use textMessage instead")
+    val message: String?,
     val phoneNumbers: List<String>,
     val simNumber: Int?,
     val withDeliveryReport: Boolean?,
     val isEncrypted: Boolean?,
     val priority: Byte = 0,
+
+    val textMessage: TextMessage? = null,
+    val dataMessage: DataMessage? = null,
 
     @SerializedName("ttl")
     private val _ttl: Long?,

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
@@ -11,6 +11,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import me.capcom.smsgateway.domain.EntitySource
+import me.capcom.smsgateway.domain.MessageContent
 import me.capcom.smsgateway.domain.ProcessingState
 import me.capcom.smsgateway.modules.localserver.domain.PostMessageRequest
 import me.capcom.smsgateway.modules.localserver.domain.PostMessageResponse
@@ -39,36 +40,122 @@ class MessagesRoutes(
     private fun Route.messagesRoutes() {
         post {
             val request = call.receive<PostMessageRequest>()
-            if (request.message.isEmpty()) {
-                call.respond(
-                    HttpStatusCode.BadRequest,
-                    mapOf("message" to "message is empty")
-                )
+
+            val messageTypes =
+                listOfNotNull(request.textMessage, request.dataMessage, request.message)
+            when {
+                messageTypes.isEmpty() -> {
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        mapOf("message" to "Must specify exactly one of: textMessage, dataMessage, or message")
+                    )
+                    return@post
+                }
+
+                messageTypes.size > 1 -> {
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        mapOf("message" to "Cannot specify multiple message types simultaneously")
+                    )
+                    return@post
+                }
             }
+
+            // Validate message parameters
+            request.message?.let { msg ->
+                // Text validation
+                if (msg.isEmpty()) {
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        mapOf("message" to "Text message is empty")
+                    )
+                    return@post
+                }
+            }
+
+            // Validate data message parameters
+            request.dataMessage?.let { dataMsg ->
+                // Port validation
+                if (dataMsg.port < 0 || dataMsg.port > 65535) {
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        mapOf("message" to "Port must be between 0 and 65535")
+                    )
+                    return@post
+                }
+
+                // Data validation (only for non-empty check)
+                if (dataMsg.data.isEmpty()) {
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        mapOf("message" to "Data message cannot be empty")
+                    )
+                    return@post
+                }
+            }
+
+            // Validate text message parameters
+            request.textMessage?.let { textMsg ->
+                // Text validation
+                if (textMsg.text.isEmpty()) {
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        mapOf("message" to "Text message is empty")
+                    )
+                    return@post
+                }
+            }
+
+            // Existing validation
             if (request.phoneNumbers.isEmpty()) {
                 call.respond(
                     HttpStatusCode.BadRequest,
                     mapOf("message" to "phoneNumbers is empty")
                 )
+                return@post
             }
             if (request.simNumber != null && request.simNumber < 1) {
                 call.respond(
                     HttpStatusCode.BadRequest,
                     mapOf("message" to "simNumber must be >= 1")
                 )
+                return@post
             }
             val skipPhoneValidation =
                 call.request.queryParameters["skipPhoneValidation"]
                     ?.toBooleanStrict() ?: false
 
+            // Create message content based on type
+            val messageContent = when {
+                request.message != null -> {
+                    MessageContent.Text(request.message)
+                }
+
+                request.textMessage != null -> {
+                    MessageContent.Text(request.textMessage.text)
+                }
+
+                request.dataMessage != null -> {
+                    MessageContent.Data(
+                        request.dataMessage.data,
+                        request.dataMessage.port.toShort()
+                    )
+                }
+
+                else -> {
+                    // This case should be caught by validation, but just in case
+                    throw IllegalStateException("Unknown message type")
+                }
+            }
+
             val sendRequest = SendRequest(
                 EntitySource.Local,
                 Message(
                     request.id ?: NanoIdUtils.randomNanoId(),
-                    request.message,
-                    request.phoneNumbers,
-                    request.isEncrypted ?: false,
-                    Date(),
+                    content = messageContent,
+                    phoneNumbers = request.phoneNumbers,
+                    isEncrypted = request.isEncrypted ?: false,
+                    createdAt = Date(),
                 ),
                 SendParams(
                     request.withDeliveryReport ?: true,

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/data/Message.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/data/Message.kt
@@ -1,10 +1,11 @@
 package me.capcom.smsgateway.modules.messages.data
 
+import me.capcom.smsgateway.domain.MessageContent
 import java.util.Date
 
 data class Message(
     val id: String,
-    val text: String,
+    val content: MessageContent,
     val phoneNumbers: List<String>,
 
     val isEncrypted: Boolean,

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/data/SendRequest.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/data/SendRequest.kt
@@ -2,7 +2,7 @@ package me.capcom.smsgateway.modules.messages.data
 
 import me.capcom.smsgateway.domain.EntitySource
 
-data class SendRequest(
+open class SendRequest(
     val source: EntitySource,
     val message: Message,
     val params: SendParams,

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/data/StoredSendRequest.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/data/StoredSendRequest.kt
@@ -1,0 +1,15 @@
+package me.capcom.smsgateway.modules.messages.data
+
+import me.capcom.smsgateway.data.entities.MessageRecipient
+import me.capcom.smsgateway.domain.EntitySource
+import me.capcom.smsgateway.domain.ProcessingState
+
+class StoredSendRequest(
+    val id: Long,
+    val state: ProcessingState,
+    val recipients: List<MessageRecipient>,
+    source: EntitySource,
+    message: Message,
+    params: SendParams
+) :
+    SendRequest(source, message, params)

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/repositories/MessagesRepository.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/repositories/MessagesRepository.kt
@@ -1,11 +1,105 @@
 package me.capcom.smsgateway.modules.messages.repositories
 
 import androidx.lifecycle.distinctUntilChanged
+import com.google.gson.GsonBuilder
 import me.capcom.smsgateway.data.dao.MessagesDao
+import me.capcom.smsgateway.data.entities.Message
+import me.capcom.smsgateway.data.entities.MessageRecipient
+import me.capcom.smsgateway.data.entities.MessageType
+import me.capcom.smsgateway.data.entities.MessageWithRecipients
+import me.capcom.smsgateway.domain.MessageContent
+import me.capcom.smsgateway.domain.ProcessingState
+import me.capcom.smsgateway.modules.messages.data.SendParams
+import me.capcom.smsgateway.modules.messages.data.SendRequest
+import me.capcom.smsgateway.modules.messages.data.StoredSendRequest
+import java.util.Date
 
 class MessagesRepository(private val dao: MessagesDao) {
+    private val gson = GsonBuilder().serializeNulls().create()
+
     val lastMessages = dao.selectLast().distinctUntilChanged()
 
-    fun getPending() = dao.getPending()
-    fun get(id: String) = dao.get(id)
+    fun get(id: String): StoredSendRequest {
+        return dao.get(id)?.toRequest()
+            ?: throw IllegalArgumentException("Message with id $id not found")
+    }
+
+    fun enqueue(request: SendRequest) {
+        val message = MessageWithRecipients(
+            Message(
+                id = request.message.id,
+                type = when (request.message.content) {
+                    is MessageContent.Text -> MessageType.Text
+                    is MessageContent.Data -> MessageType.Data
+                },
+                content = gson.toJson(request.message.content),
+                withDeliveryReport = request.params.withDeliveryReport,
+                simNumber = request.params.simNumber,
+                validUntil = request.params.validUntil,
+                isEncrypted = request.message.isEncrypted,
+                skipPhoneValidation = request.params.skipPhoneValidation,
+                priority = request.params.priority ?: Message.PRIORITY_DEFAULT,
+                source = request.source,
+
+                createdAt = request.message.createdAt.time,
+            ),
+            request.message.phoneNumbers.map {
+                MessageRecipient(
+                    request.message.id,
+                    it,
+                    ProcessingState.Pending
+                )
+            },
+        )
+
+        dao.insert(message)
+    }
+
+    fun getPending(): StoredSendRequest? {
+        val message = dao.getPending() ?: return null
+
+        if (message.state != ProcessingState.Pending) {
+            // if for some reason stored state is not in sync with recipients state
+            dao.updateMessageState(message.message.id, message.state)
+            return getPending()
+        }
+
+        return message.toRequest()
+    }
+
+    private fun MessageWithRecipients.toRequest(): StoredSendRequest {
+        val message = this
+
+        return StoredSendRequest(
+            id = message.rowId,
+            state = message.state,
+            recipients = this.recipients,
+            message.message.source,
+            me.capcom.smsgateway.modules.messages.data.Message(
+                id = message.message.id,
+                content = when (message.message.type) {
+                    MessageType.Text -> gson.fromJson(
+                        message.message.content,
+                        MessageContent.Text::class.java
+                    )
+
+                    MessageType.Data -> gson.fromJson(
+                        message.message.content,
+                        MessageContent.Data::class.java
+                    )
+                },
+                phoneNumbers = message.recipients.filter { it.state == ProcessingState.Pending }
+                    .map { it.phoneNumber },
+                isEncrypted = message.message.isEncrypted,
+                createdAt = Date(message.message.createdAt),
+            ),
+            SendParams(
+                withDeliveryReport = message.message.withDeliveryReport,
+                skipPhoneValidation = message.message.skipPhoneValidation,
+                simNumber = message.message.simNumber,
+                validUntil = message.message.validUntil,
+                priority = message.message.priority
+            ),
+        )
+    }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/vm/MessageDetailsViewModel.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/vm/MessageDetailsViewModel.kt
@@ -6,14 +6,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import me.capcom.smsgateway.data.entities.MessageWithRecipients
+import me.capcom.smsgateway.modules.messages.data.StoredSendRequest
 import me.capcom.smsgateway.modules.messages.repositories.MessagesRepository
 
 class MessageDetailsViewModel(
     private val messagesRepo: MessagesRepository
 ) : ViewModel() {
-    private val _message = MutableLiveData<MessageWithRecipients>()
-    val message: LiveData<MessageWithRecipients> = _message
+    private val _message = MutableLiveData<StoredSendRequest>()
+    val message: LiveData<StoredSendRequest> = _message
 
     fun get(id: String) {
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/data/InboxMessage.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/data/InboxMessage.kt
@@ -1,29 +1,48 @@
 package me.capcom.smsgateway.modules.receiver.data
 
+import java.util.Arrays
 import java.util.Date
 
-data class InboxMessage(
+sealed class InboxMessage(
     val address: String,
-    val body: String,
     val date: Date,
     val subscriptionId: Int?
 ) {
+    class Text(val text: String, address: String, date: Date, subscriptionId: Int?) :
+        InboxMessage(address, date, subscriptionId) {
+        override fun equals(other: Any?): Boolean {
+            return super.equals(other) && (other as? Text)?.text == this.text
+        }
+
+        override fun hashCode(): Int {
+            return 31 * super.hashCode() + text.hashCode()
+        }
+    }
+
+    class Data(val data: ByteArray?, address: String, date: Date, subscriptionId: Int?) :
+        InboxMessage(address, date, subscriptionId) {
+        override fun equals(other: Any?): Boolean {
+            return super.equals(other) && Arrays.equals((other as? Data)?.data, this.data)
+        }
+
+        override fun hashCode(): Int {
+            return 31 * super.hashCode() + data.hashCode()
+        }
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is InboxMessage) return false
 
         if (address != other.address) return false
-        if (body != other.body) return false
         if (date != other.date) return false
-        if (subscriptionId != other.subscriptionId) return false
-        return true
+        return subscriptionId == other.subscriptionId
     }
 
     override fun hashCode(): Int {
         var result = address.hashCode()
-        result = 31 * result + body.hashCode()
         result = 31 * result + date.hashCode()
-        result = 31 * result + (subscriptionId ?: 0)
+        result = 31 * result + subscriptionId.hashCode()
         return result
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
@@ -17,4 +17,7 @@ enum class WebHookEvent(val value: String) {
 
     @SerializedName("system:ping")
     SystemPing("system:ping"),
+
+    @SerializedName("sms:data-received")
+    SmsDataReceived("sms:data-received"),
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsEventPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsEventPayload.kt
@@ -36,4 +36,12 @@ sealed class SmsEventPayload(
         val message: String,
         val receivedAt: Date,
     ) : SmsEventPayload(messageId, phoneNumber, simNumber)
+
+    class SmsDataReceived(
+        messageId: String,
+        phoneNumber: String,
+        simNumber: Int?,
+        val data: String,
+        val receivedAt: Date,
+    ) : SmsEventPayload(messageId, phoneNumber, simNumber)
 }

--- a/app/src/main/java/me/capcom/smsgateway/ui/MessageDetailsFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/MessageDetailsFragment.kt
@@ -40,7 +40,7 @@ class MessageDetailsFragment : Fragment() {
 
         viewModel.message.observe(viewLifecycleOwner) {
             binding.textMessageId.text = it.message.id
-            binding.textMessage.text = it.message.text
+            binding.textMessage.text = it.message.content.toString()
             binding.textMessageState.text = it.state.name
             recipientsAdapter.submitList(it.recipients)
         }

--- a/app/src/test/java/me/capcom/smsgateway/data/entities/MessageWithRecipientsTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/data/entities/MessageWithRecipientsTest.kt
@@ -10,7 +10,7 @@ class MessageWithRecipientsTest {
     fun testStatePending() {
         val message = Message(
             id = "1",
-            text = "Test message",
+            content = "Test message",
             withDeliveryReport = true,
             simNumber = 1,
             validUntil = null,
@@ -34,7 +34,7 @@ class MessageWithRecipientsTest {
     fun testStateSent() {
         val message = Message(
             id = "1",
-            text = "Test message",
+            content = "Test message",
             withDeliveryReport = true,
             simNumber = 1,
             validUntil = null,
@@ -58,7 +58,7 @@ class MessageWithRecipientsTest {
     fun testStateDelivered() {
         val message = Message(
             id = "2",
-            text = "Test message",
+            content = "Test message",
             withDeliveryReport = true,
             simNumber = 1,
             validUntil = null,

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -1070,67 +1070,142 @@
       "Message": {
         "type": "object",
         "title": "Message",
+        "description": "For sending messages, only one of `message`, `textMessage` or `dataMessage` should be set. The `message` field is deprecated in favor of the new message types.",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "The unique identifier of the message."
+              },
+              "phoneNumbers": {
+                "type": "array",
+                "description": "The recipients' phone numbers in international notation.",
+                "items": {
+                  "type": "string",
+                  "pattern": "^\\+?\\d+$",
+                  "maxLength": 16,
+                  "example": "+79990001234"
+                }
+              },
+              "simNumber": {
+                "type": "integer",
+                "nullable": true,
+                "description": "The SIM card number; if `null`, the default is used.",
+                "minimum": 1,
+                "maximum": 3
+              },
+              "ttl": {
+                "type": "integer",
+                "nullable": true,
+                "description": "The expiration timeout in seconds; conflicts with `validUntil`.",
+                "minimum": 5,
+                "example": 86400
+              },
+              "validUntil": {
+                "type": "string",
+                "nullable": true,
+                "description": "The expiration date; conflicts with `ttl`.",
+                "format": "date-time"
+              },
+              "withDeliveryReport": {
+                "type": "boolean",
+                "description": "Whether to request a delivery report.",
+                "default": true
+              },
+              "isEncrypted": {
+                "type": "boolean",
+                "description": "Whether the message text and phone numbers are encrypted. See [Encryption Details](https://sms-gate.app/privacy/encryption).",
+                "default": false
+              },
+              "priority": {
+                "type": "integer",
+                "description": "Message priority; use values >= 100 to ignore limits and delays.",
+                "minimum": -128,
+                "maximum": 127,
+                "default": 0
+              }
+            },
+            "required": [
+              "phoneNumbers"
+            ]
+          },
+          {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "The message text. This field is deprecated, use `textMessage` instead.",
+                    "maxLength": 65535
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "textMessage": {
+                    "$ref": "#/components/schemas/TextMessage"
+                  }
+                },
+                "required": [
+                  "textMessage"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "dataMessage": {
+                    "$ref": "#/components/schemas/DataMessage"
+                  }
+                },
+                "required": [
+                  "dataMessage"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TextMessage": {
+        "type": "object",
+        "title": "TextMessage",
+        "additionalProperties": false,
         "properties": {
-          "id": {
+          "text": {
             "type": "string",
-            "description": "The unique identifier of the message."
-          },
-          "message": {
-            "type": "string",
-            "description": "The message text.",
-            "maxLength": 65535
-          },
-          "phoneNumbers": {
-            "type": "array",
-            "description": "The recipients' phone numbers in international notation.",
-            "items": {
-              "type": "string",
-              "pattern": "^\\+?\\d+$",
-              "maxLength": 16,
-              "example": "+79990001234"
-            }
-          },
-          "simNumber": {
-            "type": "integer",
-            "nullable": true,
-            "description": "The SIM card number; if `null`, the default is used.",
-            "minimum": 1,
-            "maximum": 3
-          },
-          "ttl": {
-            "type": "integer",
-            "nullable": true,
-            "description": "The expiration timeout in seconds; conflicts with `validUntil`.",
-            "minimum": 5,
-            "example": 86400
-          },
-          "validUntil": {
-            "type": "string",
-            "nullable": true,
-            "description": "The expiration date; conflicts with `ttl`.",
-            "format": "date-time"
-          },
-          "withDeliveryReport": {
-            "type": "boolean",
-            "description": "Whether to request a delivery report.",
-            "default": true
-          },
-          "isEncrypted": {
-            "type": "boolean",
-            "description": "Whether the message text and phone numbers are encrypted. See [Encryption Details](https://sms-gate.app/privacy/encryption).",
-            "default": false
-          },
-          "priority": {
-            "type": "integer",
-            "description": "Message priority; use values >= 100 to ignore limits and delays.",
-            "minimum": -128,
-            "maximum": 127,
-            "default": 0
+            "description": "Message text"
           }
         },
         "required": [
-          "message",
-          "phoneNumbers"
+          "text"
+        ]
+      },
+      "DataMessage": {
+        "type": "object",
+        "title": "DataMessage",
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "type": "string",
+            "description": "Base64-encoded payload",
+            "format": "byte"
+          },
+          "port": {
+            "type": "integer",
+            "description": "Destination port",
+            "minimum": 0,
+            "maximum": 65535
+          }
+        },
+        "required": [
+          "data",
+          "port"
         ]
       },
       "MessageStatus": {

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -742,7 +742,8 @@
               "sms:sent",
               "system:ping",
               "sms:delivered",
-              "sms:failed"
+              "sms:failed",
+              "sms:data-received"
             ],
             "description": "The type of event being reported.",
             "example": "sms:received"
@@ -802,6 +803,9 @@
               },
               {
                 "$ref": "#/components/schemas/SystemPingPayload"
+              },
+              {
+                "$ref": "#/components/schemas/SmsDataReceivedPayload"
               }
             ]
           }
@@ -915,6 +919,29 @@
         "type": "object",
         "title": "SystemPingPayload",
         "description": "Payload of `system:ping` event."
+      },
+      "SmsDataReceivedPayload": {
+        "title": "SmsDataReceivedPayload",
+        "description": "Payload of `sms:data-received` event.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SmsEventPayload"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "string",
+                "description": "Base64-encoded content of the SMS message received."
+              },
+              "receivedAt": {
+                "type": "string",
+                "description": "The timestamp when the SMS message was received.",
+                "format": "date-time"
+              }
+            }
+          }
+        ]
       },
       "LogEntry": {
         "type": "object",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for sending and handling both text and data SMS messages, including specifying data payloads and destination ports.
  - Message content is now structured and can be provided as either plain text or data in API requests.
  - Added webhook event and payload support for data SMS reception.
  - Enhanced SMS receiver to process both text and data SMS messages distinctly.

- **Improvements**
  - Enhanced validation for message submission to enforce mutually exclusive message types and ensure correct data formatting.
  - Message details display now shows structured message content.
  - Refactored message sending and storage to use a unified repository and richer message content model.
  - Updated SIM selection and sending logic to support new message content types.
  - Extended SMS broadcast receiver to listen for data SMS on a specific port.
  - Improved message state synchronization and error handling in message processing.

- **Database Migration**
  - Upgraded database schema to support the new message content structure, with automatic migration for existing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->