### PR TITLE
[webhooks] add parts count to the `sms:sent` webhook payload

### DIFF
--- a/app/schemas/me.capcom.smsgateway.data.AppDatabase/16.json
+++ b/app/schemas/me.capcom.smsgateway.data.AppDatabase/16.json
@@ -1,0 +1,397 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "c9bca869f0cb40b9f25fbc44308fe786",
+    "entities": [
+      {
+        "tableName": "Message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `withDeliveryReport` INTEGER NOT NULL DEFAULT 1, `simNumber` INTEGER, `validUntil` TEXT, `isEncrypted` INTEGER NOT NULL DEFAULT 0, `skipPhoneValidation` INTEGER NOT NULL DEFAULT 0, `priority` INTEGER NOT NULL DEFAULT 0, `source` TEXT NOT NULL DEFAULT 'Local', `type` TEXT NOT NULL DEFAULT 'Text', `content` TEXT NOT NULL, `state` TEXT NOT NULL, `partsCount` INTEGER, `createdAt` INTEGER NOT NULL DEFAULT 0, `processedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "withDeliveryReport",
+            "columnName": "withDeliveryReport",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "simNumber",
+            "columnName": "simNumber",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "validUntil",
+            "columnName": "validUntil",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEncrypted",
+            "columnName": "isEncrypted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "skipPhoneValidation",
+            "columnName": "skipPhoneValidation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Local'"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Text'"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partsCount",
+            "columnName": "partsCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "processedAt",
+            "columnName": "processedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Message_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Message_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_Message_state_processedAt",
+            "unique": false,
+            "columnNames": [
+              "state",
+              "processedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Message_state_processedAt` ON `${TABLE_NAME}` (`state`, `processedAt`)"
+          },
+          {
+            "name": "index_Message_state_createdAt",
+            "unique": false,
+            "columnNames": [
+              "state",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Message_state_createdAt` ON `${TABLE_NAME}` (`state`, `createdAt`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "MessageRecipient",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, `state` TEXT NOT NULL, `error` TEXT, PRIMARY KEY(`messageId`, `phoneNumber`), FOREIGN KEY(`messageId`) REFERENCES `Message`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "phoneNumber"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Message",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "RecipientState",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, `state` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`messageId`, `phoneNumber`, `state`), FOREIGN KEY(`messageId`, `phoneNumber`) REFERENCES `MessageRecipient`(`messageId`, `phoneNumber`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "phoneNumber",
+            "state"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "MessageRecipient",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId",
+              "phoneNumber"
+            ],
+            "referencedColumns": [
+              "messageId",
+              "phoneNumber"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "MessageState",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `state` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`messageId`, `state`), FOREIGN KEY(`messageId`) REFERENCES `Message`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "state"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Message",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "WebHook",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `event` TEXT NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "event",
+            "columnName": "event",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "logs_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`priority` TEXT NOT NULL, `module` TEXT NOT NULL, `message` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `context` TEXT, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "module",
+            "columnName": "module",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "context",
+            "columnName": "context",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_logs_entries_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_logs_entries_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c9bca869f0cb40b9f25fbc44308fe786')"
+    ]
+  }
+}

--- a/app/src/main/java/me/capcom/smsgateway/data/AppDatabase.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/AppDatabase.kt
@@ -24,7 +24,7 @@ import me.capcom.smsgateway.modules.webhooks.db.WebHooksDao
         WebHook::class,
         LogEntry::class,
     ],
-    version = 15, // Updated to version 15
+    version = 16,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -40,6 +40,7 @@ import me.capcom.smsgateway.modules.webhooks.db.WebHooksDao
         AutoMigration(from = 12, to = 13),
         // AutoMigration(from = 13, to = 14),   // manual migration
         AutoMigration(from = 14, to = 15),
+        AutoMigration(from = 15, to = 16),
     ]
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
@@ -183,6 +183,9 @@ interface MessagesDao {
         simNumber: Int
     )
 
+    @Query("UPDATE message SET partsCount = :partsCount WHERE id = :id")
+    fun updatePartsCount(id: String, partsCount: Int)
+
     @Query("DELETE FROM message WHERE createdAt < :until AND state <> 'Pending'")
     suspend fun truncateLog(until: Long)
 }

--- a/app/src/main/java/me/capcom/smsgateway/data/entities/Message.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/entities/Message.kt
@@ -42,6 +42,7 @@ data class Message(
     val content: String,
 
     val state: ProcessingState = ProcessingState.Pending,
+    val partsCount: Int? = null,
     @ColumnInfo(defaultValue = "0")
     val createdAt: Long = System.currentTimeMillis(),
     val processedAt: Long? = null,

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -282,6 +282,7 @@ class MessagesService(
                 phone?.let { setOf(it) } ?: msg.recipients.map { it.phoneNumber }.toSet(),
                 state,
                 msg.message.simNumber,
+                msg.message.partsCount,
                 error
             )
         )
@@ -353,7 +354,7 @@ class MessagesService(
                         false -> PhoneHelper.filterPhoneNumber(phoneNumber, countryCode ?: "RU")
                     }
 
-                    when (val content = message.content) {
+                    val partsCount = when (val content = message.content) {
                         is MessageContent.Text -> {
                             // Handle text messages
                             val text = when (message.isEncrypted) {
@@ -379,6 +380,8 @@ class MessagesService(
                                     deliveredIntent
                                 )
                             }
+
+                            parts.size
                         }
 
                         is MessageContent.Data -> {
@@ -402,8 +405,12 @@ class MessagesService(
                                 sentIntent,
                                 deliveredIntent
                             )
+
+                            1
                         }
                     }
+
+                    dao.updatePartsCount(id, partsCount)
 
                     updateState(id, sourcePhoneNumber, ProcessingState.Processed)
                 } catch (th: Throwable) {

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/events/MessageStateChangedEvent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/events/MessageStateChangedEvent.kt
@@ -10,6 +10,7 @@ class MessageStateChangedEvent(
     val phoneNumbers: Set<String>,
     val state: ProcessingState,
     val simNumber: Int?,
+    val partsCount: Int?,
     val error: String?
 ): AppEvent(NAME) {
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/EventsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/EventsReceiver.kt
@@ -44,6 +44,7 @@ class EventsReceiver : EventsReceiver() {
                                 messageId = event.id,
                                 phoneNumber = phoneNumber,
                                 event.simNumber,
+                                partsCount = event.partsCount ?: -1,
                                 sentAt = Date(),
                             )
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsEventPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsEventPayload.kt
@@ -11,6 +11,7 @@ sealed class SmsEventPayload(
         messageId: String,
         phoneNumber: String,
         simNumber: Int?,
+        val partsCount: Int,
         val sentAt: Date,
     ) : SmsEventPayload(messageId, phoneNumber, simNumber)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Track and store the number of SMS parts per message; partsCount is persisted and included in message state change events and webhook payloads for better multipart visibility.

- **Chores**
  - Database version upgraded with an auto-migration to persist existing data and support the new partsCount field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->