### PR TITLE
Security: protect EventsReceiver with signature-level permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
     <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <permission
+        android:name="me.capcom.smsgateway.permission.SMS_STATUS"
+        android:protectionLevel="signature" />
+
     <application
         android:name=".App"
         android:allowBackup="true"
@@ -52,7 +56,8 @@
         <receiver
             android:name=".receivers.EventsReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="true"
+            android:permission="me.capcom.smsgateway.permission.SMS_STATUS">
             <intent-filter>
                 <action android:name="me.capcom.smsgateway.ACTION_SENT" />
                 <action android:name="me.capcom.smsgateway.ACTION_DELIVERED" />
@@ -77,6 +82,7 @@
         <service
             android:name=".modules.localserver.WebService"
             android:enabled="true"
+            android:exported="false"
             android:foregroundServiceType="connectedDevice" />
         <service
             android:name="androidx.work.impl.foreground.SystemForegroundService"


### PR DESCRIPTION
## Summary
- Add signature-level custom permission to `EventsReceiver` to prevent message state spoofing by other apps
- Add explicit `android:exported="false"` to `WebService` declaration

## Problem
The `EventsReceiver` BroadcastReceiver is declared `android:exported="true"` without permission protection. Any app on the device can send forged `ACTION_SENT`/`ACTION_DELIVERED` intents with arbitrary `dataString` (parsed as `"$id|$phoneNumber"`) and `resultCode` to:
- Mark pending messages as delivered (forging delivery confirmation)
- Mark messages as failed (denial of service)

## Fix
Declare a custom permission with `android:protectionLevel="signature"` and apply it to the receiver. This ensures only the SMS Gateway app itself (or apps signed with the same certificate) can trigger delivery state updates.

## Test plan
- [ ] Build and install the APK
- [ ] Send an SMS and verify delivery tracking still works
- [ ] Verify that a test app attempting to send `ACTION_SENT` intent is blocked by the permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Introduced a new permission system to restrict access to SMS-related events
  * Enhanced service security by preventing unauthorized external access
  * Implemented signature-based permission verification controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->