### PR TITLE
[localserver] support for `deviceId` field in messages

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/WebService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/WebService.kt
@@ -137,12 +137,8 @@ class WebService : Service() {
                                 0
                             ).firstInstallTime
                             val deviceName = "${Build.MANUFACTURER}/${Build.PRODUCT}"
-                            val deviceId =
-                                deviceName.hashCode().toULong()
-                                    .toString(16).padStart(16, '0') + firstInstallTime.toULong()
-                                    .toString(16).padStart(16, '0')
                             val device = Device(
-                                deviceId,
+                                requireNotNull(settings.deviceId),
                                 deviceName,
                                 Date(firstInstallTime),
                                 Date(),
@@ -152,7 +148,7 @@ class WebService : Service() {
                             call.respond(listOf(device))
                         }
                     }
-                    MessagesRoutes(applicationContext, get(), get()).let {
+                    MessagesRoutes(applicationContext, get(), get(), get()).let {
                         route("/message") {
                             it.register(this)
                         }

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/PostMessageRequest.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/PostMessageRequest.kt
@@ -25,6 +25,8 @@ data class PostMessageRequest(
     val textMessage: TextMessage? = null,
     val dataMessage: DataMessage? = null,
 
+    val deviceId: String? = null,
+
     @SerializedName("ttl")
     private val _ttl: Long?,
     @SerializedName("validUntil")

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/PostMessageResponse.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/PostMessageResponse.kt
@@ -5,6 +5,7 @@ import java.util.Date
 
 data class PostMessageResponse(
     val id: String,
+    val deviceId: String,
     val state: ProcessingState,
     val recipients: List<Recipient>,
     val isEncrypted: Boolean,

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -42,6 +42,14 @@
               "type": "boolean",
               "default": false
             }
+          },
+          {
+            "name": "deviceActiveWithin",
+            "in": "query",
+            "description": "Filter devices active within the specified number of hours",
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "requestBody": {
@@ -1152,6 +1160,13 @@
                 "minimum": -128,
                 "maximum": 127,
                 "default": 0
+              },
+              "deviceId": {
+                "type": "string",
+                "nullable": true,
+                "description": "Optional device ID for explicit selection",
+                "maxLength": 21,
+                "example": "PyDmBQZZXYmyxMwED8Fzy"
               }
             },
             "required": [
@@ -1284,8 +1299,22 @@
               "format": "date-time",
               "readOnly": true
             }
+          },
+          "deviceId": {
+            "type": "string",
+            "description": "Device ID",
+            "maxLength": 21,
+            "readOnly": true,
+            "example": "PyDmBQZZXYmyxMwED8Fzy"
           }
-        }
+        },
+        "required": [
+          "id",
+          "state",
+          "isHashed",
+          "isEncrypted",
+          "deviceId"
+        ]
       },
       "MessageRecipient": {
         "type": "object",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device ID to message request and response data for clearer device identification.
  * Introduced device ID validation to ensure requests originate from the configured device.
  * Added optional filtering of devices by recent activity in message sending.
  * Updated API documentation to reflect new device ID fields and query parameters.

* **Bug Fixes**
  * Enhanced validation to reject requests with mismatched device IDs, providing clear error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->