### PR TITLE
[settings] stringify enums before saving

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesSettings.kt
@@ -99,11 +99,11 @@ class MessagesSettings(
         return mapOf(
             SEND_INTERVAL_MIN to sendIntervalMin,
             SEND_INTERVAL_MAX to sendIntervalMax,
-            LIMIT_PERIOD to limitPeriod,
+            LIMIT_PERIOD to limitPeriod.name,
             LIMIT_VALUE to limitValue,
-            SIM_SELECTION_MODE to simSelectionMode,
+            SIM_SELECTION_MODE to simSelectionMode.name,
             LOG_LIFETIME_DAYS to logLifetimeDays,
-            PROCESSING_ORDER to processingOrder,
+            PROCESSING_ORDER to processingOrder.name,
         )
     }
 
@@ -141,7 +141,7 @@ class MessagesSettings(
                     val newValue = value?.let { Period.valueOf(it.toString()) } ?: Period.Disabled
                     val changed = this.limitPeriod != newValue
 
-                    storage.set(key, newValue)
+                    storage.set(key, newValue.name)
 
                     changed
                 }
@@ -164,7 +164,7 @@ class MessagesSettings(
                         ?: SimSelectionMode.OSDefault
                     val changed = this.simSelectionMode != newValue
 
-                    storage.set(key, newValue)
+                    storage.set(key, newValue.name)
 
                     changed
                 }
@@ -174,7 +174,7 @@ class MessagesSettings(
                         ?: ProcessingOrder.LIFO
                     val changed = this.processingOrder != newValue
 
-                    storage.set(key, newValue)
+                    storage.set(key, newValue.name)
 
                     changed
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed persistence for several message settings (limit period, SIM selection mode, processing order) so option values are stored and restored as strings, ensuring consistent serialization and reliable import/export across app restarts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->