### PR TITLE
[receiver] add dynamic registration of BroadcastReceiver

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
@@ -3,7 +3,9 @@ package me.capcom.smsgateway.modules.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.provider.Telephony.Sms.Intents
+import android.util.Log
 import me.capcom.smsgateway.helpers.SubscriptionsHelper
 import me.capcom.smsgateway.modules.receiver.data.InboxMessage
 import org.koin.core.component.KoinComponent
@@ -45,5 +47,30 @@ class MessagesReceiver : BroadcastReceiver(), KoinComponent {
             context,
             inboxMessage
         )
+    }
+
+    companion object {
+        private const val TAG = "MessagesReceiver"
+
+        private val INSTANCE: MessagesReceiver by lazy { MessagesReceiver() }
+
+        fun register(context: Context) {
+            val filter = IntentFilter().apply {
+                addAction(Intents.SMS_RECEIVED_ACTION)
+                addAction(Intents.DATA_SMS_RECEIVED_ACTION)
+            }
+            context.registerReceiver(
+                INSTANCE,
+                filter
+            )
+        }
+
+        fun unregister(context: Context) {
+            try {
+                context.unregisterReceiver(INSTANCE)
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "Receiver was not registered", e)
+            }
+        }
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
@@ -3,6 +3,7 @@ package me.capcom.smsgateway.modules.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.os.Bundle
 import android.provider.Telephony
 import android.util.Log
@@ -85,5 +86,26 @@ class MmsReceiver : BroadcastReceiver(), KoinComponent {
 
     companion object {
         private const val TAG = "MmsReceiver"
+
+        private val INSTANCE: MmsReceiver by lazy { MmsReceiver() }
+
+        fun register(context: Context) {
+            val filter = IntentFilter().apply {
+                addAction(Telephony.Sms.Intents.WAP_PUSH_RECEIVED_ACTION)
+                addDataType("application/vnd.wap.mms-message")
+            }
+            context.registerReceiver(
+                INSTANCE,
+                filter
+            )
+        }
+
+        fun unregister(context: Context) {
+            try {
+                context.unregisterReceiver(INSTANCE)
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "Receiver was not registered", e)
+            }
+        }
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
@@ -23,11 +23,15 @@ class ReceiverService : KoinComponent {
     private val eventsReceiver by lazy { EventsReceiver() }
 
     fun start(context: Context) {
+        MessagesReceiver.register(context)
+        MmsReceiver.register(context)
         eventsReceiver.start()
     }
 
     fun stop(context: Context) {
         eventsReceiver.stop()
+        MmsReceiver.unregister(context)
+        MessagesReceiver.unregister(context)
     }
 
     fun export(context: Context, period: Pair<Date, Date>) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Receiver lifecycle updated: SMS and MMS receivers can now be explicitly registered and unregistered.
  * Service start/stop sequencing adjusted so receivers are registered before event processing begins and unregistered after it stops.
  * Result: improved reliability and stability of message reception and safer lifecycle handling during service start/stop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->