### PR TITLE
[receiver] basic MMS support in webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ SMS Gateway turns your Android smartphone into an SMS gateway. It's a lightweigh
 
 - 📜 **Multipart messages:** Send long messages with auto-partitioning.
 - 📊 **Message status tracking:** Monitor the status of sent messages in real-time.
-- 🔔 **Real-time incoming message notifications:** Receive instant notifications for incoming messages via webhook.
-- 📖 **Read received messages:** Access [previously received messages](https://docs.sms-gate.app/features/reading-messages/) using the same webhook system used for real-time notifications.
+- 🔔 **Real-time incoming message notifications:** Receive instant SMS and MMS notifications via webhooks.
+- 📖 **Read received messages:** Access [previously received messages](https://docs.sms-gate.app/features/reading-messages/) via the same webhooks used for real-time notifications.
 
 🔒 Security and Privacy:
 
@@ -153,6 +153,7 @@ To use the application, you need to grant the following permissions:
 - **READ_PHONE_STATE**: This permission is optional. If you want to select the SIM card, you can grant this permission.
 - **READ_SMS**: This permission is optional. If you want to read previous SMS messages, you need to grant this permission.
 - **RECEIVE_SMS**: This permission is optional. If you want to receive webhooks on incoming SMS, you need to grant this permission.
+- **RECEIVE_MMS**, **RECEIVE_WAP_PUSH**: This permissions are optional. If you want to receive webhooks on incoming MMS messages, you need to grant these permissions.
 
 ### Installation from APK
 
@@ -234,7 +235,7 @@ For further privacy, you can deploy your own private server. See the [Private Se
 
 ### Webhooks
 
-Webhooks can be utilized to get notifications of incoming SMS messages.
+Use webhooks to receive notifications for messaging events (e.g., incoming SMS and MMS).
 
 Follow these steps to set up webhooks:
 
@@ -247,7 +248,6 @@ Follow these steps to set up webhooks:
       -d '{ "id": "unique-id", "url": "https://webhook.site/<your-uuid>", "event": "sms:received" }' \
       http://<device_local_ip>:8080/webhooks
     ```
-    
 3. Send an SMS to the device.
 4. The application will dispatch POST request to the specified URL with a payload such as:
 
@@ -255,8 +255,10 @@ Follow these steps to set up webhooks:
     {
       "event": "sms:received",
       "payload": {
+        "messageId": "msg_12345abcde",
         "message": "Received SMS text",
         "phoneNumber": "+19162255887",
+        "simNumber": 1,
         "receivedAt": "2024-06-07T11:41:31.000+07:00"
       }
     }
@@ -375,5 +377,3 @@ Use this space to list resources you find helpful and would like to give credit 
 [issues-url]: https://github.com/capcom6/android-sms-gateway/issues
 [license-shield]: https://img.shields.io/github/license/capcom6/android-sms-gateway.svg?style=for-the-badge
 [license-url]: https://github.com/capcom6/android-sms-gateway/blob/master/LICENSE
-
-

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,9 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.RECEIVE_MMS" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <uses-permission android:name="android.permission.RECEIVE_WAP_PUSH" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -50,6 +52,17 @@
 
                 <data android:scheme="sms" />
                 <data android:port="53739" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".modules.receiver.MmsReceiver"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.BROADCAST_WAP_PUSH">
+            <intent-filter android:priority="999">
+                <action android:name="android.provider.Telephony.WAP_PUSH_RECEIVED" />
+                <data android:mimeType="application/vnd.wap.mms-message" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/me/capcom/smsgateway/helpers/SubscriptionsHelper.kt
+++ b/app/src/main/java/me/capcom/smsgateway/helpers/SubscriptionsHelper.kt
@@ -3,6 +3,7 @@ package me.capcom.smsgateway.helpers
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.telephony.SubscriptionManager
@@ -67,5 +68,21 @@ object SubscriptionsHelper {
             context,
             Manifest.permission.READ_PHONE_STATE
         ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    @SuppressLint("InlinedApi")
+    fun extractSubscriptionId(context: Context, intent: Intent): Int? {
+        return when {
+            intent.extras?.containsKey(SubscriptionManager.EXTRA_SUBSCRIPTION_INDEX) == true -> intent.extras?.getInt(
+                SubscriptionManager.EXTRA_SUBSCRIPTION_INDEX
+            )
+
+            intent.extras?.containsKey("subscription") == true -> intent.extras?.getInt("subscription")
+            intent.extras?.containsKey(SubscriptionManager.EXTRA_SLOT_INDEX) == true -> intent.extras?.getInt(
+                SubscriptionManager.EXTRA_SLOT_INDEX
+            )?.let { getSubscriptionId(context, it) }
+
+            else -> null
+        }
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
@@ -30,14 +30,14 @@ class MessagesReceiver : BroadcastReceiver(), KoinComponent {
                 messages.joinToString(separator = "") { it.displayMessageBody },
                 firstMessage.displayOriginatingAddress,
                 Date(firstMessage.timestampMillis),
-                extractSubscriptionId(context, intent)
+                SubscriptionsHelper.extractSubscriptionId(context, intent)
             )
 
             true -> InboxMessage.Data(
                 firstMessage.userData,
                 firstMessage.displayOriginatingAddress,
                 Date(firstMessage.timestampMillis),
-                extractSubscriptionId(context, intent)
+                SubscriptionsHelper.extractSubscriptionId(context, intent)
             )
         }
 
@@ -45,20 +45,5 @@ class MessagesReceiver : BroadcastReceiver(), KoinComponent {
             context,
             inboxMessage
         )
-    }
-
-    private fun extractSubscriptionId(context: Context, intent: Intent): Int? {
-        return when {
-            intent.extras?.containsKey("android.telephony.extra.SUBSCRIPTION_INDEX") == true -> intent.extras?.getInt(
-                "android.telephony.extra.SUBSCRIPTION_INDEX"
-            )
-
-            intent.extras?.containsKey("subscription") == true -> intent.extras?.getInt("subscription")
-            intent.extras?.containsKey("android.telephony.extra.SLOT_INDEX") == true -> intent.extras?.getInt(
-                "android.telephony.extra.SLOT_INDEX"
-            )?.let { SubscriptionsHelper.getSubscriptionId(context, it) }
-
-            else -> null
-        }
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
@@ -1,0 +1,89 @@
+package me.capcom.smsgateway.modules.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Telephony
+import android.util.Log
+import me.capcom.smsgateway.helpers.SubscriptionsHelper
+import me.capcom.smsgateway.modules.logs.LogsService
+import me.capcom.smsgateway.modules.logs.db.LogEntry
+import me.capcom.smsgateway.modules.receiver.data.InboxMessage
+import me.capcom.smsgateway.modules.receiver.parsers.MMSParser
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.Date
+
+class MmsReceiver : BroadcastReceiver(), KoinComponent {
+    private val receiverSvc: ReceiverService by inject()
+    private val logsService: LogsService by inject()
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Telephony.Sms.Intents.WAP_PUSH_RECEIVED_ACTION) {
+            return
+        }
+
+        val contentType = intent.type
+        if (contentType != "application/vnd.wap.mms-message") {
+            return
+        }
+
+
+        try {
+            val bundle: Bundle? = intent.extras
+            if (bundle == null) {
+                Log.w(TAG, "No extras found in MMS intent")
+                return
+            }
+
+            // Extract MMS metadata from the intent
+            val pdu = bundle.getByteArray("data") ?: bundle.getByteArray("pdu")
+
+            if (pdu == null) {
+                Log.w(TAG, "No PDU data found in MMS intent")
+                return
+            }
+
+            logsService.insert(
+                LogEntry.Priority.DEBUG,
+                MODULE_NAME,
+                "MMS received",
+                mapOf(
+                    "data" to intent.dataString,
+                    "extras" to bundle.keySet().joinToString(", ") { it },
+                    "uri" to intent.extras?.getString("uri"),
+                    "header" to intent.extras?.getByteArray("header")
+                        ?.joinToString("") { "%02x".format(it) },
+                    "pdu" to pdu.joinToString("") { "%02x".format(it) },
+                )
+            )
+
+
+            val mmsNotification = MMSParser.parseMNotificationInd(pdu)
+
+            Log.d(TAG, "MMS received from ${mmsNotification.from}")
+
+            val mmsMessage = InboxMessage.Mms(
+                messageId = mmsNotification.messageId,
+                transactionId = mmsNotification.transactionId,
+                subject = mmsNotification.subject,
+                size = mmsNotification.messageSize,
+                contentClass = mmsNotification.contentClass?.name,
+                address = mmsNotification.from.substringBefore('/'),
+                date = mmsNotification.date ?: Date(),
+                subscriptionId = SubscriptionsHelper.extractSubscriptionId(context, intent),
+            )
+
+            // Process the message using the existing ReceiverService
+            receiverSvc.process(context, mmsMessage)
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Error processing MMS", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "MmsReceiver"
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/data/InboxMessage.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/data/InboxMessage.kt
@@ -26,7 +26,26 @@ sealed class InboxMessage(
         }
 
         override fun hashCode(): Int {
-            return 31 * super.hashCode() + data.hashCode()
+            return 31 * super.hashCode() + (data?.contentHashCode() ?: 0)
+        }
+    }
+
+    class Mms(
+        val messageId: String?,
+        val transactionId: String,
+        val subject: String?,
+        val size: Long,
+        val contentClass: String?,
+        address: String,
+        date: Date,
+        subscriptionId: Int?
+    ) : InboxMessage(address, date, subscriptionId) {
+        override fun equals(other: Any?): Boolean {
+            return other is Mms && other.transactionId == this.transactionId
+        }
+
+        override fun hashCode(): Int {
+            return transactionId.hashCode()
         }
     }
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParser.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParser.kt
@@ -1,0 +1,218 @@
+package me.capcom.smsgateway.modules.receiver.parsers
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.Date
+
+
+object MMSParser {
+    private const val HEADER_MESSAGE_TYPE = 0x8C
+    private const val HEADER_TRANSACTION_ID = 0x98
+    private const val HEADER_MMS_VERSION = 0x8D
+    private const val HEADER_FROM = 0x89
+    private const val HEADER_SUBJECT = 0x96
+    private const val HEADER_DELIVERY_REPORT = 0x86
+    private const val HEADER_STORED = 0xA7
+    private const val HEADER_MESSAGE_CLASS = 0x8A
+    private const val HEADER_PRIORITY = 0x8F
+    private const val HEADER_MESSAGE_SIZE = 0x8E
+    private const val HEADER_EXPIRY = 0x88
+    private const val HEADER_REPLY_CHARGING = 0x9C
+    private const val HEADER_REPLY_CHARGING_DEADLINE = 0x9D
+    private const val HEADER_REPLY_CHARGING_SIZE = 0x9F
+    private const val HEADER_REPLY_CHARGING_ID = 0x9E
+    private const val HEADER_DISTRIBUTION_INDICATOR = 0xB1
+    private const val HEADER_ELEMENT_DESCRIPTOR = 0xB2
+    private const val HEADER_RECOMMENDED_RETRIEVAL_MODE = 0xB4
+    private const val HEADER_RECOMMENDED_RETRIEVAL_MODE_TEXT = 0xB5
+    private const val HEADER_APPLIC_ID = 0xB7
+    private const val HEADER_REPLY_APPLIC_ID = 0xB8
+    private const val HEADER_AUX_APPLIC_INFO = 0xB9
+    private const val HEADER_CONTENT_CLASS = 0xBA
+    private const val HEADER_DRM_CONTENT = 0xBB
+    private const val HEADER_REPLACE_ID = 0xBD
+    private const val HEADER_CONTENT_LOCATION = 0x83
+    private const val HEADER_MESSAGE_ID = 0x8B
+    private const val HEADER_DATE = 0x85
+
+
+    // Message type values from 7.3.30
+    private const val MESSAGE_TYPE_NOTIFICATION_IND = 130
+
+    private const val FROM_ADDRESS_PRESENT_TOKEN = 128
+
+    /**
+     * X-Mms-Content-Class field types.
+     */
+    enum class ContentClass(val value: Int) {
+        TEXT(0x80),
+        IMAGE_BASIC(0x81),
+        IMAGE_RICH(0x82),
+        VIDEO_BASIC(0x83),
+        VIDEO_RICH(0x84),
+        MEGAPIXEL(0x85),
+        CONTENT_BASIC(0x86),
+        CONTENT_RICH(0x87);
+    }
+
+    data class MNotificationInd(
+        val messageId: String?,
+        val transactionId: String,
+        val date: Date?,
+        val from: String,
+        val subject: String?,
+        val messageSize: Long,
+        val contentClass: ContentClass?
+    )
+
+    fun parseMNotificationInd(pdu: ByteArray): MNotificationInd {
+        val buffer = ByteBuffer.wrap(pdu).order(ByteOrder.BIG_ENDIAN)
+        val headers = mutableMapOf<Int, Any?>()
+
+        // Parse headers until buffer is exhausted
+        while (buffer.hasRemaining()) {
+            val headerType = buffer.get().toInt() and 0xFF
+            val value = when (headerType) {
+                HEADER_MESSAGE_TYPE -> parseShortInteger(buffer)
+                HEADER_TRANSACTION_ID -> parseTextString(buffer)
+                HEADER_MMS_VERSION -> parseShortInteger(buffer)
+                HEADER_FROM -> parseFrom(buffer)
+                HEADER_SUBJECT -> parseEncodedString(buffer)
+                HEADER_DELIVERY_REPORT -> parseShortInteger(buffer)
+                HEADER_STORED -> parseShortInteger(buffer)
+                HEADER_MESSAGE_CLASS -> parseShortInteger(buffer)
+                HEADER_PRIORITY -> parseShortInteger(buffer)
+                HEADER_MESSAGE_SIZE -> parseLongInteger(buffer)
+                HEADER_EXPIRY -> parseExpiry(buffer)
+                HEADER_REPLY_CHARGING -> parseShortInteger(buffer)
+                HEADER_REPLY_CHARGING_DEADLINE -> parseShortInteger(buffer)
+                HEADER_REPLY_CHARGING_SIZE -> parseLongInteger(buffer)
+                HEADER_REPLY_CHARGING_ID -> parseTextString(buffer)
+                HEADER_DISTRIBUTION_INDICATOR -> parseShortInteger(buffer)
+//                HEADER_ELEMENT_DESCRIPTOR -> parseShortInteger(buffer)
+                HEADER_RECOMMENDED_RETRIEVAL_MODE -> parseShortInteger(buffer)
+                HEADER_RECOMMENDED_RETRIEVAL_MODE_TEXT -> parseEncodedString(buffer)
+                HEADER_APPLIC_ID -> parseTextString(buffer)
+                HEADER_REPLY_APPLIC_ID -> parseTextString(buffer)
+                HEADER_AUX_APPLIC_INFO -> parseTextString(buffer)
+                HEADER_CONTENT_CLASS -> parseContentClass(buffer)
+                HEADER_DRM_CONTENT -> parseShortInteger(buffer)
+                HEADER_REPLACE_ID -> parseTextString(buffer)
+                HEADER_CONTENT_LOCATION -> parseTextString(buffer)
+                HEADER_MESSAGE_ID -> parseTextString(buffer)
+                HEADER_DATE -> parseLongInteger(buffer)
+
+                else -> throw IllegalArgumentException("Unknown header type: $headerType")
+            }
+            headers[headerType] = value
+        }
+
+        // Validate mandatory fields
+        require(headers[HEADER_MESSAGE_TYPE] == MESSAGE_TYPE_NOTIFICATION_IND) {
+            "Invalid message type (expected m-notification-ind)"
+        }
+
+        return MNotificationInd(
+            messageId = headers[HEADER_MESSAGE_ID] as String?,
+            transactionId = headers[HEADER_TRANSACTION_ID] as String,
+            date = (headers[HEADER_DATE] as? Long)?.let { Date(it * 1000L) },
+            from = headers[HEADER_FROM] as String,
+            subject = headers[HEADER_SUBJECT] as String?,
+            messageSize = headers[HEADER_MESSAGE_SIZE] as Long,
+            contentClass = headers[HEADER_CONTENT_CLASS] as ContentClass?
+        )
+    }
+
+    private fun parseFrom(buffer: ByteBuffer): String {
+        val length = parseShortInteger(buffer)
+        if (length <= 0 || buffer.remaining() < length) return ""
+
+        val addressType = parseShortInteger(buffer) // 128 == address-present
+        require(addressType == FROM_ADDRESS_PRESENT_TOKEN) { "Unexpected address type: $addressType" }
+
+        return parseEncodedString(buffer)
+    }
+
+    private fun parseShortInteger(buffer: ByteBuffer): Int {
+        return buffer.get().toInt() and 0xFF
+    }
+
+    private fun parseLongInteger(buffer: ByteBuffer): Long {
+        val length = parseShortInteger(buffer) // number of octets to read
+        var result = 0L
+        repeat(length.coerceAtMost(buffer.remaining())) {
+            result = (result shl 8) or (buffer.get().toLong() and 0xFF)
+        }
+        return result
+    }
+
+    private fun parseTextString(buffer: ByteBuffer): String {
+        val bytes = mutableListOf<Byte>()
+        while (buffer.hasRemaining()) {
+            val byte = buffer.get()
+            if (byte == 0x00.toByte()) break
+            bytes.add(byte)
+        }
+        return String(bytes.toByteArray(), Charsets.UTF_8)
+    }
+
+    private fun parseEncodedString(buffer: ByteBuffer): String {
+        if (!buffer.hasRemaining()) return ""
+        val mark = buffer.position()
+        val lenOrToken = buffer.get().toInt() and 0xFF
+
+        buffer.position(mark)
+
+        if (lenOrToken < 32) {
+            parseValueLength(buffer)
+            parseShortInteger(buffer)
+        }
+
+        return parseTextString(buffer)
+    }
+
+    private fun parseContentClass(buffer: ByteBuffer): ContentClass? {
+        val value = parseShortInteger(buffer)
+        return ContentClass.values().firstOrNull { it.value == value }
+    }
+
+    private fun parseExpiry(buffer: ByteBuffer): Long {
+        parseValueLength(buffer) // skip length
+
+        return when (parseShortInteger(buffer)) {
+            128 -> parseLongInteger(buffer)  // Absolute time
+            129 -> parseLongInteger(buffer)  // Relative time
+            else -> 0L
+        }
+    }
+
+    ///
+    private const val LENGTH_QUOTE = 31
+    private const val SHORT_LENGTH_MAX = 30
+
+    private fun parseValueLength(buffer: ByteBuffer): Int {
+        val temp = buffer.get()
+        val first = temp.toInt() and 0xFF
+        if (first <= SHORT_LENGTH_MAX) {
+            return first
+        } else if (first == LENGTH_QUOTE) {
+            return parseUnsignedInt(buffer)
+        }
+        throw RuntimeException("Value length > LENGTH_QUOTE!")
+    }
+
+    private fun parseUnsignedInt(buffer: ByteBuffer): Int {
+        var result = 0
+        var temp = buffer.get()
+        while (temp.toInt() and 0x80 != 0) {
+            result = result shl 7
+            result = result or (temp.toInt() and 0x7F)
+            temp = buffer.get()
+        }
+
+        result = result shl 7
+        result = result or (temp.toInt() and 0x7F)
+
+        return result
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
@@ -20,4 +20,7 @@ enum class WebHookEvent(val value: String) {
 
     @SerializedName("sms:data-received")
     SmsDataReceived("sms:data-received"),
+
+    @SerializedName("mms:received")
+    MmsReceived("mms:received"),
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/MessageEventPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/MessageEventPayload.kt
@@ -1,0 +1,7 @@
+package me.capcom.smsgateway.modules.webhooks.payload
+
+abstract class MessageEventPayload(
+    val messageId: String,
+    val phoneNumber: String,
+    val simNumber: Int?,
+)

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/MmsReceivedPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/MmsReceivedPayload.kt
@@ -1,0 +1,14 @@
+package me.capcom.smsgateway.modules.webhooks.payload
+
+import java.util.Date
+
+class MmsReceivedPayload(
+    messageId: String,
+    phoneNumber: String,
+    simNumber: Int?,
+    val transactionId: String,
+    val subject: String?,
+    val size: Long,
+    val contentClass: String?,
+    val receivedAt: Date
+) : MessageEventPayload(messageId, phoneNumber, simNumber)

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsEventPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsEventPayload.kt
@@ -3,10 +3,10 @@ package me.capcom.smsgateway.modules.webhooks.payload
 import java.util.Date
 
 sealed class SmsEventPayload(
-    val messageId: String,
-    val phoneNumber: String,
-    val simNumber: Int?,
-) {
+    messageId: String,
+    phoneNumber: String,
+    simNumber: Int?,
+) : MessageEventPayload(messageId, phoneNumber, simNumber) {
     class SmsSent(
         messageId: String,
         phoneNumber: String,

--- a/app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt
@@ -337,6 +337,7 @@ class HomeFragment : Fragment() {
                 Manifest.permission.READ_SMS,
                 Manifest.permission.RECEIVE_SMS,
                 Manifest.permission.SEND_SMS,
+                Manifest.permission.RECEIVE_MMS,
             )
                 .filter {
                     ContextCompat.checkSelfPermission(

--- a/app/src/test/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParserTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParserTest.kt
@@ -1,0 +1,237 @@
+package me.capcom.smsgateway.modules.receiver.parsers
+
+import org.junit.Test
+
+internal class MMSParserTest {
+    private fun hexToBytes(hex: String) = hex
+        .replace(Regex("\\s"), "")
+        .chunked(2)
+        .map { it.toInt(16).toByte() }
+        .toByteArray()
+
+    @Test
+    fun parseMNotificationIndTest() {
+        val tests = listOf(
+            """
+                8C 82 98 74 31 2D 50 5A 4A 4B 6E 44 6F
+                37 72 00 8D 93 89 17 80 31 39 31 36 32
+                32 35 35 38 38 37 2F 54 59 50 45 3D 50
+                4C 4D 4E 00 8A 80 88 05 81 03 03 F4 7F
+                8E 02 05 39 83 68 74 74 70 3A 2F 2F 78
+                78 78 2E 78 78 78 78 78 78 78 78 2E 78
+                78 78 2F 6D 6D 73 63 3F 78 78 2D 78 78
+                78 78 78 78 78 78 78 00
+            """.trimIndent(),
+            """
+                8C 82 98 6D 2D 37 2D 31 31 32 2D 33 2D
+                63 65 66 37 65 66 2D 62 39 2D 35 31 2D
+                32 00 8D 92 89 0F 80 0D 83 31 39 31 36
+                32 32 35 35 38 38 37 00 8A 80 8E 02 02
+                83 88 05 81 03 03 F4 80 83 68 74 74 70
+                3A 2F 2F 78 78 2E 78 2D 78 78 78 78 78
+                78 2E 78 78 78 2F 6D 6D 3F 54 3D 6D 2D
+                78 2D 78 78 2D 78 2D 78 78 78 78 78 78
+                2D 78 78 00 86 80
+            """.trimIndent(),
+            """
+                8C 82 98 6D 2D 36 2D 34 63 2D 36 2D 61
+                65 34 34 66 61 2D 39 66 2D 37 33 2D 31
+                00 8D 92 89 0F 80 0D 83 31 39 31 36 32
+                32 35 35 38 38 37 00 8A 80 8E 02 02 83
+                88 05 81 03 03 F4 80 83 68 74 74 70 3A
+                2F 2F 78 78 2E 78 2D 78 78 78 78 78 78
+                2E 78 78 78 2F 6D 6D 3F 54 3D 78 2D 78
+                2D 78 78 2D 78 2D 78 78 78 78 78 78 2D
+                78 78 00 86 80
+            """.trimIndent(),
+            """
+                8C 82 98 6D 2D 37 2D 34 66 2D 37 2D 38
+                64 64 66 31 35 2D 37 64 2D 31 31 2D 33
+                00 8D 92 89 0F 80 0D 83 31 39 31 36 32
+                32 35 35 38 38 37 00 8A 80 8E 02 02 92
+                88 05 81 03 03 F4 80 83 68 74 74 70 3A
+                2F 2F 78 78 2E 78 2D 78 78 78 78 78 78
+                2E 78 78 78 2F 6D 6D 3F 54 3D 6D 2D 78
+                2D 78 78 2D 78 2D 78 78 78 78 78 78 2D
+                78 78 00 86 80
+            """.trimIndent(),
+            """
+                8C 82 98 6D 2D 31 2D 34 34 2D 38 2D 64
+                30 65 32 64 38 2D 62 62 2D 36 2D 35 00
+                8D 92 89 0F 80 0D 83 31 39 31 36 32 32
+                35 35 38 38 37 00 8A 80 8E 02 02 9E 88
+                05 81 03 03 F4 80 83 68 74 74 70 3A 2F
+                2F 78 78 2E 78 2D 78 78 78 78 78 78 2E
+                78 78 78 2F 6D 6D 3F 54 3D 6D 2D 78 2D
+                78 2D 78 2D 78 78 78 78 78 78 2D 78 78
+                00 86 80
+            """.trimIndent(),
+        )
+
+        tests.forEach {
+            val notification = MMSParser.parseMNotificationInd(hexToBytes(it))
+            assert(notification.from.contains("19162255887"))
+        }
+    }
+
+    @Test
+    fun simpleTest() {
+        val data = byteArrayOf(
+            0x8C.toByte(),
+            0x82.toByte(),
+            0x98.toByte(),
+            0x69,
+            0x64,
+            0x31,
+            0x5F,
+            0x31,
+            0x35,
+            0x36,
+            0x33,
+            0x39,
+            0x34,
+            0x38,
+            0x38,
+            0x34,
+            0x30,
+            0x00,
+            0x8D.toByte(),
+            0x92.toByte(),
+            0x8B.toByte(),
+            0x35,
+            0x38,
+            0x63,
+            0x66,
+            0x63,
+            0x36,
+            0x64,
+            0x61,
+            0x2D,
+            0x32,
+            0x30,
+            0x32,
+            0x35,
+            0x30,
+            0x38,
+            0x32,
+            0x32,
+            0x30,
+            0x34,
+            0x35,
+            0x31,
+            0x34,
+            0x34,
+            0x40,
+            0x6D,
+            0x6D,
+            0x73,
+            0x63,
+            0x2E,
+            0x6D,
+            0x74,
+            0x73,
+            0x2E,
+            0x72,
+            0x75,
+            0x00,
+            0x85.toByte(),
+            0x04,
+            0x68,
+            0xA7.toByte(),
+            0xCD.toByte(),
+            0x31,
+            0x89.toByte(),
+            0x18,
+            0x80.toByte(),
+            0x2B,
+            0x31,
+            0x39,
+            0x31,
+            0x36,
+            0x32,
+            0x32,
+            0x35,
+            0x35,
+            0x38,
+            0x38,
+            0x37,
+            0x2F,
+            0x54,
+            0x59,
+            0x50,
+            0x45,
+            0x3D,
+            0x50,
+            0x4C,
+            0x4D,
+            0x4E,
+            0x00,
+            0x8A.toByte(),
+            0x80.toByte(),
+            0x8E.toByte(),
+            0x04,
+            0x00,
+            0x01,
+            0x8B.toByte(),
+            0xD8.toByte(),
+            0x88.toByte(),
+            0x05,
+            0x81.toByte(),
+            0x03,
+            0x03,
+            0xF4.toByte(),
+            0x80.toByte(),
+            0x83.toByte(),
+            0x68,
+            0x74,
+            0x74,
+            0x70,
+            0x3A,
+            0x2F,
+            0x2F,
+            0x31,
+            0x30,
+            0x2E,
+            0x34,
+            0x37,
+            0x2E,
+            0x31,
+            0x33,
+            0x33,
+            0x2E,
+            0x33,
+            0x35,
+            0x2F,
+            0x3F,
+            0x6D,
+            0x65,
+            0x73,
+            0x73,
+            0x61,
+            0x67,
+            0x65,
+            0x2D,
+            0x69,
+            0x64,
+            0x3D,
+            0x31,
+            0x35,
+            0x36,
+            0x33,
+            0x39,
+            0x34,
+            0x38,
+            0x38,
+            0x34,
+            0x30,
+            0x26,
+            0x69,
+            0x64,
+            0x3D,
+            0x31
+        )
+
+        val notification = MMSParser.parseMNotificationInd(data)
+        assert(notification.from == "+19162255887/TYPE=PLMN")
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incoming MMS support: app detects MMS notifications, extracts metadata, and emits a new "mms:received" webhook with messageId, transactionId, subject, size, sender, SIM number and timestamp.

* **Chores**
  * Requests runtime RECEIVE_MMS and RECEIVE_WAP_PUSH permissions and registers a high-priority MMS receiver.

* **Refactor**
  * Shared webhook payload base and centralized SIM/subscription extraction.

* **Tests**
  * Added unit tests for MMS notification parsing.

* **Documentation**
  * README updated to document MMS support, webhook payloads, and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->