### PR TITLE
Security: disable backup to protect stored credentials

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,9 @@
 
     <application
         android:name=".App"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="${networkSecurityConfig}"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="sharedpref" path="." />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="." />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
## Summary
- Set `android:allowBackup="false"` to prevent credential extraction via ADB backup
- Add `backup_rules.xml` and `data_extraction_rules.xml` as defense-in-depth

## Problem
With `allowBackup="true"` and no backup exclusion rules, `adb backup` captures all SharedPreferences containing:
- Local server JWT secret and basic auth password
- Encryption passphrase
- Cloud gateway registration token
- FCM token

These can be restored to another device to impersonate the gateway.

## Fix
1. Disable backup entirely (`allowBackup="false"`)
2. Add `fullBackupContent` rules (Android 11 and below) excluding all SharedPreferences
3. Add `dataExtractionRules` (Android 12+) excluding SharedPreferences from both cloud backup and device transfer

The exclusion rules serve as defense-in-depth — if backup is re-enabled for other reasons, credentials remain protected.

## Test plan
- [ ] Verify app builds successfully with the new XML resources
- [ ] Verify `adb backup` produces no usable SharedPreferences data
- [ ] Verify app functionality is unaffected (backup was never used for app features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Modified backup configuration to exclude app settings and preferences from cloud backups and device-to-device data transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->