### PR TITLE
CI: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -28,16 +28,16 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup JAVA 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: "temurin"
           java-version: 17
 
       - name: Cache Gradle and wrapper
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: |
             ~/.gradle/caches
@@ -86,7 +86,7 @@ jobs:
         run: ./gradlew bundle${TARGET^}
       #3
       - name: Upload ${{ inputs.build-type }} Build to Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.build-type }}-artifacts
           path: |

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06 # v5
         with:
           days-before-issue-stale: 7
           days-before-issue-close: 7

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -11,12 +11,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set App Version
         run: |
           sed -i "s/{{VERSION}}/${GITHUB_REF_NAME#v}/" docs/api/swagger.json
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@4a2e02b36f31d8974a0d09d3bb9f3172aa2d0d0d # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/api

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -27,17 +27,17 @@ jobs:
     needs: [build]
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-artifacts
 
       - name: Download insecure artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: insecure-artifacts
 
       - name: Upload to S3
-        uses: capcom6/upload-s3-action@master
+        uses: capcom6/upload-s3-action@c4fae9e0868ea2a99ef8e9318e93821e84086955 # master
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
         with:
@@ -53,7 +53,7 @@ jobs:
           destination_dir: apk/${{ github.event.pull_request.head.sha }}
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -61,7 +61,7 @@ jobs:
           body-includes: Pull request artifacts
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -25,14 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-artifacts
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: insecure-artifacts
       - name: Create Github Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77 # v1
         with:
           generate_release_notes: true
           prerelease: true


### PR DESCRIPTION
## Summary
- Pin all third-party GitHub Actions to commit SHAs instead of mutable tags/branches
- Original tags preserved as trailing comments for maintainability

## Problem
Several Actions were referenced by mutable tags or branch names, creating supply-chain risk:

| Action | Previous Pin | Risk |
|--------|-------------|------|
| `capcom6/upload-s3-action@master` | **Branch ref** | Runs on every PR with AWS secrets (key ID, secret key, bucket) — any push to master of that repo would execute in this CI context |
| `softprops/action-gh-release@v1` | Semver tag | Runs with `contents: write` permission |
| `actions/checkout@v4` | Semver tag | Standard risk |
| All others | Semver tags | Standard risk |

The existing `capcom6/discord-webhook@3a447f4...` was already correctly SHA-pinned — this PR applies the same approach to all other Actions.

## Fix
Replace all mutable references with pinned commit SHAs. Each SHA has the original tag as a trailing comment:
```yaml
uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
```

## Actions pinned
- `actions/checkout` v4
- `actions/setup-java` v3
- `actions/cache` v3
- `actions/upload-artifact` v4
- `actions/download-artifact` v4
- `actions/stale` v5
- `softprops/action-gh-release` v1
- `peter-evans/find-comment` v3
- `peter-evans/create-or-update-comment` v4
- `peaceiris/actions-gh-pages` v3
- `capcom6/upload-s3-action` master

## Test plan
- [ ] Verify all workflows still trigger and complete successfully
- [ ] Verify SHA values match the expected tag versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build and deployment workflows to use pinned action versions for improved security and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->