### PR TITLE
[receiver] always use application context for broadcast receiver

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/incoming/IncomingMessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/incoming/IncomingMessagesService.kt
@@ -74,6 +74,10 @@ class IncomingMessagesService(
         return repository.selectById(id)
     }
 
+    fun isMessageProcessed(message: InboxMessage): Boolean {
+        return getById(buildId(message)) != null
+    }
+
     private fun buildId(message: InboxMessage): String {
         val prefix = when (message) {
             is InboxMessage.Data -> "data:"

--- a/app/src/main/java/me/capcom/smsgateway/modules/orchestrator/OrchestratorService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/orchestrator/OrchestratorService.kt
@@ -34,7 +34,6 @@ class OrchestratorService(
         try {
             localServerSvc.start(context)
             pingSvc.start(context)
-            receiverService.start(context)
         } catch (e: Throwable) {
             logsSvc.insert(
                 LogEntry.Priority.WARN,

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
@@ -57,12 +57,13 @@ class MessagesReceiver : BroadcastReceiver(), KoinComponent {
         private val INSTANCE: MessagesReceiver by lazy { MessagesReceiver() }
 
         fun register(context: Context) {
-            unregister(context)
+            val appContext = context.applicationContext
+            unregister(appContext)
 
             val textFilter = IntentFilter().apply {
                 addAction(Intents.SMS_RECEIVED_ACTION)
             }
-            context.registerReceiver(
+            appContext.registerReceiver(
                 INSTANCE,
                 textFilter
             )
@@ -72,7 +73,7 @@ class MessagesReceiver : BroadcastReceiver(), KoinComponent {
                 addDataScheme("sms")
                 addDataAuthority("*", "53739")
             }
-            context.registerReceiver(
+            appContext.registerReceiver(
                 INSTANCE,
                 dataFilter
             )
@@ -80,7 +81,7 @@ class MessagesReceiver : BroadcastReceiver(), KoinComponent {
 
         fun unregister(context: Context) {
             try {
-                context.unregisterReceiver(INSTANCE)
+                context.applicationContext.unregisterReceiver(INSTANCE)
             } catch (e: IllegalArgumentException) {
                 Log.w(TAG, "Receiver was not registered", e)
             }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
@@ -90,11 +90,14 @@ class MmsReceiver : BroadcastReceiver(), KoinComponent {
         private val INSTANCE: MmsReceiver by lazy { MmsReceiver() }
 
         fun register(context: Context) {
+            val appContext = context.applicationContext
+            unregister(appContext)
+
             val filter = IntentFilter().apply {
                 addAction(Telephony.Sms.Intents.WAP_PUSH_RECEIVED_ACTION)
                 addDataType("application/vnd.wap.mms-message")
             }
-            context.registerReceiver(
+            appContext.registerReceiver(
                 INSTANCE,
                 filter
             )
@@ -102,7 +105,7 @@ class MmsReceiver : BroadcastReceiver(), KoinComponent {
 
         fun unregister(context: Context) {
             try {
-                context.unregisterReceiver(INSTANCE)
+                context.applicationContext.unregisterReceiver(INSTANCE)
             } catch (e: IllegalArgumentException) {
                 Log.w(TAG, "Receiver was not registered", e)
             }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
@@ -77,6 +77,17 @@ class ReceiverService : KoinComponent {
             mapOf("message" to message)
         )
 
+        // Dedup safety net: skip if this exact message was already processed
+        if (incomingMessagesService.isMessageProcessed(message)) {
+            logsService.insert(
+                LogEntry.Priority.DEBUG,
+                MODULE_NAME,
+                "ReceiverService::process - duplicate message, skipping",
+                mapOf("message" to message)
+            )
+            return
+        }
+
         val simSlotIndex = message.subscriptionId?.let {
             SubscriptionsHelper.getSimSlotIndex(context, it)
         }

--- a/app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt
@@ -358,7 +358,7 @@ class HomeFragment : Fragment() {
     }
 
     private fun start() {
-        orchestratorSvc.start(requireContext(), false)
+        orchestratorSvc.start(requireContext().applicationContext, false)
     }
 
     private fun requestPermissionsAndStart() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate message detection to prevent the same incoming message from being processed more than once
  * Enhanced broadcast receiver registration/unregistration stability by consistently using the application context
  * Clearer error handling when starting background services, with separate logging for receiver startup failures
  * Fixed context usage in startup flows to improve overall app reliability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->