### PR TITLE
[receiver] add body of mms to webhook

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
@@ -15,6 +15,7 @@ import me.capcom.smsgateway.modules.receiver.parsers.MMSParser
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.Date
+import android.net.Uri
 
 class MmsReceiver : BroadcastReceiver(), KoinComponent {
     private val receiverSvc: ReceiverService by inject()
@@ -65,12 +66,116 @@ class MmsReceiver : BroadcastReceiver(), KoinComponent {
 
             Log.d(TAG, "MMS received from ${mmsNotification.from}")
 
+            // De-duplicate - skip if we've processed this transaction ID recently
+            val now = System.currentTimeMillis()
+            synchronized(processedTransactions) {
+                // Clean up old entries
+                processedTransactions.entries.removeIf { now - it.value > DUPLICATE_WINDOW_MS }
+                
+                // Check if already processed
+                if (processedTransactions.containsKey(mmsNotification.transactionId)) {
+                    Log.d(TAG, "Skipping duplicate MMS with transaction ID: ${mmsNotification.transactionId}")
+                    return
+                }
+                
+                // Mark as processed
+                processedTransactions[mmsNotification.transactionId] = now
+            }
+
+            // Try to read text parts from the MMS using the ContentProvider
+            var body: String? = null
+            Log.d(TAG, "Attempting to read MMS body from ContentProvider")
+            
+            try {
+                // Increase delay for MMS with images
+                Thread.sleep(1500)
+                
+                val mmsUri = Uri.parse("content://mms")
+                val projection = arrayOf("_id", "date", "m_size", "tr_id")
+                
+                Log.d(TAG, "Querying MMS provider for transaction ID: ${mmsNotification.transactionId}")
+                
+                // Try to match by transaction ID first
+                var cursor = context.contentResolver.query(
+                    mmsUri,
+                    projection,
+                    "tr_id = ?",
+                    arrayOf(mmsNotification.transactionId),
+                    null
+                )
+                
+                // If not found by transaction ID, fall back to latest message
+                if (cursor == null || cursor.count == 0) {
+                    cursor?.close()
+                    Log.d(TAG, "Transaction ID not found, trying latest message")
+                    cursor = context.contentResolver.query(
+                        mmsUri,
+                        projection,
+                        null,
+                        null,
+                        "_id DESC LIMIT 1"
+                    )
+                }
+                
+                if (cursor != null) {
+                    Log.d(TAG, "Found ${cursor.count} recent MMS messages")
+                    
+                    if (cursor.count > 0 && cursor.moveToFirst()) {
+                        val mmsId = cursor.getString(cursor.getColumnIndex("_id"))
+                        Log.d(TAG, "Using latest MMS ID=$mmsId")
+                        
+                        val partsUri = Uri.parse("content://mms/$mmsId/part")
+                        val partProjection = arrayOf("_id", "ct", "text")
+                        val partsCursor = context.contentResolver.query(partsUri, partProjection, null, null, null)
+                        
+                        if (partsCursor != null) {
+                            Log.d(TAG, "Found ${partsCursor.count} parts for MMS ID $mmsId")
+                            val ctIndex = partsCursor.getColumnIndex("ct")
+                            val textIndex = partsCursor.getColumnIndex("text")
+                            
+                            while (partsCursor.moveToNext()) {
+                                val ct = if (ctIndex >= 0) partsCursor.getString(ctIndex) else ""
+                                Log.d(TAG, "Part content-type: $ct")
+                                
+                                if (ct.startsWith("text")) {
+                                    val text = if (textIndex >= 0) partsCursor.getString(textIndex) else null
+                                    if (!text.isNullOrEmpty()) {
+                                        body = if (body == null) text else body + "\n" + text
+                                        Log.d(TAG, "Extracted text: ${text.take(100)}")
+                                    }
+                                }
+                            }
+                            partsCursor.close()
+                        }
+                    }
+                    cursor.close()
+                } else {
+                    Log.w(TAG, "Query returned null cursor")
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to read MMS parts: ${e.message}", e)
+            }
+            
+            // Debug log about extracted body
+            logsService.insert(
+                LogEntry.Priority.DEBUG,
+                MODULE_NAME,
+                "MMS body extraction",
+                mapOf(
+                    "bodyFound" to (body != null),
+                    "bodyLength" to (body?.length ?: 0),
+                    "bodyPreview" to (body?.take(200))
+                )
+            )
+            Log.d("MmsReceiver", "MMS body extraction: found=${body != null} length=${body?.length ?: 0} preview=${body?.take(200) ?: "null"}")
+
             val mmsMessage = InboxMessage.Mms(
                 messageId = mmsNotification.messageId,
                 transactionId = mmsNotification.transactionId,
                 subject = mmsNotification.subject,
                 size = mmsNotification.messageSize,
                 contentClass = mmsNotification.contentClass?.name,
+                body = body,
                 address = mmsNotification.from.substringBefore('/'),
                 date = mmsNotification.date ?: Date(),
                 subscriptionId = SubscriptionsHelper.extractSubscriptionId(context, intent),
@@ -86,8 +191,10 @@ class MmsReceiver : BroadcastReceiver(), KoinComponent {
 
     companion object {
         private const val TAG = "MmsReceiver"
+        private const val DUPLICATE_WINDOW_MS = 60000L // 1 minute
 
         private val INSTANCE: MmsReceiver by lazy { MmsReceiver() }
+        private val processedTransactions = mutableMapOf<String, Long>()
 
         fun register(context: Context) {
             val filter = IntentFilter().apply {

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
@@ -95,6 +95,7 @@ class ReceiverService : KoinComponent {
                 subject = message.subject,
                 size = message.size,
                 contentClass = message.contentClass,
+                body = message.body,
                 receivedAt = message.date
             )
         }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/data/InboxMessage.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/data/InboxMessage.kt
@@ -36,6 +36,7 @@ sealed class InboxMessage(
         val subject: String?,
         val size: Long,
         val contentClass: String?,
+        val body: String?,
         address: String,
         date: Date,
         subscriptionId: Int?

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/MmsReceivedPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/MmsReceivedPayload.kt
@@ -10,5 +10,6 @@ class MmsReceivedPayload(
     val subject: String?,
     val size: Long,
     val contentClass: String?,
+    val body: String?,
     val receivedAt: Date
 ) : MessageEventPayload(messageId, phoneNumber, simNumber)


### PR DESCRIPTION
For MMS incoming webhook, there was no body captured.  This adds the body content of an MMS to the mms/incoming webhook.  This was tested and works for long text only messages 1000 chars+ and MMS with images and text (images are ignored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MMS message bodies are now extracted and included in webhook payloads and stored with incoming MMS metadata.
  * Reception now waits up to 30s for message content to appear before processing to improve body extraction reliability.

* **Bug Fixes / Reliability**
  * Progressive retries and sender/address checks reduce missed or partial MMS bodies; processing proceeds with null body only after timeout.
  * Duplicate MMS filtering behavior unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->