### PR TITLE
[settings] notify user on real changes only

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionSettings.kt
@@ -40,11 +40,18 @@ class EncryptionSettings(
         private const val VERSION = "version"
     }
 
-    override fun import(data: Map<String, *>) {
-        data.forEach { (key, value) ->
-            when (key) {
-                PASSPHRASE -> storage.set(key, value?.toString())
+    override fun import(data: Map<String, *>): Boolean {
+        return data.map {
+            when (it.key) {
+                PASSPHRASE -> {
+                    val newValue = it.value?.toString()
+                    val changed = passphrase != newValue
+                    storage.set(it.key, newValue)
+                    changed
+                }
+
+                else -> false
             }
-        }
+        }.any { it }
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewaySettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewaySettings.kt
@@ -50,19 +50,33 @@ class GatewaySettings(
         )
     }
 
-    override fun import(data: Map<String, *>) {
-        data.forEach { (key, value) ->
-            when (key) {
+    override fun import(data: Map<String, *>): Boolean {
+        return data.map {
+            when (it.key) {
                 CLOUD_URL -> {
-                    val url = value?.toString()
+                    val url = it.value?.toString() ?: PUBLIC_URL
                     if (url != null && !url.startsWith("https://")) {
                         throw IllegalArgumentException("url must start with https://")
                     }
-                    storage.set(key, url)
+
+                    val changed = serverUrl != url
+
+                    storage.set(it.key, url)
+
+                    changed
                 }
 
-                PRIVATE_TOKEN -> storage.set(key, value?.toString())
+                PRIVATE_TOKEN -> {
+                    val newValue = it.value?.toString()
+                    val changed = privateToken != newValue
+
+                    storage.set(it.key, newValue)
+
+                    changed
+                }
+
+                else -> false
             }
-        }
+        }.any { it }
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/logs/LogsSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/logs/LogsSettings.kt
@@ -44,11 +44,20 @@ class LogsSettings(
         )
     }
 
-    override fun import(data: Map<String, *>) {
-        data.forEach { (key, value) ->
-            when (key) {
-                LIFETIME_DAYS -> storage.set(key, value?.toString()?.toFloat()?.toInt()?.toString())
+    override fun import(data: Map<String, *>): Boolean {
+        return data.map {
+            when (it.key) {
+                LIFETIME_DAYS -> {
+                    val newValue = it.value?.toString()?.toFloat()?.toInt()?.takeIf { it > 0 }
+                    val changed = lifetimeDays != newValue
+
+                    storage.set(it.key, newValue?.toString())
+
+                    changed
+                }
+
+                else -> false
             }
-        }
+        }.any { it }
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesSettings.kt
@@ -107,44 +107,92 @@ class MessagesSettings(
         )
     }
 
-    override fun import(data: Map<String, *>) {
-        data.forEach { (key, value) ->
+    override fun import(data: Map<String, *>): Boolean {
+        return data.map {
+            val key = it.key
+            val value = it.value
+
             when (key) {
-                SEND_INTERVAL_MIN -> storage.set(
-                    key,
-                    value?.toString()?.toFloat()?.toInt()?.toString()
-                )
+                SEND_INTERVAL_MIN -> {
+                    val newValue = value?.toString()?.toFloat()?.toInt()
+                    val changed = this.sendIntervalMin != newValue
 
-                SEND_INTERVAL_MAX -> storage.set(
-                    key,
-                    value?.toString()?.toFloat()?.toInt()?.toString()
-                )
+                    storage.set(
+                        key,
+                        newValue?.toString()
+                    )
 
-                LIMIT_PERIOD -> storage.set(key, value?.let { Period.valueOf(it.toString()) })
-                LIMIT_VALUE -> {
-                    val limitValue = value?.toString()?.toInt()
-                    if (limitValue != null && limitValue < 1) {
-                        throw IllegalArgumentException("Limit value must be >= 1")
-                    }
-                    storage.set(key, limitValue?.toString())
+                    changed
                 }
 
-                SIM_SELECTION_MODE -> storage.set(
-                    key,
-                    value?.let { SimSelectionMode.valueOf(it.toString()) })
+                SEND_INTERVAL_MAX -> {
+                    val newValue = value?.toString()?.toFloat()?.toInt()
+                    val changed = this.sendIntervalMax != newValue
 
-                PROCESSING_ORDER -> storage.set(
-                    key,
-                    value?.let { ProcessingOrder.valueOf(it.toString()) })
+                    storage.set(
+                        key,
+                        newValue?.toString()
+                    )
+
+                    changed
+                }
+
+                LIMIT_PERIOD -> {
+                    val newValue = value?.let { Period.valueOf(it.toString()) } ?: Period.Disabled
+                    val changed = this.limitPeriod != newValue
+
+                    storage.set(key, newValue)
+
+                    changed
+                }
+
+                LIMIT_VALUE -> {
+                    val limitValue = value?.toString()?.toFloat()?.toInt()
+                    if (limitValue != null && limitValue < 0) {
+                        throw IllegalArgumentException("Limit value must be >= 0")
+                    }
+
+                    val changed = this.limitValue != (limitValue ?: 0)
+
+                    storage.set(key, limitValue?.toString())
+
+                    changed
+                }
+
+                SIM_SELECTION_MODE -> {
+                    val newValue = value?.let { SimSelectionMode.valueOf(it.toString()) }
+                        ?: SimSelectionMode.OSDefault
+                    val changed = this.simSelectionMode != newValue
+
+                    storage.set(key, newValue)
+
+                    changed
+                }
+
+                PROCESSING_ORDER -> {
+                    val newValue = value?.let { ProcessingOrder.valueOf(it.toString()) }
+                        ?: ProcessingOrder.LIFO
+                    val changed = this.processingOrder != newValue
+
+                    storage.set(key, newValue)
+
+                    changed
+                }
 
                 LOG_LIFETIME_DAYS -> {
-                    val logLifetimeDays = value?.toString()?.toInt()
+                    val logLifetimeDays = value?.toString()?.toFloat()?.toInt()
                     if (logLifetimeDays != null && logLifetimeDays < 1) {
                         throw IllegalArgumentException("Log lifetime days must be >= 1")
                     }
+
+                    val changed = this.logLifetimeDays != logLifetimeDays
                     storage.set(key, logLifetimeDays?.toString())
+
+                    changed
                 }
+
+                else -> false
             }
-        }
+        }.any { it }
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/ping/PingSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/ping/PingSettings.kt
@@ -25,14 +25,23 @@ class PingSettings(
         )
     }
 
-    override fun import(data: Map<String, *>) {
-        data.forEach { (key, value) ->
+    override fun import(data: Map<String, *>): Boolean {
+        return data.map { (key, value) ->
             when (key) {
-                INTERVAL_SECONDS -> storage.set(
-                    key,
-                    value?.toString()?.toFloat()?.toInt()?.toString()
-                )
+                INTERVAL_SECONDS -> {
+                    val newValue = value?.toString()?.toFloat()?.toInt()?.takeIf { it > 0 }
+                    val changed = this.intervalSeconds != newValue
+
+                    storage.set(
+                        key,
+                        newValue?.toString()
+                    )
+
+                    changed
+                }
+
+                else -> false
             }
-        }
+        }.any { it }
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/settings/Importer.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/settings/Importer.kt
@@ -1,5 +1,5 @@
 package me.capcom.smsgateway.modules.settings
 
 interface Importer {
-    fun import(data: Map<String, *>)
+    fun import(data: Map<String, *>): Boolean
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/settings/SettingsService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/settings/SettingsService.kt
@@ -38,7 +38,7 @@ class SettingsService(
             return
         }
 
-        data.forEach { (key, value) ->
+        val changed = data.map { (key, value) ->
             try {
                 settings[key]?.let {
                     (it as? Importer)?.import(value as Map<String, *>)
@@ -46,6 +46,10 @@ class SettingsService(
             } catch (e: IllegalArgumentException) {
                 throw IllegalArgumentException("Failed to import $key: ${e.message}", e)
             }
+        }
+
+        if (changed.none { it == true }) {
+            return
         }
 
         notificationsService.notify(

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebhooksSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebhooksSettings.kt
@@ -36,20 +36,42 @@ class WebhooksSettings(
         )
     }
 
-    override fun import(data: Map<String, *>) {
-        data.forEach { (key, value) ->
+    override fun import(data: Map<String, *>): Boolean {
+        return data.map { (key, value) ->
             when (key) {
-                INTERNET_REQUIRED -> storage.set(key, value?.toString()?.toBoolean())
+                INTERNET_REQUIRED -> {
+                    val newValue = value?.toString()?.toBoolean()
+                    val changed = this.internetRequired != (newValue ?: true)
+
+                    storage.set(key, newValue)
+
+                    changed
+                }
+
                 RETRY_COUNT -> {
-                    val retryCount = value?.toString()?.toInt()
+                    val retryCount = value?.toString()?.toFloat()?.toInt() ?: 15
                     if (retryCount != null && retryCount < 1) {
                         throw IllegalArgumentException("Retry count must be >= 1")
                     }
+
+                    val changed = this.retryCount != retryCount
+
                     storage.set(key, retryCount?.toString())
+
+                    changed
                 }
 
-                SIGNING_KEY -> storage.set(key, value?.toString())
+                SIGNING_KEY -> {
+                    val newValue = value?.toString()
+                    val changed = this.signingKey != newValue
+
+                    storage.set(key, newValue)
+
+                    changed
+                }
+
+                else -> false
             }
-        }
+        }.any { it }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Settings import routines now report whether any values changed, enabling callers to know if updates occurred.
  * Individual modules detect per-setting changes and update storage only when values differ, avoiding unnecessary writes.
  * Notifications and downstream actions are triggered only when real changes occur, reducing redundant updates, processing, and potential side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->