### PR TITLE
Security: document IV/salt reuse weakness in encryption

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionService.kt
@@ -36,6 +36,10 @@ class EncryptionService(
             params.getValue("i").toInt()
         )
 
+        // SECURITY NOTE: Using salt as IV weakens AES-CBC. Identical passphrase+salt
+        // pairs produce identical keystreams. A proper fix requires coordinated changes
+        // to both the encryption (server) and decryption (this app) sides to derive
+        // the IV independently — e.g., PBKDF2 output of 384 bits (256 key + 128 IV).
         return decryptText(text, secretKey, salt)
     }
 


### PR DESCRIPTION
## Summary
- Document the AES-CBC IV/salt reuse vulnerability in `EncryptionService`

## Problem
`EncryptionService.decrypt()` uses the PBKDF2 salt directly as the AES-CBC initialization vector. In AES-CBC, the IV should be independent of the salt. When the same passphrase+salt pair is reused across messages, identical plaintext blocks produce identical ciphertext, breaking semantic security.

## Why not a code fix?
The encryption format (`$algorithm$params$salt$ciphertext`) is shared between the server-side encryption and this client-side decryption. Changing how the IV is derived on the client alone would break decryption of existing messages. The fix needs to be coordinated:

**Recommended approach:**
1. Derive 384 bits from PBKDF2 instead of 256 (key=256 + IV=128)
2. Update both server and client
3. Add a format version indicator for backward compatibility

This PR documents the issue to start that conversation.

## Test plan
- [ ] Verify existing encrypted messages still decrypt correctly (no functional change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for decryption procedures with clarifications on current security implementation to support future maintenance and system improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->