### PR TITLE
[settings] don't show notification for empty update

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/settings/SettingsService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/settings/SettingsService.kt
@@ -34,6 +34,10 @@ class SettingsService(
     }
 
     fun update(data: Map<String, *>) {
+        if (data.isEmpty()) {
+            return
+        }
+
         data.forEach { (key, value) ->
             try {
                 settings[key]?.let {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance in settings updates by preventing unnecessary processing when no update data is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->