### PR TITLE
[messages] add ability to cancel pending message

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
@@ -20,7 +20,7 @@ import java.util.Date
 @Dao
 interface MessagesDao {
     //#region Read
-    @Query("SELECT COUNT(*) as count, MAX(processedAt) as lastTimestamp FROM message WHERE state <> 'Pending' AND state <> 'Failed' AND processedAt >= :timestamp")
+    @Query("SELECT COUNT(*) as count, MAX(processedAt) as lastTimestamp FROM message WHERE state NOT IN ('Pending', 'Cancelling', 'Cancelled', 'Failed') AND processedAt >= :timestamp")
     fun countProcessedFrom(timestamp: Long): MessagesStats
 
     @Query("SELECT COUNT(*) as count, MAX(processedAt) as lastTimestamp FROM message WHERE state = 'Failed' AND processedAt >= :timestamp")
@@ -31,6 +31,8 @@ interface MessagesDao {
         SELECT
             COUNT(*) as total,
             COALESCE(SUM(CASE WHEN state = 'Pending' THEN 1 ELSE 0 END), 0) as pending,
+            COALESCE(SUM(CASE WHEN state = 'Cancelling' THEN 1 ELSE 0 END), 0) as cancelling,
+            COALESCE(SUM(CASE WHEN state = 'Cancelled' THEN 1 ELSE 0 END), 0) as cancelled,
             COALESCE(SUM(CASE WHEN state = 'Sent' THEN 1 ELSE 0 END), 0) as sent,
             COALESCE(SUM(CASE WHEN state = 'Delivered' THEN 1 ELSE 0 END), 0) as delivered,
             COALESCE(SUM(CASE WHEN state = 'Failed' THEN 1 ELSE 0 END), 0) as failed
@@ -104,7 +106,7 @@ interface MessagesDao {
     )
     fun _insertRecipientStatesByMessage(
         messageId: String,
-        state: me.capcom.smsgateway.domain.ProcessingState
+        state: ProcessingState
     )
 
     @Transaction
@@ -129,9 +131,9 @@ interface MessagesDao {
     }
 
     @Query("UPDATE message SET state = :state WHERE id = :id AND state <> 'Failed'")
-    fun _updateMessageState(id: String, state: me.capcom.smsgateway.domain.ProcessingState)
+    fun _updateMessageState(id: String, state: ProcessingState)
 
-    fun updateMessageState(id: String, state: me.capcom.smsgateway.domain.ProcessingState) {
+    fun updateMessageState(id: String, state: ProcessingState) {
         _updateMessageState(id, state)
         _insertMessageState(
             MessageState(
@@ -142,6 +144,20 @@ interface MessagesDao {
         )
     }
 
+    @Query("UPDATE message SET state = 'Cancelled' WHERE id = :id AND state = 'Pending'")
+    fun _cancelMessage(id: String): Int
+
+    @Transaction
+    fun cancelMessage(id: String) {
+        val updated = _cancelMessage(id)
+        if (updated == 0) return
+        
+        _insertMessageState(
+            MessageState(id, ProcessingState.Cancelled, System.currentTimeMillis())
+        )
+        updateRecipientsState(id, ProcessingState.Cancelled, null)
+    }
+
     @Query("UPDATE message SET state = 'Processed', processedAt = strftime('%s', 'now') * 1000 WHERE id = :id")
     fun _setMessageProcessed(id: String)
     fun setMessageProcessed(id: String) {
@@ -149,7 +165,7 @@ interface MessagesDao {
         _insertMessageState(
             MessageState(
                 id,
-                me.capcom.smsgateway.domain.ProcessingState.Processed,
+                ProcessingState.Processed,
                 System.currentTimeMillis()
             )
         )
@@ -159,7 +175,7 @@ interface MessagesDao {
     fun _updateRecipientState(
         id: String,
         phoneNumber: String,
-        state: me.capcom.smsgateway.domain.ProcessingState,
+        state: ProcessingState,
         error: String?
     )
 
@@ -167,7 +183,7 @@ interface MessagesDao {
     fun updateRecipientState(
         id: String,
         phoneNumber: String,
-        state: me.capcom.smsgateway.domain.ProcessingState,
+        state: ProcessingState,
         error: String?
     ) {
         _updateRecipientState(id, phoneNumber, state, error)
@@ -181,14 +197,14 @@ interface MessagesDao {
     @Query("UPDATE messagerecipient SET state = :state, error = :error WHERE messageId = :id AND state <> 'Failed'")
     fun _updateRecipientsState(
         id: String,
-        state: me.capcom.smsgateway.domain.ProcessingState,
+        state: ProcessingState,
         error: String?
     )
 
     @Transaction
     fun updateRecipientsState(
         id: String,
-        state: me.capcom.smsgateway.domain.ProcessingState,
+        state: ProcessingState,
         error: String?
     ) {
         _updateRecipientsState(id, state, error)
@@ -204,6 +220,6 @@ interface MessagesDao {
     @Query("UPDATE message SET partsCount = :partsCount WHERE id = :id")
     fun updatePartsCount(id: String, partsCount: Int)
 
-    @Query("DELETE FROM message WHERE createdAt < :until AND state <> 'Pending'")
+    @Query("DELETE FROM message WHERE createdAt < :until AND state NOT IN ('Pending', 'Cancelling')")
     suspend fun truncateLog(until: Long)
 }

--- a/app/src/main/java/me/capcom/smsgateway/data/entities/MessageWithRecipients.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/entities/MessageWithRecipients.kt
@@ -22,6 +22,8 @@ data class MessageWithRecipients(
     val state: me.capcom.smsgateway.domain.ProcessingState
         get() = when {
             recipients.any { it.state == me.capcom.smsgateway.domain.ProcessingState.Pending } -> me.capcom.smsgateway.domain.ProcessingState.Pending
+            recipients.any { it.state == me.capcom.smsgateway.domain.ProcessingState.Cancelling } -> me.capcom.smsgateway.domain.ProcessingState.Cancelling
+            recipients.any { it.state == me.capcom.smsgateway.domain.ProcessingState.Cancelled } -> me.capcom.smsgateway.domain.ProcessingState.Cancelled
             recipients.any { it.state == me.capcom.smsgateway.domain.ProcessingState.Processed } -> me.capcom.smsgateway.domain.ProcessingState.Processed
 
             recipients.all { it.state == me.capcom.smsgateway.domain.ProcessingState.Failed } -> me.capcom.smsgateway.domain.ProcessingState.Failed

--- a/app/src/main/java/me/capcom/smsgateway/data/entities/MessagesTotals.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/entities/MessagesTotals.kt
@@ -3,6 +3,8 @@ package me.capcom.smsgateway.data.entities
 data class MessagesTotals(
     val total: Long,
     val pending: Long,
+    val cancelling: Long,
+    val cancelled: Long,
     val sent: Long,
     val delivered: Long,
     val failed: Long,

--- a/app/src/main/java/me/capcom/smsgateway/domain/ProcessingState.kt
+++ b/app/src/main/java/me/capcom/smsgateway/domain/ProcessingState.kt
@@ -2,6 +2,8 @@ package me.capcom.smsgateway.domain
 
 enum class ProcessingState {
     Pending,
+    Cancelling,
+    Cancelled,
     Processed,
     Sent,
     Delivered,

--- a/app/src/main/java/me/capcom/smsgateway/modules/events/ExternalEventType.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/events/ExternalEventType.kt
@@ -14,4 +14,7 @@ enum class ExternalEventType {
 
     @SerializedName("SettingsUpdated")
     SettingsUpdated,
+
+    @SerializedName("MessageCancelled")
+    MessageCancelled,
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/EventsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/EventsReceiver.kt
@@ -7,6 +7,7 @@ import me.capcom.smsgateway.domain.EntitySource
 import me.capcom.smsgateway.modules.events.EventBus
 import me.capcom.smsgateway.modules.events.EventsReceiver
 import me.capcom.smsgateway.modules.gateway.events.DeviceRegisteredEvent
+import me.capcom.smsgateway.modules.gateway.events.MessageCancelledEvent
 import me.capcom.smsgateway.modules.gateway.events.MessageEnqueuedEvent
 import me.capcom.smsgateway.modules.gateway.events.SettingsUpdatedEvent
 import me.capcom.smsgateway.modules.gateway.events.WebhooksUpdatedEvent
@@ -15,6 +16,7 @@ import me.capcom.smsgateway.modules.gateway.workers.PullMessagesWorker
 import me.capcom.smsgateway.modules.gateway.workers.SendStateWorker
 import me.capcom.smsgateway.modules.gateway.workers.SettingsUpdateWorker
 import me.capcom.smsgateway.modules.gateway.workers.WebhooksUpdateWorker
+import me.capcom.smsgateway.modules.messages.MessagesService
 import me.capcom.smsgateway.modules.messages.events.MessageStateChangedEvent
 import me.capcom.smsgateway.modules.ping.events.PingEvent
 import org.koin.core.component.get
@@ -91,6 +93,23 @@ class EventsReceiver : EventsReceiver() {
                     if (settings.fcmToken != null) return@collect
 
                     SSEForegroundService.start(get())
+                }
+            }
+
+            launch {
+                Log.d("EventsReceiver", "launched MessageCancelledEvent")
+                eventBus.collect<MessageCancelledEvent> { event ->
+                    Log.d("EventsReceiver", "Event: $event")
+
+                    if (!settings.enabled) return@collect
+
+                    try {
+                        get<MessagesService>().cancelMessage(event.messageId)
+                    } catch (_: IllegalArgumentException) {
+                        // message not found locally — nothing to cancel
+                    } catch (_: IllegalStateException) {
+                        // message not in Pending state — already sent/cancelled
+                    }
                 }
             }
         }

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayApi.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayApi.kt
@@ -200,6 +200,7 @@ class GatewayApi(
         val validUntil: Date?,
         val scheduleAt: Date?,
         val priority: Byte?,
+        val state: ProcessingState?,
         val createdAt: Date?,
 
         @SerializedName("message")

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.os.Build
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.http.HttpStatusCode
-import me.capcom.smsgateway.data.entities.MessageWithRecipients
 import me.capcom.smsgateway.domain.EntitySource
 import me.capcom.smsgateway.domain.MessageContent
+import me.capcom.smsgateway.domain.ProcessingState
 import me.capcom.smsgateway.helpers.SubscriptionsHelper
 import me.capcom.smsgateway.modules.events.EventBus
 import me.capcom.smsgateway.modules.gateway.events.DeviceRegisteredEvent
@@ -237,7 +237,42 @@ class GatewayService(
         }
     }
 
-    private fun processMessage(context: Context, message: GatewayApi.Message) {
+    private suspend fun processMessage(context: Context, message: GatewayApi.Message) {
+        when (message.state) {
+            ProcessingState.Pending, null -> {}
+            ProcessingState.Cancelling -> {
+                try {
+                    messagesService.cancelMessage(message.id)
+                } catch (_: IllegalArgumentException) {
+                    // message not found locally — nothing to cancel
+                    sendState(
+                        GatewayApi.MessagePatchRequest(
+                            message.id,
+                            ProcessingState.Cancelled,
+                            message.phoneNumbers.map {
+                                GatewayApi.RecipientState(
+                                    it,
+                                    ProcessingState.Cancelled,
+                                    null
+                                )
+                            },
+                            mapOf(ProcessingState.Cancelled to Date())
+                        )
+                    )
+                    return
+                } catch (_: IllegalStateException) {
+                    // message not in Pending state — already sent/cancelled
+                }
+                return
+            }
+
+            ProcessingState.Cancelled,
+            ProcessingState.Processed,
+            ProcessingState.Sent,
+            ProcessingState.Delivered,
+            ProcessingState.Failed -> return
+        }
+
         val messageState = messagesService.getMessage(message.id)
         if (messageState != null) {
             SendStateWorker.start(context, message.id)
@@ -272,26 +307,13 @@ class GatewayService(
     }
 
     internal suspend fun sendState(
-        message: MessageWithRecipients
+        request: GatewayApi.MessagePatchRequest
     ) {
         val settings = settings.registrationInfo ?: return
 
         api.patchMessages(
             settings.token,
-            listOf(
-                GatewayApi.MessagePatchRequest(
-                    message.message.id,
-                    message.message.state,
-                    message.recipients.map {
-                        GatewayApi.RecipientState(
-                            it.phoneNumber,
-                            it.state,
-                            it.error
-                        )
-                    },
-                    message.states.associate { it.state to Date(it.updatedAt) }
-                )
-            )
+            listOf(request)
         )
     }
     //endregion

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/events/MessageCancelledEvent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/events/MessageCancelledEvent.kt
@@ -1,0 +1,25 @@
+package me.capcom.smsgateway.modules.gateway.events
+
+import com.google.gson.GsonBuilder
+import com.google.gson.annotations.SerializedName
+import me.capcom.smsgateway.extensions.configure
+import me.capcom.smsgateway.modules.events.AppEvent
+
+class MessageCancelledEvent(val messageId: String) : AppEvent(NAME) {
+    data class Payload(
+        @SerializedName("messageId")
+        val messageId: String
+    )
+
+    companion object {
+        fun withPayload(payload: String): MessageCancelledEvent {
+            val obj = GsonBuilder().configure().create().fromJson(payload, Payload::class.java)
+
+            return MessageCancelledEvent(
+                obj.messageId,
+            )
+        }
+
+        const val NAME = "MessageCancelledEvent"
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/workers/SendStateWorker.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/workers/SendStateWorker.kt
@@ -12,10 +12,12 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import me.capcom.smsgateway.modules.gateway.GatewayApi
 import me.capcom.smsgateway.modules.gateway.GatewayService
 import me.capcom.smsgateway.modules.messages.MessagesService
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.util.Date
 import java.util.concurrent.TimeUnit
 
 class SendStateWorker(appContext: Context, params: WorkerParameters) :
@@ -28,7 +30,20 @@ class SendStateWorker(appContext: Context, params: WorkerParameters) :
             val message = messagesService.getMessage(messageId) ?: return Result.failure()
 
             withContext(Dispatchers.IO) {
-                gatewayService.sendState(message)
+                gatewayService.sendState(
+                    GatewayApi.MessagePatchRequest(
+                        message.message.id,
+                        message.message.state,
+                        message.recipients.map {
+                            GatewayApi.RecipientState(
+                                it.phoneNumber,
+                                it.state,
+                                it.error
+                            )
+                        },
+                        message.states.associate { it.state to Date(it.updatedAt) },
+                    )
+                )
             }
             return Result.success()
         } catch (th: Throwable) {

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/auth/AuthScopes.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/auth/AuthScopes.kt
@@ -6,6 +6,7 @@ enum class AuthScopes(val value: String) {
     MessagesSend("messages:send"),
     MessagesRead("messages:read"),
     MessagesExport("messages:export"),
+    MessagesCancel("messages:cancel"),
 
     InboxList("inbox:list"),
     InboxRead("inbox:read"),

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
@@ -1,12 +1,14 @@
 package me.capcom.smsgateway.modules.localserver.routes
 
 import android.content.Context
+import android.util.Log
 import com.aventrix.jnanoid.jnanoid.NanoIdUtils
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
@@ -214,6 +216,35 @@ class MessagesRoutes(
                 message.toDomain(
                     requireNotNull(settings.deviceId),
                     includeContent = true
+                )
+            )
+        }
+        delete("{id}") {
+            if (!requireScope(AuthScopes.MessagesCancel)) return@delete
+            val id = call.parameters["id"]
+                ?: return@delete call.respond(HttpStatusCode.BadRequest)
+
+            val message = try {
+                messagesService.cancelMessage(id)
+            } catch (e: IllegalArgumentException) {
+                Log.w("MessagesRoutes", "Cancel message $id not found", e)
+                return@delete call.respond(HttpStatusCode.NotFound)
+            } catch (e: IllegalStateException) {
+                return@delete call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf("message" to e.message)
+                )
+            } catch (e: Throwable) {
+                return@delete call.respond(
+                    HttpStatusCode.InternalServerError,
+                    mapOf("message" to e.message)
+                )
+            }
+
+            call.respond(
+                message.toDomain(
+                    requireNotNull(settings.deviceId),
+                    includeContent = false
                 )
             )
         }

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -90,6 +90,39 @@ class MessagesService(
     }
     //#endregion
 
+    //#region Cancel
+    suspend fun cancelMessage(id: String): MessageWithRecipients {
+        val existing = dao.get(id)
+            ?: throw IllegalArgumentException("Message with id $id not found")
+
+        if (existing.message.state == ProcessingState.Cancelled) {
+            return existing
+        }
+
+        if (existing.message.state != ProcessingState.Pending) {
+            throw IllegalStateException("Message $id is not in Pending state")
+        }
+
+        dao.cancelMessage(id)
+
+        val message = requireNotNull(dao.get(id))
+
+        events.emit(
+            MessageStateChangedEvent(
+                id,
+                message.message.source,
+                message.recipients.map { it.phoneNumber }.toSet(),
+                message.message.state,
+                message.message.simNumber,
+                message.message.partsCount,
+                null
+            )
+        )
+
+        return message
+    }
+    //#endregion
+
     //#region Send
     fun enqueueMessage(request: SendRequest): MessageWithRecipients {
         val priority = request.params.priority ?: Message.PRIORITY_DEFAULT
@@ -196,6 +229,7 @@ class MessagesService(
 
                 else -> ProcessingState.Failed to "Delivery result: $resultCode"
             }
+
             else -> return
         }
 
@@ -277,6 +311,17 @@ class MessagesService(
     private suspend fun sendMessage(request: StoredSendRequest): Boolean {
         if (request.params.validUntil?.before(Date()) == true) {
             updateState(request.message.id, null, ProcessingState.Failed, "TTL expired")
+            return false
+        }
+
+        // Re-check state: message might have been cancelled while in queue
+        val currentState = dao.get(request.message.id)?.message?.state
+        if (currentState == ProcessingState.Cancelling || currentState == ProcessingState.Cancelled) {
+            logsService.insert(
+                LogEntry.Priority.INFO,
+                MODULE_NAME,
+                "Skipping cancelled message ${request.message.id}",
+            )
             return false
         }
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/orchestrator/EventsRouter.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/orchestrator/EventsRouter.kt
@@ -7,13 +7,14 @@ import kotlinx.coroutines.launch
 import me.capcom.smsgateway.modules.events.EventBus
 import me.capcom.smsgateway.modules.events.ExternalEvent
 import me.capcom.smsgateway.modules.events.ExternalEventType
+import me.capcom.smsgateway.modules.gateway.events.MessageCancelledEvent
 import me.capcom.smsgateway.modules.gateway.events.MessageEnqueuedEvent
 import me.capcom.smsgateway.modules.gateway.events.SettingsUpdatedEvent
 import me.capcom.smsgateway.modules.gateway.events.WebhooksUpdatedEvent
 import me.capcom.smsgateway.modules.receiver.events.MessagesExportRequestedEvent
 
 class EventsRouter(
-    private val eventBus: EventBus
+    private val eventBus: EventBus,
 ) {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
@@ -41,6 +42,14 @@ class EventsRouter(
                     eventBus.emit(
                         SettingsUpdatedEvent()
                     )
+
+                ExternalEventType.MessageCancelled -> {
+                    eventBus.emit(
+                        MessageCancelledEvent.withPayload(
+                            requireNotNull(event.data)
+                        )
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/EventsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/EventsReceiver.kt
@@ -37,6 +37,7 @@ class EventsReceiver : EventsReceiver() {
                         ProcessingState.Sent -> WebHookEvent.SmsSent
                         ProcessingState.Delivered -> WebHookEvent.SmsDelivered
                         ProcessingState.Failed -> WebHookEvent.SmsFailed
+                        ProcessingState.Cancelled -> WebHookEvent.SmsCancelled
                         else -> return@collect
                     }
 
@@ -70,6 +71,14 @@ class EventsReceiver : EventsReceiver() {
                                 simNumber = event.simNumber,
                                 failedAt = Date(),
                                 reason = event.error ?: "Unknown",
+                                sender = sender,
+                                recipient = destination,
+                            )
+
+                            WebHookEvent.SmsCancelled -> SmsEventPayload.SmsCancelled(
+                                messageId = event.id,
+                                simNumber = event.simNumber,
+                                cancelledAt = Date(),
                                 sender = sender,
                                 recipient = destination,
                             )

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
@@ -29,4 +29,7 @@ enum class WebHookEvent(val value: String) {
 
     @SerializedName("app:started")
     AppStarted("app:started"),
+
+    @SerializedName("sms:cancelled")
+    SmsCancelled("sms:cancelled"),
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsEventPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsEventPayload.kt
@@ -54,4 +54,12 @@ sealed class SmsEventPayload(
         val data: String,
         val receivedAt: Date,
     ) : SmsEventPayload(messageId, sender, recipient, simNumber, sender)
+
+    class SmsCancelled(
+        messageId: String,
+        sender: String?,
+        recipient: String,
+        simNumber: Int?,
+        val cancelledAt: Date,
+    ) : SmsEventPayload(messageId, sender, recipient, simNumber, recipient)
 }

--- a/app/src/main/java/me/capcom/smsgateway/ui/styles/Colors.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/styles/Colors.kt
@@ -5,6 +5,8 @@ import android.graphics.Color
 val me.capcom.smsgateway.domain.ProcessingState.color: Int
     get() = when (this) {
         me.capcom.smsgateway.domain.ProcessingState.Pending -> Color.parseColor("#FFBB86FC")
+        me.capcom.smsgateway.domain.ProcessingState.Cancelling -> Color.parseColor("#FFFFC107")
+        me.capcom.smsgateway.domain.ProcessingState.Cancelled -> Color.parseColor("#FF9E9E9E")
         me.capcom.smsgateway.domain.ProcessingState.Processed -> Color.parseColor("#FF6200EE")
         me.capcom.smsgateway.domain.ProcessingState.Sent -> Color.parseColor("#FF3700B3")
         me.capcom.smsgateway.domain.ProcessingState.Delivered -> Color.parseColor("#FF03DAC5")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added message cancellation with a new authorization scope and authenticated `DELETE /{id}` endpoint, returning the refreshed canceled message.
  * Introduced `Cancelling`/`Cancelled` processing states, including cancellation event handling and `sms:cancelled` webhook support.
* **Bug Fixes / Improvements**
  * Sending now aborts when a message is `Cancelling` or `Cancelled`.
  * Message status resolution now prioritizes recipient cancellation state.
  * Updated message statistics/counts to include separate cancel metrics; log truncation now preserves `Pending`/`Cancelling`.
  * Added UI colors for the new states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->