### PR TITLE
[ui] add queue status info

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/data/entities/MessagesTotals.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/entities/MessagesTotals.kt
@@ -1,0 +1,9 @@
+package me.capcom.smsgateway.data.entities
+
+data class MessagesTotals(
+    val total: Long,
+    val pending: Long,
+    val sent: Long,
+    val delivered: Long,
+    val failed: Long,
+)

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesRepository.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesRepository.kt
@@ -1,5 +1,6 @@
 package me.capcom.smsgateway.modules.messages
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.distinctUntilChanged
 import com.google.gson.GsonBuilder
 import me.capcom.smsgateway.data.dao.MessagesDao
@@ -7,6 +8,7 @@ import me.capcom.smsgateway.data.entities.Message
 import me.capcom.smsgateway.data.entities.MessageRecipient
 import me.capcom.smsgateway.data.entities.MessageType
 import me.capcom.smsgateway.data.entities.MessageWithRecipients
+import me.capcom.smsgateway.data.entities.MessagesTotals
 import me.capcom.smsgateway.domain.MessageContent
 import me.capcom.smsgateway.domain.ProcessingState
 import me.capcom.smsgateway.modules.messages.data.SendParams
@@ -18,6 +20,8 @@ class MessagesRepository(private val dao: MessagesDao) {
     private val gson = GsonBuilder().serializeNulls().create()
 
     val lastMessages = dao.selectLast().distinctUntilChanged()
+
+    val messagesTotals: LiveData<MessagesTotals> = dao.getMessagesStats().distinctUntilChanged()
 
     fun get(id: String): StoredSendRequest {
         return dao.get(id)?.toRequest()

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/vm/MessagesListViewModel.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/vm/MessagesListViewModel.kt
@@ -3,6 +3,7 @@ package me.capcom.smsgateway.modules.messages.vm
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import me.capcom.smsgateway.data.entities.Message
+import me.capcom.smsgateway.data.entities.MessagesTotals
 import me.capcom.smsgateway.modules.messages.MessagesRepository
 
 class MessagesListViewModel(
@@ -10,4 +11,7 @@ class MessagesListViewModel(
 ) : ViewModel() {
     val messages: LiveData<List<Message>> =
         messagesRepo.lastMessages
+
+    val totals: LiveData<MessagesTotals> =
+        messagesRepo.messagesTotals
 }

--- a/app/src/main/java/me/capcom/smsgateway/ui/MessagesListFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/MessagesListFragment.kt
@@ -21,16 +21,6 @@ class MessagesListFragment : Fragment(), MessagesAdapter.OnItemClickListener<Mes
     private var _binding: FragmentMessagesListBinding? = null
     private val binding get() = _binding!!
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        viewModel.messages.observe(this) {
-            messagesAdapter.submitList(it) {
-                _binding?.recyclerView?.scrollToPosition(0)
-            }
-        }
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -47,6 +37,25 @@ class MessagesListFragment : Fragment(), MessagesAdapter.OnItemClickListener<Mes
         binding.recyclerView.addItemDecoration(
             DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL)
         )
+
+        // Observe stats LiveData
+        viewModel.totals.observe(viewLifecycleOwner) { stats ->
+            stats?.let {
+                binding.totalMessages.text = getString(R.string.total_messages, it.total)
+                binding.pendingMessages.text = getString(R.string.pending_messages, it.pending)
+                binding.sentMessages.text = getString(R.string.sent_messages, it.sent)
+                binding.deliveredMessages.text =
+                    getString(R.string.delivered_messages, it.delivered)
+                binding.failedMessages.text = getString(R.string.failed_messages, it.failed)
+            }
+        }
+
+        viewModel.messages.observe(viewLifecycleOwner) {
+            val shouldScrollToTop = binding.recyclerView.computeVerticalScrollOffset() == 0
+            messagesAdapter.submitList(it) {
+                if (shouldScrollToTop) _binding?.recyclerView?.scrollToPosition(0)
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/res/layout/fragment_messages_list.xml
+++ b/app/src/main/res/layout/fragment_messages_list.xml
@@ -1,16 +1,103 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".ui.MessagesListFragment">
 
+    <!-- Fixed top panel with queue statistics -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/statisticsCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="4dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="12dp">
+
+            <TextView
+                android:id="@+id/queueTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="@string/queue_status"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+
+            <!-- GridLayout for stats -->
+            <GridLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:alignmentMode="alignMargins"
+                android:columnCount="3"
+                android:rowOrderPreserved="false"
+                android:useDefaultMargins="true">
+
+                <TextView
+                    android:id="@+id/totalMessages"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_columnSpan="2"
+                    android:layout_columnWeight="1"
+                    android:ellipsize="middle"
+                    android:singleLine="true"
+                    tools:text="Total: 0" />
+
+                <TextView
+                    android:id="@+id/pendingMessages"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_columnWeight="1"
+                    android:ellipsize="middle"
+                    android:singleLine="true"
+                    tools:text="Pending: 0" />
+
+                <TextView
+                    android:id="@+id/sentMessages"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_columnWeight="1"
+                    android:ellipsize="middle"
+                    android:singleLine="true"
+                    tools:text="Sent: 0" />
+
+                <TextView
+                    android:id="@+id/deliveredMessages"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_columnWeight="1"
+                    android:ellipsize="middle"
+                    android:singleLine="true"
+                    tools:text="Delivered: 0" />
+
+                <TextView
+                    android:id="@+id/failedMessages"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_columnWeight="1"
+                    android:ellipsize="middle"
+                    android:singleLine="true"
+                    tools:text="Failed: 0" />
+
+            </GridLayout>
+
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <!-- RecyclerView for messages -->
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:listitem="@layout/item_message" />
 
-</FrameLayout>
+</LinearLayout>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -129,4 +129,10 @@
     </plurals>
     <string name="processing">Обработка</string>
     <string name="processing_order_title">Порядок обработки</string>
+    <string name="queue_status">📊 Статус очереди</string>
+    <string name="total_messages">Всего: %1$d</string>
+    <string name="pending_messages">В ожидании: %1$d</string>
+    <string name="sent_messages">Отправлено: %1$d</string>
+    <string name="delivered_messages">Доставлено: %1$d</string>
+    <string name="failed_messages">Сбоев: %1$d</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -45,6 +45,7 @@
     <string name="limits">限制</string>
     <string name="list_of_last_50_log_entries">最近 50 条日志记录</string>
     <string name="local">本地</string>
+    <string name="listening_to_the_server_events">正在监听服务器事件…</string>
     <string name="local_address">本地地址</string>
     <string name="local_server_dotdotdot">本地服务器…</string>
     <string name="local_sms_gateway_notifications">本地短信网关通知</string>
@@ -123,4 +124,10 @@
     <plurals name="review_incoming_sms_webhooks">
         <item quantity="other">您已注册 %1$d 个短信接收 Webhook。请检查以避免安全风险。</item>
     </plurals>
+    <string name="queue_status">📊 队列状态</string>
+    <string name="total_messages">总计：%1$d</string>
+    <string name="pending_messages">待处理：%1$d</string>
+    <string name="sent_messages">已发送：%1$d</string>
+    <string name="delivered_messages">已送达：%1$d</string>
+    <string name="failed_messages">失败：%1$d</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,4 +125,10 @@
     </plurals>
     <string name="processing">Processing</string>
     <string name="processing_order_title">Processing order</string>
+    <string name="queue_status">📊 Queue Status</string>
+    <string name="total_messages">Total: %1$d</string>
+    <string name="pending_messages">Pending: %1$d</string>
+    <string name="sent_messages">Sent: %1$d</string>
+    <string name="delivered_messages">Delivered: %1$d</string>
+    <string name="failed_messages">Failed: %1$d</string>
 </resources>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages screen now exposes live queue statistics (total, pending, sent, delivered, failed) to the UI.

* **UI**
  * Added a top status card with header and five stat fields; message list now shares vertical space beneath it and respects view lifecycle.

* **Bug Fixes**
  * Observers made lifecycle-safe; list auto-scrolls only when already at the top.

* **Localization**
  * Added localized strings for queue status and each statistic display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->