### PR TITLE
[messages] allow `*` and `#` in phone number

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -424,7 +424,7 @@ class MessagesService(
                         false -> sourcePhoneNumber
                     }
                     val normalizedPhoneNumber = when (request.params.skipPhoneValidation) {
-                        true -> phoneNumber.filter { it.isDigit() || it == '+' }
+                        true -> phoneNumber.filter { it.isDigit() || it == '+' || it == '*' || it == '#' }
                         false -> PhoneHelper.filterPhoneNumber(phoneNumber, countryCode ?: "RU")
                     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced phone number handling when validation is disabled to preserve asterisks and hash symbols alongside digits and the plus sign.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->