### PR TITLE
[ui] clear backstack on messages tab change

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/ui/HolderFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/HolderFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import me.capcom.smsgateway.R
 import me.capcom.smsgateway.databinding.FragmentHolderBinding
@@ -73,6 +74,7 @@ class HolderFragment : Fragment() {
         isOutgoingSelected = true
 
         updateButtonStates()
+        childFragmentManager.popBackStackImmediate(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
         val outgoing = childFragmentManager.findFragmentByTag(TAG_OUTGOING)
             ?: MessagesListFragment.newInstance()
         val incoming = childFragmentManager.findFragmentByTag(TAG_INCOMING)
@@ -88,6 +90,7 @@ class HolderFragment : Fragment() {
         isOutgoingSelected = false
 
         updateButtonStates()
+        childFragmentManager.popBackStackImmediate(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
         val incoming = childFragmentManager.findFragmentByTag(TAG_INCOMING)
             ?: IncomingMessagesListFragment.newInstance()
         val outgoing = childFragmentManager.findFragmentByTag(TAG_OUTGOING)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation stability when switching between outgoing and incoming message views by clearing prior child-view history before showing the selected pane, ensuring the chosen view displays consistently and preventing unexpected back-stack behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capcom6/android-sms-gateway/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->