### PR TITLE
Security: enforce minimum PBKDF2 iteration count

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionService.kt
@@ -25,6 +25,11 @@ class EncryptionService(
             throw RuntimeException("Missing iteration count")
         }
 
+        val iterationCount = params.getValue("i").toInt()
+        require(iterationCount >= MIN_ITERATIONS) {
+            "Iteration count too low: $iterationCount (minimum: $MIN_ITERATIONS)"
+        }
+
         val salt = decode(chunks[3])
         val text = chunks[4]
 
@@ -33,7 +38,7 @@ class EncryptionService(
             passphrase.toCharArray(),
             salt,
             256,
-            params.getValue("i").toInt()
+            iterationCount
         )
 
         return decryptText(text, secretKey, salt)
@@ -68,5 +73,9 @@ class EncryptionService(
         return params.split(',')
             .map { it.split('=', limit = 2) }
             .associate { it[0] to it[1] }
+    }
+
+    companion object {
+        const val MIN_ITERATIONS = 100_000
     }
 }


### PR DESCRIPTION
## Summary
- Enforce minimum iteration count of 100,000 for PBKDF2 key derivation in `EncryptionService.decrypt()`

## Problem
The `decrypt()` method reads the iteration count from the ciphertext's `i=` parameter without validation. An attacker who can deliver a crafted encrypted message with `i=1` effectively nullifies PBKDF2 key-stretching, enabling trivial brute-force of the passphrase.

## Fix
Add `require(iterationCount >= MIN_ITERATIONS)` check before using the caller-supplied iteration count. The minimum is set to 100,000 (OWASP recommends 720,000+ for PBKDF2-SHA1, but 100,000 provides a reasonable backward-compatible floor).

## Test plan
- [ ] Verify normal encrypted messages (with standard iteration counts) still decrypt successfully
- [ ] Verify a crafted message with `i=1` is rejected with a clear error
- [ ] Verify a crafted message with `i=99999` is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced encryption parameter validation by enforcing a minimum iteration count threshold for PBKDF2 key derivation, preventing weak encryption configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->