### PR TITLE
[messages] rate limit high priority messages in some cases

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/data/entities/Message.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/entities/Message.kt
@@ -48,6 +48,7 @@ data class Message(
     val processedAt: Long? = null,
 ) {
     companion object {
+        const val PRIORITY_MIN: Byte = Byte.MIN_VALUE
         const val PRIORITY_DEFAULT: Byte = 0
         const val PRIORITY_EXPEDITED: Byte = 100
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Priority-aware throttling for outgoing messages: expedited messages skip delays only when their priority is higher than the last sent message.
  * Delivery order improved by considering recent message priority, reducing unnecessary waits for truly urgent messages and keeping limits for others.
  * Smoother, more consistent sending behavior under load.

* **Chores**
  * Added a minimum priority constant for message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->