### PR TITLE
[webhooks] add `app:started` event

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/orchestrator/OrchestratorService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/orchestrator/OrchestratorService.kt
@@ -2,6 +2,7 @@ package me.capcom.smsgateway.modules.orchestrator
 
 import android.content.Context
 import me.capcom.smsgateway.helpers.SettingsHelper
+import me.capcom.smsgateway.helpers.SubscriptionsHelper
 import me.capcom.smsgateway.modules.gateway.GatewayService
 import me.capcom.smsgateway.modules.localserver.LocalServerService
 import me.capcom.smsgateway.modules.logs.LogsService
@@ -10,6 +11,8 @@ import me.capcom.smsgateway.modules.messages.MessagesService
 import me.capcom.smsgateway.modules.ping.PingService
 import me.capcom.smsgateway.modules.receiver.ReceiverService
 import me.capcom.smsgateway.modules.webhooks.WebHooksService
+import me.capcom.smsgateway.modules.webhooks.domain.WebHookEvent
+import me.capcom.smsgateway.modules.webhooks.payload.AppStartedPayload
 
 class OrchestratorService(
     private val messagesSvc: MessagesService,
@@ -51,6 +54,13 @@ class OrchestratorService(
                 "Can't register receiver"
             )
         }
+
+        val simCards = SubscriptionsHelper.getActiveSimCards(context)
+        webHooksSvc.emit(
+            context,
+            WebHookEvent.AppStarted,
+            AppStartedPayload(simCards)
+        )
     }
 
     fun stop(context: Context) {

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
@@ -26,4 +26,7 @@ enum class WebHookEvent(val value: String) {
 
     @SerializedName("mms:downloaded")
     MmsDownloaded("mms:downloaded"),
+
+    @SerializedName("app:started")
+    AppStarted("app:started"),
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/AppStartedPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/AppStartedPayload.kt
@@ -1,0 +1,7 @@
+package me.capcom.smsgateway.modules.webhooks.payload
+
+import me.capcom.smsgateway.modules.localserver.domain.SimCard
+
+data class AppStartedPayload(
+    val simCards: List<SimCard>,
+)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App startup webhook notifications: The application now emits an `app:started` webhook when startup completes, enabling external integrations to react immediately.
  * Active SIM card details in startup payload: The startup webhook includes the list of currently active SIM cards, so subscribers can auto-populate configuration/status based on the device’s available SIMs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->