### PR TITLE
[ping] start working thread on create

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/ping/services/PingForegroundService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/ping/services/PingForegroundService.kt
@@ -70,6 +70,7 @@ class PingForegroundService : Service() {
 
         wakeLock.acquire()
         wifiLock.acquire()
+        workingThread.start()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -80,8 +81,6 @@ class PingForegroundService : Service() {
         )
 
         startForeground(NotificationsService.NOTIFICATION_ID_PING_SERVICE, notification)
-
-        workingThread.start()
 
         return super.onStartCommand(intent, flags, startId)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ping service initialization timing to ensure background operations start at the correct point in the service lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->