### PR TITLE
[receiver] unregister before registration to avoid double events

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
@@ -55,6 +55,8 @@ class MessagesReceiver : BroadcastReceiver(), KoinComponent {
         private val INSTANCE: MessagesReceiver by lazy { MessagesReceiver() }
 
         fun register(context: Context) {
+            unregister(context)
+
             val textFilter = IntentFilter().apply {
                 addAction(Intents.SMS_RECEIVED_ACTION)
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message receiver registration stability by preventing duplicate registrations on successive initialization attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->