### PR TITLE
[mms] incoming attachments support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -92,6 +92,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/assets/api/swagger.json
+++ b/app/src/main/assets/api/swagger.json
@@ -559,6 +559,13 @@
       },
       "smsgateway.IncomingMessage": {
         "properties": {
+          "attachments": {
+            "description": "List of MMS attachments (only present for MMS_DOWNLOADED messages).",
+            "items": {
+              "$ref": "#/components/schemas/smsgateway.IncomingMessageAttachment"
+            },
+            "type": "array"
+          },
           "contentPreview": {
             "description": "Message body preview or metadata",
             "example": "Hello World!",
@@ -610,6 +617,33 @@
         ],
         "type": "object"
       },
+      "smsgateway.IncomingMessageAttachment": {
+        "properties": {
+          "contentType": {
+            "description": "MIME type of the attachment (e.g. image/jpeg).",
+            "type": "string"
+          },
+          "name": {
+            "description": "Display name of the attachment file.",
+            "type": "string"
+          },
+          "partId": {
+            "description": "Part ID of the attachment, corresponding to the _id in content://mms/part.",
+            "type": "integer"
+          },
+          "size": {
+            "description": "Size of the attachment in bytes.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "partId",
+          "name",
+          "size",
+          "contentType"
+        ],
+        "type": "object"
+      },
       "smsgateway.IncomingMessageType": {
         "enum": [
           "SMS",
@@ -642,6 +676,7 @@
           "devices:list",
           "devices:delete",
           "inbox:list",
+          "inbox:read",
           "inbox:refresh",
           "logs:read",
           "messages:send",
@@ -660,6 +695,7 @@
           "ScopeDevicesList",
           "ScopeDevicesDelete",
           "ScopeInboxList",
+          "ScopeInboxRead",
           "ScopeInboxRefresh",
           "ScopeLogsRead",
           "ScopeMessagesSend",
@@ -2040,6 +2076,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Include attachment metadata in response (for MMS messages)",
+            "in": "query",
+            "name": "includeAttachments",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -2125,6 +2170,102 @@
           }
         ],
         "summary": "Get incoming messages",
+        "tags": [
+          "User",
+          "Inbox"
+        ]
+      }
+    },
+    "/inbox/{id}/attachments/{partId}": {
+      "get": {
+        "description": "Download a specific MMS attachment by message ID and part ID.",
+        "parameters": [
+          {
+            "description": "Incoming message ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Attachment part ID",
+            "in": "path",
+            "name": "partId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {}
+            },
+            "description": "The attachment file"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/smsgateway.ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/smsgateway.ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/smsgateway.ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/smsgateway.ErrorResponse"
+                }
+              }
+            },
+            "description": "Attachment not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/smsgateway.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "ApiAuth": []
+          },
+          {
+            "JWTAuth": []
+          }
+        ],
+        "summary": "Download MMS attachment",
         "tags": [
           "User",
           "Inbox"

--- a/app/src/main/java/me/capcom/smsgateway/App.kt
+++ b/app/src/main/java/me/capcom/smsgateway/App.kt
@@ -13,6 +13,7 @@ import me.capcom.smsgateway.modules.incoming.incomingModule
 import me.capcom.smsgateway.modules.localserver.localserverModule
 import me.capcom.smsgateway.modules.logs.logsModule
 import me.capcom.smsgateway.modules.messages.messagesModule
+import me.capcom.smsgateway.modules.mms.mmsModule
 import me.capcom.smsgateway.modules.notifications.notificationsModule
 import me.capcom.smsgateway.modules.orchestrator.OrchestratorService
 import me.capcom.smsgateway.modules.orchestrator.orchestratorModule
@@ -44,6 +45,7 @@ class App: Application() {
                 dbModule,
                 logsModule,
                 notificationsModule,
+                mmsModule,
                 messagesModule,
                 incomingModule,
                 receiverModule,

--- a/app/src/main/java/me/capcom/smsgateway/modules/incoming/IncomingMessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/incoming/IncomingMessagesService.kt
@@ -1,17 +1,20 @@
 package me.capcom.smsgateway.modules.incoming
 
 import android.content.Context
+import android.util.Base64
 import me.capcom.smsgateway.helpers.SubscriptionsHelper
 import me.capcom.smsgateway.modules.incoming.db.IncomingMessage
 import me.capcom.smsgateway.modules.incoming.db.IncomingMessageType
 import me.capcom.smsgateway.modules.incoming.repositories.IncomingMessagesRepository
 import me.capcom.smsgateway.modules.logs.LogsService
 import me.capcom.smsgateway.modules.logs.db.LogEntry
+import me.capcom.smsgateway.modules.mms.MmsAttachmentStorage
 import me.capcom.smsgateway.modules.receiver.data.InboxMessage
 
 class IncomingMessagesService(
     private val context: Context,
     private val repository: IncomingMessagesRepository,
+    private val attachmentStorage: MmsAttachmentStorage,
     private val logsService: LogsService,
 ) {
     fun save(message: InboxMessage): IncomingMessage {
@@ -42,6 +45,9 @@ class IncomingMessagesService(
         ).also {
             try {
                 repository.insert(it)
+                if (message is InboxMessage.MMS) {
+                    persistMmsAttachments(it.id, message)
+                }
             } catch (e: Exception) {
                 logsService.insert(
                     LogEntry.Priority.ERROR,
@@ -52,6 +58,50 @@ class IncomingMessagesService(
                         "exception" to e.stackTraceToString(),
                     )
                 )
+            }
+        }
+    }
+
+    private fun persistMmsAttachments(messageId: String, message: InboxMessage.MMS) {
+        message.attachments.forEach { att ->
+            val decoded = att.data?.let {
+                runCatching {
+                    Base64.decode(it, Base64.DEFAULT)
+                }.onFailure { e ->
+                    logsService.insert(
+                        LogEntry.Priority.WARN,
+                        MODULE_NAME,
+                        "Failed to decode MMS attachment data",
+                        mapOf(
+                            "messageId" to messageId,
+                            "partId" to att.partId,
+                            "name" to (att.name ?: ""),
+                            "error" to (e.message ?: e.toString()),
+                        )
+                    )
+                }.getOrNull()
+            }
+            if (decoded != null) {
+                try {
+                    attachmentStorage.store(
+                        messageId,
+                        att.partId,
+                        att.name,
+                        att.contentType,
+                        decoded,
+                    )
+                } catch (e: Exception) {
+                    logsService.insert(
+                        LogEntry.Priority.WARN,
+                        MODULE_NAME,
+                        "Failed to persist MMS attachment",
+                        mapOf(
+                            "messageId" to message.messageId,
+                            "partId" to att.partId,
+                            "error" to (e.message ?: e.toString()),
+                        )
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/WebService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/WebService.kt
@@ -181,7 +181,7 @@ class WebService : Service() {
                             it.register(this)
                         }
                     }
-                    InboxRoutes(applicationContext, get(), get(), get()).let {
+                    InboxRoutes(applicationContext, get(), get(), get(), get()).let {
                         route("/inbox") {
                             it.register(this)
                         }

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/InboxRoutes.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/InboxRoutes.kt
@@ -1,9 +1,12 @@
 package me.capcom.smsgateway.modules.localserver.routes
 
 import android.content.Context
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
+import io.ktor.server.http.content.LocalFileContent
 import io.ktor.server.request.receive
+import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
@@ -17,6 +20,7 @@ import me.capcom.smsgateway.modules.localserver.LocalServerSettings
 import me.capcom.smsgateway.modules.localserver.auth.AuthScopes
 import me.capcom.smsgateway.modules.localserver.auth.requireScope
 import me.capcom.smsgateway.modules.localserver.domain.InboxRefreshRequest
+import me.capcom.smsgateway.modules.mms.MmsAttachmentStorage
 import me.capcom.smsgateway.modules.receiver.ReceiverService
 import java.util.Date
 
@@ -24,6 +28,7 @@ class InboxRoutes(
     private val context: Context,
     private val incomingMessagesService: IncomingMessagesService,
     private val receiverService: ReceiverService,
+    private val attachmentStorage: MmsAttachmentStorage,
     private val settings: LocalServerSettings,
 ) {
     fun register(routing: Route) {
@@ -44,6 +49,15 @@ class InboxRoutes(
                 )
                 return@get
             }
+            val includeAttachments = call.request.queryParameters["includeAttachments"]?.let {
+                it.toBooleanStrictOrNull() ?: run {
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        mapOf("message" to "includeAttachments must be true or false")
+                    )
+                    return@get
+                }
+            } ?: false
             val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: 50
             val offset = call.request.queryParameters["offset"]?.toIntOrNull() ?: 0
 
@@ -133,26 +147,34 @@ class InboxRoutes(
 
             call.response.headers.append("X-Total-Count", total.toString())
 
-            call.respond(messages.map { it.toDomain() } as GetIncomingMessagesResponse)
+            call.respond(messages.map { it.toDomain(includeAttachments) } as GetIncomingMessagesResponse)
         }
 
-//        get("{id}") {
-//            if (!requireScope(AuthScopes.InboxRead)) return@get
-//            val id = call.parameters["id"]
-//                ?: return@get call.respond(HttpStatusCode.BadRequest)
-//
-//            val message = try {
-//                incomingMessagesService.getById(id)
-//                    ?: return@get call.respond(HttpStatusCode.NotFound)
-//            } catch (e: Throwable) {
-//                return@get call.respond(
-//                    HttpStatusCode.InternalServerError,
-//                    mapOf("message" to e.message)
-//                )
-//            }
-//
-//            call.respond(message.toDomain())
-//        }
+        get("{id}/attachments/{partId}") {
+            if (!requireScope(AuthScopes.InboxRead)) return@get
+            val id = call.parameters["id"]
+                ?: return@get call.respond(HttpStatusCode.BadRequest)
+            val partId = call.parameters["partId"]?.toLongOrNull()
+                ?: return@get call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf("message" to "partId must be a number")
+                )
+
+            val attachment = attachmentStorage.find(id, partId)
+                ?: return@get call.respond(HttpStatusCode.NotFound)
+            val file = attachment.file
+            if (!file.exists()) {
+                return@get call.respond(HttpStatusCode.NotFound)
+            }
+
+            val safeName = attachment.displayName
+                .replace(Regex("[\\r\\n\"\\\\]"), "_")
+            call.response.header(
+                "Content-Disposition",
+                "attachment; filename=\"${safeName}\""
+            )
+            call.respond(LocalFileContent(file, parseContentType(attachment.contentType)))
+        }
 
         post("refresh") {
             if (!requireScope(AuthScopes.InboxRefresh)) return@post
@@ -197,9 +219,33 @@ class InboxRoutes(
         val simNumber: Int?,
         val contentPreview: String,
         val createdAt: Date,
+        val attachments: List<AttachmentRef> = emptyList(),
     )
 
-    private fun IncomingMessage.toDomain() = InboxMessage(
+    data class AttachmentRef(
+        val partId: Long,
+        val name: String,
+        val size: Long,
+        val contentType: String,
+    )
+
+    private fun listAttachmentRefs(messageId: String): List<AttachmentRef> {
+        return attachmentStorage.list(messageId).map { attachment ->
+            AttachmentRef(
+                partId = attachment.partId,
+                name = attachment.displayName,
+                size = attachment.file.length(),
+                contentType = attachment.contentType,
+            )
+        }.sortedBy { it.partId }
+    }
+
+    private fun parseContentType(raw: String): ContentType {
+        return runCatching { ContentType.parse(raw) }
+            .getOrDefault(ContentType.Application.OctetStream)
+    }
+
+    private fun IncomingMessage.toDomain(includeAttachments: Boolean = false) = InboxMessage(
         id = id,
         type = type,
         sender = sender,
@@ -207,6 +253,7 @@ class InboxRoutes(
         simNumber = simNumber,
         contentPreview = contentPreview,
         createdAt = Date(createdAt),
+        attachments = if (includeAttachments) listAttachmentRefs(id) else emptyList(),
     )
 }
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/MmsAttachmentStorage.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/MmsAttachmentStorage.kt
@@ -1,0 +1,164 @@
+package me.capcom.smsgateway.modules.mms
+
+import android.content.Context
+import com.google.gson.Gson
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import me.capcom.smsgateway.modules.logs.LogsService
+import me.capcom.smsgateway.modules.logs.db.LogEntry
+import java.io.File
+import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Persists MMS attachment bytes under the app's private files directory so
+ * they can be served back to webhook consumers and survive beyond
+ * the lifetime of the Android MMS provider entry.
+ *
+ * Layout: `<filesDir>/mms-in/<sha256(messageId)>/<partId>`
+ * Metadata: `<filesDir>/mms-in/<sha256(messageId)>/<partId>.metadata` (JSON)
+ */
+class MmsAttachmentStorage(
+    private val context: Context,
+    private val logsSvc: LogsService,
+) {
+
+    private val gson = Gson()
+
+    private val lastCleanupMs = AtomicLong(0L)
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    private val root: File
+        get() = File(context.filesDir, "mms-in").apply { mkdirs() }
+
+    fun store(
+        messageId: String,
+        partId: Long,
+        name: String?,
+        contentType: String,
+        bytes: ByteArray,
+    ): StoredAttachment {
+        val dir = messageDir(messageId).apply { mkdirs() }
+        val file = File(dir, "$partId")
+        file.writeBytes(bytes)
+        val meta = AttachmentMetadata(
+            name = name,
+            contentType = contentType.ifBlank { DEFAULT_CONTENT_TYPE },
+        )
+        metadataFile(file).writeText(gson.toJson(meta))
+        scope.launch { cleanupIfNeeded() }
+        return StoredAttachment(partId, meta.displayName, meta.contentType, file)
+    }
+
+    fun find(messageId: String, partId: Long): StoredAttachment? {
+        val dir = messageDir(messageId)
+        if (!dir.isDirectory) return null
+        val file = File(dir, "$partId")
+        if (!file.isFile) return null
+        val meta = readMetadata(file)
+        return StoredAttachment(partId, meta.displayName, meta.contentType, file)
+    }
+
+    fun list(messageId: String): List<StoredAttachment> {
+        val dir = messageDir(messageId)
+        if (!dir.isDirectory) return emptyList()
+        return dir.listFiles()
+            ?.filter { it.isFile && !it.name.endsWith(METADATA_SUFFIX) }
+            ?.mapNotNull { file ->
+                val partId = file.name.toLongOrNull() ?: return@mapNotNull null
+                val meta = readMetadata(file)
+                StoredAttachment(partId, meta.displayName, meta.contentType, file)
+            }
+            .orEmpty()
+    }
+
+    fun remove(messageId: String) {
+        val dir = messageDir(messageId)
+        if (!dir.exists()) return
+        val removed = dir.deleteRecursively()
+        check(removed) { "Failed to remove MMS attachments directory: ${dir.absolutePath}" }
+    }
+
+    fun cleanup(retentionDays: Int = 30) {
+        try {
+            val dir = root
+            if (!dir.isDirectory) return
+            val deadline = System.currentTimeMillis() - retentionDays * MILLIS_PER_DAY
+            dir.listFiles()
+                ?.filter { it.isDirectory }
+                ?.forEach { msgDir ->
+                    val mostRecent = msgDir.walkTopDown()
+                        .filter { it.isFile }
+                        .maxOfOrNull { it.lastModified() } ?: 0L
+                    if (mostRecent < deadline) {
+                        msgDir.deleteRecursively()
+                    }
+                }
+        } catch (e: Exception) {
+            logsSvc.insert(
+                priority = LogEntry.Priority.ERROR,
+                module = MODULE_NAME,
+                message = "Failed to cleanup MMS attachments: ${e.message}",
+                context = mapOf("error" to e.toString())
+            )
+        }
+    }
+
+    private fun cleanupIfNeeded() {
+        val now = System.currentTimeMillis()
+        val prev = lastCleanupMs.get()
+        if (now - prev >= CLEANUP_INTERVAL_MS) {
+            if (lastCleanupMs.compareAndSet(prev, now)) {
+                cleanup()
+            }
+        }
+    }
+
+    private fun messageDir(messageId: String): File = File(root, digest(messageId))
+
+    private fun digest(s: String): String {
+        val bytes = MessageDigest.getInstance("SHA-256")
+            .digest(s.toByteArray(Charsets.UTF_8))
+        val sb = StringBuilder(bytes.size * 2)
+        for (b in bytes) sb.append("%02x".format(b))
+        return sb.toString()
+    }
+
+    private fun readMetadata(file: File): AttachmentMetadata {
+        val metaFile = metadataFile(file)
+        if (!metaFile.isFile) return AttachmentMetadata()
+        return try {
+            gson.fromJson(metaFile.readText(), AttachmentMetadata::class.java)
+                ?: AttachmentMetadata()
+        } catch (_: Exception) {
+            AttachmentMetadata()
+        }
+    }
+
+    private fun metadataFile(file: File): File = File(file.parentFile, file.name + METADATA_SUFFIX)
+
+    private data class AttachmentMetadata(
+        val name: String? = null,
+        val contentType: String = DEFAULT_CONTENT_TYPE,
+    ) {
+        val displayName: String
+            get() = name?.takeIf { it.isNotBlank() } ?: "attachment"
+    }
+
+    data class StoredAttachment(
+        val partId: Long,
+        val displayName: String,
+        val contentType: String,
+        val file: File,
+    )
+
+    companion object {
+        private const val DEFAULT_CONTENT_TYPE = "application/octet-stream"
+        private const val METADATA_SUFFIX = ".metadata"
+        private const val CLEANUP_INTERVAL_MS = 3_600_000L
+        private const val MILLIS_PER_DAY = 86_400_000L
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/Module.kt
@@ -1,0 +1,10 @@
+package me.capcom.smsgateway.modules.mms
+
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.module
+
+val mmsModule = module {
+    singleOf(::MmsAttachmentStorage)
+}
+
+val MODULE_NAME = "mms"

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/CharacterSets.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/CharacterSets.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (C) 2007 Esmertec AG.
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+
+public class CharacterSets {
+    /**
+     * IANA assigned MIB enum numbers.
+     * <p>
+     * From wap-230-wsp-20010705-a.pdf
+     * Any-charset = <Octet 128>
+     * Equivalent to the special RFC2616 charset value "*"
+     */
+    public static final int ANY_CHARSET = 0x00;
+    public static final int US_ASCII = 0x03;
+    public static final int ISO_8859_1 = 0x04;
+    public static final int ISO_8859_2 = 0x05;
+    public static final int ISO_8859_3 = 0x06;
+    public static final int ISO_8859_4 = 0x07;
+    public static final int ISO_8859_5 = 0x08;
+    public static final int ISO_8859_6 = 0x09;
+    public static final int ISO_8859_7 = 0x0A;
+    public static final int ISO_8859_8 = 0x0B;
+    public static final int ISO_8859_9 = 0x0C;
+    public static final int SHIFT_JIS = 0x11;
+    public static final int UTF_8 = 0x6A;
+    public static final int BIG5 = 0x07EA;
+    public static final int UCS2 = 0x03E8;
+    public static final int UTF_16 = 0x03F7;
+
+    /**
+     * Extend charsets.
+     * <p>
+     * From http://www.iana.org/assignments/character-sets/
+     */
+    public static final int BIG5_HKSCS = 0x0835; //2101
+    public static final int BOCU_1 = 0x03FC; //1020
+    public static final int CESU_8 = 0x03F8; //1016
+    public static final int CP864 = 0x0803; //2051
+    public static final int EUC_JP = 0x12; //18
+    public static final int EUC_KR = 0x26; //38
+    public static final int GB18030 = 0x72; //114
+    public static final int GBK = 0x71; //113
+    public static final int HZ_GB_2312 = 0x0825; //2085
+    public static final int GB_2312 = 0x07E9; //2025
+    public static final int ISO_2022_CN = 0x68; //104
+    public static final int ISO_2022_CN_EXT = 0x69; //105
+    public static final int ISO_2022_JP = 0x27; //39
+    public static final int ISO_2022_KR = 0x25; //37
+    public static final int ISO_8859_10 = 0x0D; //13
+    public static final int ISO_8859_13 = 0x6D; //109
+    public static final int ISO_8859_14 = 0x6E; //110
+    public static final int ISO_8859_15 = 0x6F; //111
+    public static final int ISO_8859_16 = 0x70; //112
+    public static final int KOI8_R = 0x0824; //2084
+    public static final int KOI8_U = 0x0828; //2088
+    public static final int MACINTOSH = 0x07EB; //2027
+    public static final int SCSU = 0x03F3; //1011
+    public static final int TIS_620 = 0x08D3; //2259
+    public static final int UTF_16BE = 0x03F5; //1013
+    public static final int UTF_16LE = 0x03F6; //1014
+    public static final int UTF_32 = 0x03F9; //1017
+    public static final int UTF_32BE = 0x03FA; //1018
+    public static final int UTF_32LE = 0x03FB; //1019
+    public static final int UTF_7 = 0x03F4; //1012
+    public static final int WINDOWS_1250 = 0x08CA; //2250
+    public static final int WINDOWS_1251 = 0x08CB; //2251
+    public static final int WINDOWS_1252 = 0x08CC; //2252
+    public static final int WINDOWS_1253 = 0x08CD; //2253
+    public static final int WINDOWS_1254 = 0x08CE; //2254
+    public static final int WINDOWS_1255 = 0x08CF; //2255
+    public static final int WINDOWS_1256 = 0x08D0; //2256
+    public static final int WINDOWS_1257 = 0x08D1; //2257
+    public static final int WINDOWS_1258 = 0x08D2; //2258
+
+    /**
+     * If the encoding of given data is unsupported, use UTF_8 to decode it.
+     */
+    public static final int DEFAULT_CHARSET = UTF_8;
+    /**
+     * The Well-known-charset Mime name.
+     */
+    public static final String MIMENAME_ANY_CHARSET = "*";
+    public static final String MIMENAME_US_ASCII = "us-ascii";
+    public static final String MIMENAME_ISO_8859_1 = "iso-8859-1";
+    public static final String MIMENAME_ISO_8859_2 = "iso-8859-2";
+    public static final String MIMENAME_ISO_8859_3 = "iso-8859-3";
+    public static final String MIMENAME_ISO_8859_4 = "iso-8859-4";
+    public static final String MIMENAME_ISO_8859_5 = "iso-8859-5";
+    public static final String MIMENAME_ISO_8859_6 = "iso-8859-6";
+    public static final String MIMENAME_ISO_8859_7 = "iso-8859-7";
+    public static final String MIMENAME_ISO_8859_8 = "iso-8859-8";
+    public static final String MIMENAME_ISO_8859_9 = "iso-8859-9";
+    public static final String MIMENAME_SHIFT_JIS = "shift_JIS";
+    public static final String MIMENAME_UTF_8 = "utf-8";
+    public static final String MIMENAME_BIG5 = "big5";
+    public static final String MIMENAME_UCS2 = "iso-10646-ucs-2";
+    public static final String MIMENAME_UTF_16 = "utf-16";
+    /**
+     * Extend charsets.
+     * <p>
+     * From http://www.iana.org/assignments/character-sets/
+     */
+    public static final String MIMENAME_BIG5_HKSCS = "Big5-HKSCS";
+    public static final String MIMENAME_BOCU_1 = "BOCU-1";
+    public static final String MIMENAME_CESU_8 = "CESU-8";
+    public static final String MIMENAME_CP864 = "cp864";
+    public static final String MIMENAME_EUC_JP = "EUC-JP";
+    public static final String MIMENAME_EUC_KR = "EUC-KR";
+    public static final String MIMENAME_GB18030 = "GB18030";
+    public static final String MIMENAME_GBK = "GBK";
+    public static final String MIMENAME_HZ_GB_2312 = "HZ-GB-2312";
+    public static final String MIMENAME_GB_2312 = "GB2312";
+    public static final String MIMENAME_ISO_2022_CN = "ISO-2022-CN";
+    public static final String MIMENAME_ISO_2022_CN_EXT = "ISO-2022-CN-EXT";
+    public static final String MIMENAME_ISO_2022_JP = "ISO-2022-JP";
+    public static final String MIMENAME_ISO_2022_KR = "ISO-2022-KR";
+    public static final String MIMENAME_ISO_8859_10 = "ISO-8859-10";
+    public static final String MIMENAME_ISO_8859_13 = "ISO-8859-13";
+    public static final String MIMENAME_ISO_8859_14 = "ISO-8859-14";
+    public static final String MIMENAME_ISO_8859_15 = "ISO-8859-15";
+    public static final String MIMENAME_ISO_8859_16 = "ISO-8859-16";
+    public static final String MIMENAME_KOI8_R = "KOI8-R";
+    public static final String MIMENAME_KOI8_U = "KOI8-U";
+    public static final String MIMENAME_MACINTOSH = "macintosh";
+    public static final String MIMENAME_SCSU = "SCSU";
+    public static final String MIMENAME_TIS_620 = "TIS-620";
+    public static final String MIMENAME_UTF_16BE = "UTF-16BE";
+    public static final String MIMENAME_UTF_16LE = "UTF-16LE";
+    public static final String MIMENAME_UTF_32 = "UTF-32";
+    public static final String MIMENAME_UTF_32BE = "UTF-32BE";
+    public static final String MIMENAME_UTF_32LE = "UTF-32LE";
+    public static final String MIMENAME_UTF_7 = "UTF-7";
+    public static final String MIMENAME_WINDOWS_1250 = "windows-1250";
+    public static final String MIMENAME_WINDOWS_1251 = "windows-1251";
+    public static final String MIMENAME_WINDOWS_1252 = "windows-1252";
+    public static final String MIMENAME_WINDOWS_1253 = "windows-1253";
+    public static final String MIMENAME_WINDOWS_1254 = "windows-1254";
+    public static final String MIMENAME_WINDOWS_1255 = "windows-1255";
+    public static final String MIMENAME_WINDOWS_1256 = "windows-1256";
+    public static final String MIMENAME_WINDOWS_1257 = "windows-1257";
+    public static final String MIMENAME_WINDOWS_1258 = "windows-1258";
+    public static final String DEFAULT_CHARSET_NAME = MIMENAME_UTF_8;
+    /**
+     * Array of MIB enum numbers.
+     */
+    private static final int[] MIBENUM_NUMBERS = {
+            ANY_CHARSET,
+            US_ASCII,
+            ISO_8859_1,
+            ISO_8859_2,
+            ISO_8859_3,
+            ISO_8859_4,
+            ISO_8859_5,
+            ISO_8859_6,
+            ISO_8859_7,
+            ISO_8859_8,
+            ISO_8859_9,
+            SHIFT_JIS,
+            UTF_8,
+            BIG5,
+            UCS2,
+            UTF_16,
+            BIG5_HKSCS,
+            BOCU_1,
+            CESU_8,
+            CP864,
+            EUC_JP,
+            EUC_KR,
+            GB18030,
+            GBK,
+            HZ_GB_2312,
+            GB_2312,
+            ISO_2022_CN,
+            ISO_2022_CN_EXT,
+            ISO_2022_JP,
+            ISO_2022_KR,
+            ISO_8859_10,
+            ISO_8859_13,
+            ISO_8859_14,
+            ISO_8859_15,
+            ISO_8859_16,
+            KOI8_R,
+            KOI8_U,
+            MACINTOSH,
+            SCSU,
+            TIS_620,
+            UTF_16BE,
+            UTF_16LE,
+            UTF_32,
+            UTF_32BE,
+            UTF_32LE,
+            UTF_7,
+            WINDOWS_1250,
+            WINDOWS_1251,
+            WINDOWS_1252,
+            WINDOWS_1253,
+            WINDOWS_1254,
+            WINDOWS_1255,
+            WINDOWS_1256,
+            WINDOWS_1257,
+            WINDOWS_1258,
+    };
+    /**
+     * Array of the names of character sets.
+     */
+    private static final String[] MIME_NAMES = {
+            MIMENAME_ANY_CHARSET,
+            MIMENAME_US_ASCII,
+            MIMENAME_ISO_8859_1,
+            MIMENAME_ISO_8859_2,
+            MIMENAME_ISO_8859_3,
+            MIMENAME_ISO_8859_4,
+            MIMENAME_ISO_8859_5,
+            MIMENAME_ISO_8859_6,
+            MIMENAME_ISO_8859_7,
+            MIMENAME_ISO_8859_8,
+            MIMENAME_ISO_8859_9,
+            MIMENAME_SHIFT_JIS,
+            MIMENAME_UTF_8,
+            MIMENAME_BIG5,
+            MIMENAME_UCS2,
+            MIMENAME_UTF_16,
+            MIMENAME_BIG5_HKSCS,
+            MIMENAME_BOCU_1,
+            MIMENAME_CESU_8,
+            MIMENAME_CP864,
+            MIMENAME_EUC_JP,
+            MIMENAME_EUC_KR,
+            MIMENAME_GB18030,
+            MIMENAME_GBK,
+            MIMENAME_HZ_GB_2312,
+            MIMENAME_GB_2312,
+            MIMENAME_ISO_2022_CN,
+            MIMENAME_ISO_2022_CN_EXT,
+            MIMENAME_ISO_2022_JP,
+            MIMENAME_ISO_2022_KR,
+            MIMENAME_ISO_8859_10,
+            MIMENAME_ISO_8859_13,
+            MIMENAME_ISO_8859_14,
+            MIMENAME_ISO_8859_15,
+            MIMENAME_ISO_8859_16,
+            MIMENAME_KOI8_R,
+            MIMENAME_KOI8_U,
+            MIMENAME_MACINTOSH,
+            MIMENAME_SCSU,
+            MIMENAME_TIS_620,
+            MIMENAME_UTF_16BE,
+            MIMENAME_UTF_16LE,
+            MIMENAME_UTF_32,
+            MIMENAME_UTF_32BE,
+            MIMENAME_UTF_32LE,
+            MIMENAME_UTF_7,
+            MIMENAME_WINDOWS_1250,
+            MIMENAME_WINDOWS_1251,
+            MIMENAME_WINDOWS_1252,
+            MIMENAME_WINDOWS_1253,
+            MIMENAME_WINDOWS_1254,
+            MIMENAME_WINDOWS_1255,
+            MIMENAME_WINDOWS_1256,
+            MIMENAME_WINDOWS_1257,
+            MIMENAME_WINDOWS_1258,
+    };
+
+    private static final HashMap<Integer, String> MIBENUM_TO_NAME_MAP;
+    private static final HashMap<String, Integer> NAME_TO_MIBENUM_MAP;
+
+    static {
+        // Create the HashMaps.
+        MIBENUM_TO_NAME_MAP = new HashMap<Integer, String>();
+        NAME_TO_MIBENUM_MAP = new HashMap<String, Integer>();
+        assert (MIBENUM_NUMBERS.length == MIME_NAMES.length);
+        int count = MIBENUM_NUMBERS.length - 1;
+        for (int i = 0; i <= count; i++) {
+            MIBENUM_TO_NAME_MAP.put(MIBENUM_NUMBERS[i], MIME_NAMES[i]);
+            NAME_TO_MIBENUM_MAP.put(MIME_NAMES[i], MIBENUM_NUMBERS[i]);
+        }
+    }
+
+    private CharacterSets() {
+    } // Non-instantiatable
+
+    /**
+     * Map an MIBEnum number to the name of the charset which this number
+     * is assigned to by IANA.
+     *
+     * @param mibEnumValue An IANA assigned MIBEnum number.
+     * @return The name string of the charset.
+     * @throws UnsupportedEncodingException
+     */
+    public static String getMimeName(int mibEnumValue)
+            throws UnsupportedEncodingException {
+        String name = MIBENUM_TO_NAME_MAP.get(mibEnumValue);
+        if (name == null) {
+            throw new UnsupportedEncodingException();
+        }
+        return name;
+    }
+
+    /**
+     * Map a well-known charset name to its assigned MIBEnum number.
+     *
+     * @param mimeName The charset name.
+     * @return The MIBEnum number assigned by IANA for this charset.
+     * @throws UnsupportedEncodingException
+     */
+    public static int getMibEnumValue(String mimeName)
+            throws UnsupportedEncodingException {
+        if (null == mimeName) {
+            return -1;
+        }
+
+        Integer mibEnumValue = NAME_TO_MIBENUM_MAP.get(mimeName);
+        if (mibEnumValue == null) {
+            throw new UnsupportedEncodingException();
+        }
+        return mibEnumValue;
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/EncodedStringValue.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/EncodedStringValue.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (C) 2007-2008 Esmertec AG.
+ * Copyright (C) 2007-2008 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+import android.util.Log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+
+/**
+ * Encoded-string-value = Text-string | Value-length Char-set Text-string
+ */
+public class EncodedStringValue implements Cloneable {
+    private static final String TAG = "EncodedStringValue";
+    private static final boolean DEBUG = false;
+    private static final boolean LOCAL_LOGV = false;
+
+    /**
+     * The Char-set value.
+     */
+    private int mCharacterSet;
+
+    /**
+     * The Text-string value.
+     */
+    private byte[] mData;
+
+    /**
+     * Constructor.
+     *
+     * @param charset the Char-set value
+     * @param data    the Text-string value
+     * @throws NullPointerException if Text-string value is null.
+     */
+    public EncodedStringValue(int charset, byte[] data) {
+        // TODO: CharSet needs to be validated against MIBEnum.
+        if (null == data) {
+            throw new NullPointerException("EncodedStringValue: Text-string is null.");
+        }
+
+        mCharacterSet = charset;
+        mData = new byte[data.length];
+        System.arraycopy(data, 0, mData, 0, data.length);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param data the Text-string value
+     * @throws NullPointerException if Text-string value is null.
+     */
+    public EncodedStringValue(byte[] data) {
+        this(CharacterSets.DEFAULT_CHARSET, data);
+    }
+
+    public EncodedStringValue(String data) {
+        try {
+            mData = data.getBytes(CharacterSets.DEFAULT_CHARSET_NAME);
+            mCharacterSet = CharacterSets.DEFAULT_CHARSET;
+        } catch (UnsupportedEncodingException e) {
+            Log.e(TAG, "Default encoding must be supported.", e);
+        }
+    }
+
+    /**
+     * Extract an EncodedStringValue[] from a given String.
+     */
+    public static EncodedStringValue[] extract(String src) {
+        String[] values = src.split(";");
+
+        ArrayList<EncodedStringValue> list = new ArrayList<EncodedStringValue>();
+        for (int i = 0; i < values.length; i++) {
+            if (values[i].length() > 0) {
+                list.add(new EncodedStringValue(values[i]));
+            }
+        }
+
+        int len = list.size();
+        if (len > 0) {
+            return list.toArray(new EncodedStringValue[len]);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Concatenate an EncodedStringValue[] into a single String.
+     */
+    public static String concat(EncodedStringValue[] addr) {
+        StringBuilder sb = new StringBuilder();
+        int maxIndex = addr.length - 1;
+        for (int i = 0; i <= maxIndex; i++) {
+            sb.append(addr[i].getString());
+            if (i < maxIndex) {
+                sb.append(";");
+            }
+        }
+
+        return sb.toString();
+    }
+
+    public static EncodedStringValue copy(EncodedStringValue value) {
+        if (value == null) {
+            return null;
+        }
+
+        return new EncodedStringValue(value.mCharacterSet, value.mData);
+    }
+
+    public static EncodedStringValue[] encodeStrings(String[] array) {
+        int count = array.length;
+        if (count > 0) {
+            EncodedStringValue[] encodedArray = new EncodedStringValue[count];
+            for (int i = 0; i < count; i++) {
+                encodedArray[i] = new EncodedStringValue(array[i]);
+            }
+            return encodedArray;
+        }
+        return null;
+    }
+
+    /**
+     * Get Char-set value.
+     *
+     * @return the value
+     */
+    public int getCharacterSet() {
+        return mCharacterSet;
+    }
+
+    /**
+     * Set Char-set value.
+     *
+     * @param charset the Char-set value
+     */
+    public void setCharacterSet(int charset) {
+        // TODO: CharSet needs to be validated against MIBEnum.
+        mCharacterSet = charset;
+    }
+
+    /**
+     * Get Text-string value.
+     *
+     * @return the value
+     */
+    public byte[] getTextString() {
+        byte[] byteArray = new byte[mData.length];
+
+        System.arraycopy(mData, 0, byteArray, 0, mData.length);
+        return byteArray;
+    }
+
+    /**
+     * Set Text-string value.
+     *
+     * @param textString the Text-string value
+     * @throws NullPointerException if Text-string value is null.
+     */
+    public void setTextString(byte[] textString) {
+        if (null == textString) {
+            throw new NullPointerException("EncodedStringValue: Text-string is null.");
+        }
+
+        mData = new byte[textString.length];
+        System.arraycopy(textString, 0, mData, 0, textString.length);
+    }
+
+    /**
+     * Convert this object to a {@link java.lang.String}. If the encoding of
+     * the EncodedStringValue is null or unsupported, it will be
+     * treated as iso-8859-1 encoding.
+     *
+     * @return The decoded String.
+     */
+    public String getString() {
+        if (CharacterSets.ANY_CHARSET == mCharacterSet) {
+            return new String(mData); // system default encoding.
+        } else {
+            try {
+                String name = CharacterSets.getMimeName(mCharacterSet);
+                return new String(mData, name);
+            } catch (UnsupportedEncodingException e) {
+                if (LOCAL_LOGV) {
+                    Log.v(TAG, e.getMessage(), e);
+                }
+                try {
+                    return new String(mData, CharacterSets.MIMENAME_ISO_8859_1);
+                } catch (UnsupportedEncodingException e2) {
+                    return new String(mData); // system default encoding.
+                }
+            }
+        }
+    }
+
+    /**
+     * Append to Text-string.
+     *
+     * @param textString the textString to append
+     * @throws NullPointerException if the text String is null
+     *                              or an IOException occurred.
+     */
+    public void appendTextString(byte[] textString) {
+        if (null == textString) {
+            throw new NullPointerException("Text-string is null.");
+        }
+
+        if (null == mData) {
+            mData = new byte[textString.length];
+            System.arraycopy(textString, 0, mData, 0, textString.length);
+        } else {
+            ByteArrayOutputStream newTextString = new ByteArrayOutputStream();
+            try {
+                newTextString.write(mData);
+                newTextString.write(textString);
+            } catch (IOException e) {
+                e.printStackTrace();
+                throw new NullPointerException(
+                        "appendTextString: failed when write a new Text-string");
+            }
+
+            mData = newTextString.toByteArray();
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        int len = mData.length;
+        byte[] dstBytes = new byte[len];
+        System.arraycopy(mData, 0, dstBytes, 0, len);
+
+        try {
+            return new EncodedStringValue(mCharacterSet, dstBytes);
+        } catch (Exception e) {
+            Log.e(TAG, "failed to clone an EncodedStringValue: " + this);
+            e.printStackTrace();
+            throw new CloneNotSupportedException(e.getMessage());
+        }
+    }
+
+    /**
+     * Split this encoded string around matches of the given pattern.
+     *
+     * @param pattern the delimiting pattern
+     * @return the array of encoded strings computed by splitting this encoded
+     * string around matches of the given pattern
+     */
+    public EncodedStringValue[] split(String pattern) {
+        String[] temp = getString().split(pattern);
+        EncodedStringValue[] ret = new EncodedStringValue[temp.length];
+        for (int i = 0; i < ret.length; ++i) {
+            try {
+                ret[i] = new EncodedStringValue(mCharacterSet,
+                        temp[i].getBytes());
+            } catch (NullPointerException e) {
+                // Can't arrive here
+                return null;
+            }
+        }
+        return ret;
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/GenericPdu.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/GenericPdu.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2007 Esmertec AG.
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+public class GenericPdu {
+    /**
+     * The headers of pdu.
+     */
+    PduHeaders mPduHeaders = null;
+
+    /**
+     * Constructor.
+     */
+    public GenericPdu() {
+        mPduHeaders = new PduHeaders();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param headers Headers for this PDU.
+     */
+    GenericPdu(PduHeaders headers) {
+        mPduHeaders = headers;
+    }
+
+    /**
+     * Get the headers of this PDU.
+     *
+     * @return A PduHeaders of this PDU.
+     */
+    PduHeaders getPduHeaders() {
+        return mPduHeaders;
+    }
+
+    /**
+     * Get X-Mms-Message-Type field value.
+     *
+     * @return the X-Mms-Report-Allowed value
+     */
+    public int getMessageType() {
+        return mPduHeaders.getOctet(PduHeaders.MESSAGE_TYPE);
+    }
+
+    /**
+     * Set X-Mms-Message-Type field value.
+     *
+     * @param value the value
+     * @throws InvalidHeaderValueException if the value is invalid.
+     *                                     RuntimeException if field's value is not Octet.
+     */
+    public void setMessageType(int value) throws InvalidHeaderValueException {
+        mPduHeaders.setOctet(value, PduHeaders.MESSAGE_TYPE);
+    }
+
+    /**
+     * Get X-Mms-MMS-Version field value.
+     *
+     * @return the X-Mms-MMS-Version value
+     */
+    public int getMmsVersion() {
+        return mPduHeaders.getOctet(PduHeaders.MMS_VERSION);
+    }
+
+    /**
+     * Set X-Mms-MMS-Version field value.
+     *
+     * @param value the value
+     * @throws InvalidHeaderValueException if the value is invalid.
+     *                                     RuntimeException if field's value is not Octet.
+     */
+    public void setMmsVersion(int value) throws InvalidHeaderValueException {
+        mPduHeaders.setOctet(value, PduHeaders.MMS_VERSION);
+    }
+
+    /**
+     * Get From value.
+     * From-value = Value-length
+     * (Address-present-token Encoded-string-value | Insert-address-token)
+     *
+     * @return the value
+     */
+    public EncodedStringValue getFrom() {
+        return mPduHeaders.getEncodedStringValue(PduHeaders.FROM);
+    }
+
+    /**
+     * Set From value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+    public void setFrom(EncodedStringValue value) {
+        mPduHeaders.setEncodedStringValue(value, PduHeaders.FROM);
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/InvalidHeaderValueException.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/InvalidHeaderValueException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2007 Esmertec AG.
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+/**
+ * Thrown when an invalid header value was set.
+ */
+public class InvalidHeaderValueException extends MmsException {
+    private static final long serialVersionUID = -2053384496042052262L;
+
+    /**
+     * Constructs an InvalidHeaderValueException with no detailed message.
+     */
+    public InvalidHeaderValueException() {
+        super();
+    }
+
+    /**
+     * Constructs an InvalidHeaderValueException with the specified detailed message.
+     *
+     * @param message the detailed message.
+     */
+    public InvalidHeaderValueException(String message) {
+        super(message);
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/MmsException.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/MmsException.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2007 Esmertec AG.
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+/**
+ * A generic exception that is thrown by the Mms client.
+ */
+public class MmsException extends Exception {
+    private static final long serialVersionUID = -7323249827281485390L;
+
+    /**
+     * Creates a new MmsException.
+     */
+    public MmsException() {
+        super();
+    }
+
+    /**
+     * Creates a new MmsException with the specified detail message.
+     *
+     * @param message the detail message.
+     */
+    public MmsException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new MmsException with the specified cause.
+     *
+     * @param cause the cause.
+     */
+    public MmsException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new MmsException with the specified detail message and cause.
+     *
+     * @param message the detail message.
+     * @param cause the cause.
+     */
+    public MmsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/MultimediaMessagePdu.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/MultimediaMessagePdu.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2007 Esmertec AG.
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+/**
+ * Multimedia message PDU.
+ */
+public class MultimediaMessagePdu extends GenericPdu {
+    /**
+     * The body.
+     */
+    private PduBody mMessageBody;
+
+    /**
+     * Constructor.
+     */
+    public MultimediaMessagePdu() {
+        super();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param header the header of this PDU
+     * @param body   the body of this PDU
+     */
+    public MultimediaMessagePdu(PduHeaders header, PduBody body) {
+        super(header);
+        mMessageBody = body;
+    }
+
+    /**
+     * Constructor with given headers.
+     *
+     * @param headers Headers for this PDU.
+     */
+    MultimediaMessagePdu(PduHeaders headers) {
+        super(headers);
+    }
+
+    /**
+     * Get body of the PDU.
+     *
+     * @return the body
+     */
+    public PduBody getBody() {
+        return mMessageBody;
+    }
+
+    /**
+     * Set body of the PDU.
+     *
+     * @param body the body
+     */
+    public void setBody(PduBody body) {
+        mMessageBody = body;
+    }
+
+    /**
+     * Get subject.
+     *
+     * @return the value
+     */
+    public EncodedStringValue getSubject() {
+        return mPduHeaders.getEncodedStringValue(PduHeaders.SUBJECT);
+    }
+
+    /**
+     * Set subject.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+    public void setSubject(EncodedStringValue value) {
+        mPduHeaders.setEncodedStringValue(value, PduHeaders.SUBJECT);
+    }
+
+    /**
+     * Get To value.
+     *
+     * @return the value
+     */
+    public EncodedStringValue[] getTo() {
+        return mPduHeaders.getEncodedStringValues(PduHeaders.TO);
+    }
+
+    /**
+     * Add a "To" value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+    public void addTo(EncodedStringValue value) {
+        mPduHeaders.appendEncodedStringValue(value, PduHeaders.TO);
+    }
+
+    /**
+     * Get X-Mms-Priority value.
+     *
+     * @return the value
+     */
+    public int getPriority() {
+        return mPduHeaders.getOctet(PduHeaders.PRIORITY);
+    }
+
+    /**
+     * Set X-Mms-Priority value.
+     *
+     * @param value the value
+     * @throws InvalidHeaderValueException if the value is invalid.
+     */
+    public void setPriority(int value) throws InvalidHeaderValueException {
+        mPduHeaders.setOctet(value, PduHeaders.PRIORITY);
+    }
+
+    /**
+     * Get Date value.
+     *
+     * @return the value
+     */
+    public long getDate() {
+        return mPduHeaders.getLongInteger(PduHeaders.DATE);
+    }
+
+    /**
+     * Set Date value in seconds.
+     *
+     * @param value the value
+     */
+    public void setDate(long value) {
+        mPduHeaders.setLongInteger(value, PduHeaders.DATE);
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/PduBody.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/PduBody.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2007 Esmertec AG.
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Vector;
+
+public class PduBody {
+    private Vector<PduPart> mParts = null;
+
+    private Map<String, PduPart> mPartMapByContentId = null;
+    private Map<String, PduPart> mPartMapByContentLocation = null;
+    private Map<String, PduPart> mPartMapByName = null;
+    private Map<String, PduPart> mPartMapByFileName = null;
+
+    /**
+     * Constructor.
+     */
+    public PduBody() {
+        mParts = new Vector<PduPart>();
+
+        mPartMapByContentId = new HashMap<String, PduPart>();
+        mPartMapByContentLocation = new HashMap<String, PduPart>();
+        mPartMapByName = new HashMap<String, PduPart>();
+        mPartMapByFileName = new HashMap<String, PduPart>();
+    }
+
+    private void putPartToMaps(PduPart part) {
+        // Put part to mPartMapByContentId.
+        byte[] contentId = part.getContentId();
+        if (null != contentId) {
+            mPartMapByContentId.put(new String(contentId), part);
+        }
+
+        // Put part to mPartMapByContentLocation.
+        byte[] contentLocation = part.getContentLocation();
+        if (null != contentLocation) {
+            String clc = new String(contentLocation);
+            mPartMapByContentLocation.put(clc, part);
+        }
+
+        // Put part to mPartMapByName.
+        byte[] name = part.getName();
+        if (null != name) {
+            String clc = new String(name);
+            mPartMapByName.put(clc, part);
+        }
+
+        // Put part to mPartMapByFileName.
+        byte[] fileName = part.getFilename();
+        if (null != fileName) {
+            String clc = new String(fileName);
+            mPartMapByFileName.put(clc, part);
+        }
+    }
+
+    /**
+     * Appends the specified part to the end of this body.
+     *
+     * @param part part to be appended
+     * @return true when success, false when fail
+     * @throws NullPointerException when part is null
+     */
+    public boolean addPart(PduPart part) {
+        if (null == part) {
+            throw new NullPointerException();
+        }
+
+        putPartToMaps(part);
+        return mParts.add(part);
+    }
+
+    /**
+     * Inserts the specified part at the specified position.
+     *
+     * @param index index at which the specified part is to be inserted
+     * @param part  part to be inserted
+     * @throws NullPointerException when part is null
+     */
+    public void addPart(int index, PduPart part) {
+        if (null == part) {
+            throw new NullPointerException();
+        }
+
+        putPartToMaps(part);
+        mParts.add(index, part);
+    }
+
+    /**
+     * Removes the part at the specified position.
+     *
+     * @param index index of the part to return
+     * @return part at the specified index
+     */
+    public PduPart removePart(int index) {
+        return mParts.remove(index);
+    }
+
+    /**
+     * Remove all of the parts.
+     */
+    public void removeAll() {
+        mParts.clear();
+    }
+
+    /**
+     * Get the part at the specified position.
+     *
+     * @param index index of the part to return
+     * @return part at the specified index
+     */
+    public PduPart getPart(int index) {
+        return mParts.get(index);
+    }
+
+    /**
+     * Get the index of the specified part.
+     *
+     * @param part the part object
+     * @return index the index of the first occurrence of the part in this body
+     */
+    public int getPartIndex(PduPart part) {
+        return mParts.indexOf(part);
+    }
+
+    /**
+     * Get the number of parts.
+     *
+     * @return the number of parts
+     */
+    public int getPartsNum() {
+        return mParts.size();
+    }
+
+    /**
+     * Get pdu part by content id.
+     *
+     * @param cid the value of content id.
+     * @return the pdu part.
+     */
+    public PduPart getPartByContentId(String cid) {
+        return mPartMapByContentId.get(cid);
+    }
+
+    /**
+     * Get pdu part by Content-Location. Content-Location of part is
+     * the same as filename and name(param of content-type).
+     *
+     * @param fileName the value of filename.
+     * @return the pdu part.
+     */
+    public PduPart getPartByContentLocation(String fileName) {
+        return mPartMapByContentLocation.get(fileName);
+    }
+
+    /**
+     * Get pdu part by name.
+     *
+     * @param fileName the value of filename.
+     * @return the pdu part.
+     */
+    public PduPart getPartByName(String fileName) {
+        return mPartMapByName.get(fileName);
+    }
+
+    /**
+     * Get pdu part by filename.
+     *
+     * @param fileName the value of filename.
+     * @return the pdu part.
+     */
+    public PduPart getPartByFileName(String fileName) {
+        return mPartMapByFileName.get(fileName);
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/PduContentTypes.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/PduContentTypes.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2007 Esmertec AG.
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+public class PduContentTypes {
+    /**
+     * All content types. From:
+     * http://www.openmobilealliance.org/tech/omna/omna-wsp-content-type.htm
+     */
+    static final String[] contentTypes = {
+            "*/*",                                        /* 0x00 */
+            "text/*",                                     /* 0x01 */
+            "text/html",                                  /* 0x02 */
+            "text/plain",                                 /* 0x03 */
+            "text/x-hdml",                                /* 0x04 */
+            "text/x-ttml",                                /* 0x05 */
+            "text/x-vCalendar",                           /* 0x06 */
+            "text/x-vCard",                               /* 0x07 */
+            "text/vnd.wap.wml",                           /* 0x08 */
+            "text/vnd.wap.wmlscript",                     /* 0x09 */
+            "text/vnd.wap.wta-event",                     /* 0x0A */
+            "multipart/*",                                /* 0x0B */
+            "multipart/mixed",                            /* 0x0C */
+            "multipart/form-data",                        /* 0x0D */
+            "multipart/byterantes",                       /* 0x0E */
+            "multipart/alternative",                      /* 0x0F */
+            "application/*",                              /* 0x10 */
+            "application/java-vm",                        /* 0x11 */
+            "application/x-www-form-urlencoded",          /* 0x12 */
+            "application/x-hdmlc",                        /* 0x13 */
+            "application/vnd.wap.wmlc",                   /* 0x14 */
+            "application/vnd.wap.wmlscriptc",             /* 0x15 */
+            "application/vnd.wap.wta-eventc",             /* 0x16 */
+            "application/vnd.wap.uaprof",                 /* 0x17 */
+            "application/vnd.wap.wtls-ca-certificate",    /* 0x18 */
+            "application/vnd.wap.wtls-user-certificate",  /* 0x19 */
+            "application/x-x509-ca-cert",                 /* 0x1A */
+            "application/x-x509-user-cert",               /* 0x1B */
+            "image/*",                                    /* 0x1C */
+            "image/gif",                                  /* 0x1D */
+            "image/jpeg",                                 /* 0x1E */
+            "image/tiff",                                 /* 0x1F */
+            "image/png",                                  /* 0x20 */
+            "image/vnd.wap.wbmp",                         /* 0x21 */
+            "application/vnd.wap.multipart.*",            /* 0x22 */
+            "application/vnd.wap.multipart.mixed",        /* 0x23 */
+            "application/vnd.wap.multipart.form-data",    /* 0x24 */
+            "application/vnd.wap.multipart.byteranges",   /* 0x25 */
+            "application/vnd.wap.multipart.alternative",  /* 0x26 */
+            "application/xml",                            /* 0x27 */
+            "text/xml",                                   /* 0x28 */
+            "application/vnd.wap.wbxml",                  /* 0x29 */
+            "application/x-x968-cross-cert",              /* 0x2A */
+            "application/x-x968-ca-cert",                 /* 0x2B */
+            "application/x-x968-user-cert",               /* 0x2C */
+            "text/vnd.wap.si",                            /* 0x2D */
+            "application/vnd.wap.sic",                    /* 0x2E */
+            "text/vnd.wap.sl",                            /* 0x2F */
+            "application/vnd.wap.slc",                    /* 0x30 */
+            "text/vnd.wap.co",                            /* 0x31 */
+            "application/vnd.wap.coc",                    /* 0x32 */
+            "application/vnd.wap.multipart.related",      /* 0x33 */
+            "application/vnd.wap.sia",                    /* 0x34 */
+            "text/vnd.wap.connectivity-xml",              /* 0x35 */
+            "application/vnd.wap.connectivity-wbxml",     /* 0x36 */
+            "application/pkcs7-mime",                     /* 0x37 */
+            "application/vnd.wap.hashed-certificate",     /* 0x38 */
+            "application/vnd.wap.signed-certificate",     /* 0x39 */
+            "application/vnd.wap.cert-response",          /* 0x3A */
+            "application/xhtml+xml",                      /* 0x3B */
+            "application/wml+xml",                        /* 0x3C */
+            "text/css",                                   /* 0x3D */
+            "application/vnd.wap.mms-message",            /* 0x3E */
+            "application/vnd.wap.rollover-certificate",   /* 0x3F */
+            "application/vnd.wap.locc+wbxml",             /* 0x40 */
+            "application/vnd.wap.loc+xml",                /* 0x41 */
+            "application/vnd.syncml.dm+wbxml",            /* 0x42 */
+            "application/vnd.syncml.dm+xml",              /* 0x43 */
+            "application/vnd.syncml.notification",        /* 0x44 */
+            "application/vnd.wap.xhtml+xml",              /* 0x45 */
+            "application/vnd.wv.csp.cir",                 /* 0x46 */
+            "application/vnd.oma.dd+xml",                 /* 0x47 */
+            "application/vnd.oma.drm.message",            /* 0x48 */
+            "application/vnd.oma.drm.content",            /* 0x49 */
+            "application/vnd.oma.drm.rights+xml",         /* 0x4A */
+            "application/vnd.oma.drm.rights+wbxml",       /* 0x4B */
+            "application/vnd.wv.csp+xml",                 /* 0x4C */
+            "application/vnd.wv.csp+wbxml",               /* 0x4D */
+            "application/vnd.syncml.ds.notification",     /* 0x4E */
+            "audio/*",                                    /* 0x4F */
+            "video/*",                                    /* 0x50 */
+            "application/vnd.oma.dd2+xml",                /* 0x51 */
+            "application/mikey"                           /* 0x52 */
+    };
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/PduHeaders.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/PduHeaders.java
@@ -1,0 +1,721 @@
+/*
+ * Copyright (C) 2007 Esmertec AG.
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+import me.capcom.smsgateway.modules.mms.pdu.aosp.InvalidHeaderValueException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class PduHeaders {
+    /**
+     * All pdu header fields.
+     */
+    public static final int BCC                             = 0x81;
+    public static final int CC                              = 0x82;
+    public static final int CONTENT_LOCATION                = 0x83;
+    public static final int CONTENT_TYPE                    = 0x84;
+    public static final int DATE                            = 0x85;
+    public static final int DELIVERY_REPORT                 = 0x86;
+    public static final int DELIVERY_TIME                   = 0x87;
+    public static final int EXPIRY                          = 0x88;
+    public static final int FROM                            = 0x89;
+    public static final int MESSAGE_CLASS                   = 0x8A;
+    public static final int MESSAGE_ID                      = 0x8B;
+    public static final int MESSAGE_TYPE                    = 0x8C;
+    public static final int MMS_VERSION                     = 0x8D;
+    public static final int MESSAGE_SIZE                    = 0x8E;
+    public static final int PRIORITY                        = 0x8F;
+
+    public static final int READ_REPLY                      = 0x90;
+    public static final int READ_REPORT                     = 0x90;
+    public static final int REPORT_ALLOWED                  = 0x91;
+    public static final int RESPONSE_STATUS                 = 0x92;
+    public static final int RESPONSE_TEXT                   = 0x93;
+    public static final int SENDER_VISIBILITY               = 0x94;
+    public static final int STATUS                          = 0x95;
+    public static final int SUBJECT                         = 0x96;
+    public static final int TO                              = 0x97;
+    public static final int TRANSACTION_ID                  = 0x98;
+    public static final int RETRIEVE_STATUS                 = 0x99;
+    public static final int RETRIEVE_TEXT                   = 0x9A;
+    public static final int READ_STATUS                     = 0x9B;
+    public static final int REPLY_CHARGING                  = 0x9C;
+    public static final int REPLY_CHARGING_DEADLINE         = 0x9D;
+    public static final int REPLY_CHARGING_ID               = 0x9E;
+    public static final int REPLY_CHARGING_SIZE             = 0x9F;
+
+    public static final int PREVIOUSLY_SENT_BY              = 0xA0;
+    public static final int PREVIOUSLY_SENT_DATE            = 0xA1;
+    public static final int STORE                           = 0xA2;
+    public static final int MM_STATE                        = 0xA3;
+    public static final int MM_FLAGS                        = 0xA4;
+    public static final int STORE_STATUS                    = 0xA5;
+    public static final int STORE_STATUS_TEXT               = 0xA6;
+    public static final int STORED                          = 0xA7;
+    public static final int ATTRIBUTES                      = 0xA8;
+    public static final int TOTALS                          = 0xA9;
+    public static final int MBOX_TOTALS                     = 0xAA;
+    public static final int QUOTAS                          = 0xAB;
+    public static final int MBOX_QUOTAS                     = 0xAC;
+    public static final int MESSAGE_COUNT                   = 0xAD;
+    public static final int CONTENT                         = 0xAE;
+    public static final int START                           = 0xAF;
+
+    public static final int ADDITIONAL_HEADERS              = 0xB0;
+    public static final int DISTRIBUTION_INDICATOR          = 0xB1;
+    public static final int ELEMENT_DESCRIPTOR              = 0xB2;
+    public static final int LIMIT                           = 0xB3;
+    public static final int RECOMMENDED_RETRIEVAL_MODE      = 0xB4;
+    public static final int RECOMMENDED_RETRIEVAL_MODE_TEXT = 0xB5;
+    public static final int STATUS_TEXT                     = 0xB6;
+    public static final int APPLIC_ID                       = 0xB7;
+    public static final int REPLY_APPLIC_ID                 = 0xB8;
+    public static final int AUX_APPLIC_ID                   = 0xB9;
+    public static final int CONTENT_CLASS                   = 0xBA;
+    public static final int DRM_CONTENT                     = 0xBB;
+    public static final int ADAPTATION_ALLOWED              = 0xBC;
+    public static final int REPLACE_ID                      = 0xBD;
+    public static final int CANCEL_ID                       = 0xBE;
+    public static final int CANCEL_STATUS                   = 0xBF;
+
+    /**
+     * X-Mms-Message-Type field types.
+     */
+    public static final int MESSAGE_TYPE_SEND_REQ           = 0x80;
+    public static final int MESSAGE_TYPE_SEND_CONF          = 0x81;
+    public static final int MESSAGE_TYPE_NOTIFICATION_IND   = 0x82;
+    public static final int MESSAGE_TYPE_NOTIFYRESP_IND     = 0x83;
+    public static final int MESSAGE_TYPE_RETRIEVE_CONF      = 0x84;
+    public static final int MESSAGE_TYPE_ACKNOWLEDGE_IND    = 0x85;
+    public static final int MESSAGE_TYPE_DELIVERY_IND       = 0x86;
+    public static final int MESSAGE_TYPE_READ_REC_IND       = 0x87;
+    public static final int MESSAGE_TYPE_READ_ORIG_IND      = 0x88;
+    public static final int MESSAGE_TYPE_FORWARD_REQ        = 0x89;
+    public static final int MESSAGE_TYPE_FORWARD_CONF       = 0x8A;
+    public static final int MESSAGE_TYPE_MBOX_STORE_REQ     = 0x8B;
+    public static final int MESSAGE_TYPE_MBOX_STORE_CONF    = 0x8C;
+    public static final int MESSAGE_TYPE_MBOX_VIEW_REQ      = 0x8D;
+    public static final int MESSAGE_TYPE_MBOX_VIEW_CONF     = 0x8E;
+    public static final int MESSAGE_TYPE_MBOX_UPLOAD_REQ    = 0x8F;
+    public static final int MESSAGE_TYPE_MBOX_UPLOAD_CONF   = 0x90;
+    public static final int MESSAGE_TYPE_MBOX_DELETE_REQ    = 0x91;
+    public static final int MESSAGE_TYPE_MBOX_DELETE_CONF   = 0x92;
+    public static final int MESSAGE_TYPE_MBOX_DESCR         = 0x93;
+    public static final int MESSAGE_TYPE_DELETE_REQ         = 0x94;
+    public static final int MESSAGE_TYPE_DELETE_CONF        = 0x95;
+    public static final int MESSAGE_TYPE_CANCEL_REQ         = 0x96;
+    public static final int MESSAGE_TYPE_CANCEL_CONF        = 0x97;
+
+    /**
+     *  X-Mms-Delivery-Report |
+     *  X-Mms-Read-Report |
+     *  X-Mms-Report-Allowed |
+     *  X-Mms-Sender-Visibility |
+     *  X-Mms-Store |
+     *  X-Mms-Stored |
+     *  X-Mms-Totals |
+     *  X-Mms-Quotas |
+     *  X-Mms-Distribution-Indicator |
+     *  X-Mms-DRM-Content |
+     *  X-Mms-Adaptation-Allowed |
+     *  field types.
+     */
+    public static final int VALUE_YES                       = 0x80;
+    public static final int VALUE_NO                        = 0x81;
+
+    /**
+     *  Delivery-Time |
+     *  Expiry and Reply-Charging-Deadline |
+     *  field type components.
+     */
+    public static final int VALUE_ABSOLUTE_TOKEN            = 0x80;
+    public static final int VALUE_RELATIVE_TOKEN            = 0x81;
+
+    /**
+     * X-Mms-MMS-Version field types.
+     */
+    public static final int MMS_VERSION_1_3                 = ((1 << 4) | 3);
+    public static final int MMS_VERSION_1_2                 = ((1 << 4) | 2);
+    public static final int MMS_VERSION_1_1                 = ((1 << 4) | 1);
+    public static final int MMS_VERSION_1_0                 = ((1 << 4) | 0);
+
+    // Current version is 1.2.
+    public static final int CURRENT_MMS_VERSION             = MMS_VERSION_1_2;
+
+    /**
+     *  From field type components.
+     */
+    public static final int FROM_ADDRESS_PRESENT_TOKEN      = 0x80;
+    public static final int FROM_INSERT_ADDRESS_TOKEN       = 0x81;
+
+    public static final String FROM_ADDRESS_PRESENT_TOKEN_STR = "address-present-token";
+    public static final String FROM_INSERT_ADDRESS_TOKEN_STR = "insert-address-token";
+
+    /**
+     *  X-Mms-Status Field.
+     */
+    public static final int STATUS_EXPIRED                  = 0x80;
+    public static final int STATUS_RETRIEVED                = 0x81;
+    public static final int STATUS_REJECTED                 = 0x82;
+    public static final int STATUS_DEFERRED                 = 0x83;
+    public static final int STATUS_UNRECOGNIZED             = 0x84;
+    public static final int STATUS_INDETERMINATE            = 0x85;
+    public static final int STATUS_FORWARDED                = 0x86;
+    public static final int STATUS_UNREACHABLE              = 0x87;
+
+    /**
+     *  MM-Flags field type components.
+     */
+    public static final int MM_FLAGS_ADD_TOKEN              = 0x80;
+    public static final int MM_FLAGS_REMOVE_TOKEN           = 0x81;
+    public static final int MM_FLAGS_FILTER_TOKEN           = 0x82;
+
+    /**
+     *  X-Mms-Message-Class field types.
+     */
+    public static final int MESSAGE_CLASS_PERSONAL          = 0x80;
+    public static final int MESSAGE_CLASS_ADVERTISEMENT     = 0x81;
+    public static final int MESSAGE_CLASS_INFORMATIONAL     = 0x82;
+    public static final int MESSAGE_CLASS_AUTO              = 0x83;
+
+    public static final String MESSAGE_CLASS_PERSONAL_STR = "personal";
+    public static final String MESSAGE_CLASS_ADVERTISEMENT_STR = "advertisement";
+    public static final String MESSAGE_CLASS_INFORMATIONAL_STR = "informational";
+    public static final String MESSAGE_CLASS_AUTO_STR = "auto";
+
+    /**
+     *  X-Mms-Priority field types.
+     */
+    public static final int PRIORITY_LOW                    = 0x80;
+    public static final int PRIORITY_NORMAL                 = 0x81;
+    public static final int PRIORITY_HIGH                   = 0x82;
+
+    /**
+     *  X-Mms-Response-Status field types.
+     */
+    public static final int RESPONSE_STATUS_OK                   = 0x80;
+    public static final int RESPONSE_STATUS_ERROR_UNSPECIFIED    = 0x81;
+    public static final int RESPONSE_STATUS_ERROR_SERVICE_DENIED = 0x82;
+
+    public static final int RESPONSE_STATUS_ERROR_MESSAGE_FORMAT_CORRUPT     = 0x83;
+    public static final int RESPONSE_STATUS_ERROR_SENDING_ADDRESS_UNRESOLVED = 0x84;
+
+    public static final int RESPONSE_STATUS_ERROR_MESSAGE_NOT_FOUND    = 0x85;
+    public static final int RESPONSE_STATUS_ERROR_NETWORK_PROBLEM      = 0x86;
+    public static final int RESPONSE_STATUS_ERROR_CONTENT_NOT_ACCEPTED = 0x87;
+    public static final int RESPONSE_STATUS_ERROR_UNSUPPORTED_MESSAGE  = 0x88;
+    public static final int RESPONSE_STATUS_ERROR_TRANSIENT_FAILURE    = 0xC0;
+
+    public static final int RESPONSE_STATUS_ERROR_TRANSIENT_SENDNG_ADDRESS_UNRESOLVED = 0xC1;
+    public static final int RESPONSE_STATUS_ERROR_TRANSIENT_MESSAGE_NOT_FOUND         = 0xC2;
+    public static final int RESPONSE_STATUS_ERROR_TRANSIENT_NETWORK_PROBLEM           = 0xC3;
+    public static final int RESPONSE_STATUS_ERROR_TRANSIENT_PARTIAL_SUCCESS           = 0xC4;
+
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_FAILURE                             = 0xE0;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_SERVICE_DENIED                      = 0xE1;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_MESSAGE_FORMAT_CORRUPT              = 0xE2;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_SENDING_ADDRESS_UNRESOLVED          = 0xE3;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_MESSAGE_NOT_FOUND                   = 0xE4;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_CONTENT_NOT_ACCEPTED                = 0xE5;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_REPLY_CHARGING_LIMITATIONS_NOT_MET  = 0xE6;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_REPLY_CHARGING_REQUEST_NOT_ACCEPTED = 0xE6;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_REPLY_CHARGING_FORWARDING_DENIED    = 0xE8;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_REPLY_CHARGING_NOT_SUPPORTED        = 0xE9;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_ADDRESS_HIDING_NOT_SUPPORTED        = 0xEA;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_LACK_OF_PREPAID                     = 0xEB;
+    public static final int RESPONSE_STATUS_ERROR_PERMANENT_END                                 = 0xFF;
+
+    /**
+     *  X-Mms-Retrieve-Status field types.
+     */
+    public static final int RETRIEVE_STATUS_OK                                  = 0x80;
+    public static final int RETRIEVE_STATUS_ERROR_TRANSIENT_FAILURE             = 0xC0;
+    public static final int RETRIEVE_STATUS_ERROR_TRANSIENT_MESSAGE_NOT_FOUND   = 0xC1;
+    public static final int RETRIEVE_STATUS_ERROR_TRANSIENT_NETWORK_PROBLEM     = 0xC2;
+    public static final int RETRIEVE_STATUS_ERROR_PERMANENT_FAILURE             = 0xE0;
+    public static final int RETRIEVE_STATUS_ERROR_PERMANENT_SERVICE_DENIED      = 0xE1;
+    public static final int RETRIEVE_STATUS_ERROR_PERMANENT_MESSAGE_NOT_FOUND   = 0xE2;
+    public static final int RETRIEVE_STATUS_ERROR_PERMANENT_CONTENT_UNSUPPORTED = 0xE3;
+    public static final int RETRIEVE_STATUS_ERROR_END                           = 0xFF;
+
+    /**
+     *  X-Mms-Sender-Visibility field types.
+     */
+    public static final int SENDER_VISIBILITY_HIDE          = 0x80;
+    public static final int SENDER_VISIBILITY_SHOW          = 0x81;
+
+    /**
+     *  X-Mms-Read-Status field types.
+     */
+    public static final int READ_STATUS_READ                        = 0x80;
+    public static final int READ_STATUS__DELETED_WITHOUT_BEING_READ = 0x81;
+
+    /**
+     *  X-Mms-Cancel-Status field types.
+     */
+    public static final int CANCEL_STATUS_REQUEST_SUCCESSFULLY_RECEIVED = 0x80;
+    public static final int CANCEL_STATUS_REQUEST_CORRUPTED             = 0x81;
+
+    /**
+     *  X-Mms-Reply-Charging field types.
+     */
+    public static final int REPLY_CHARGING_REQUESTED           = 0x80;
+    public static final int REPLY_CHARGING_REQUESTED_TEXT_ONLY = 0x81;
+    public static final int REPLY_CHARGING_ACCEPTED            = 0x82;
+    public static final int REPLY_CHARGING_ACCEPTED_TEXT_ONLY  = 0x83;
+
+    /**
+     *  X-Mms-MM-State field types.
+     */
+    public static final int MM_STATE_DRAFT                  = 0x80;
+    public static final int MM_STATE_SENT                   = 0x81;
+    public static final int MM_STATE_NEW                    = 0x82;
+    public static final int MM_STATE_RETRIEVED              = 0x83;
+    public static final int MM_STATE_FORWARDED              = 0x84;
+
+    /**
+     * X-Mms-Recommended-Retrieval-Mode field types.
+     */
+    public static final int RECOMMENDED_RETRIEVAL_MODE_MANUAL = 0x80;
+
+    /**
+     *  X-Mms-Content-Class field types.
+     */
+    public static final int CONTENT_CLASS_TEXT              = 0x80;
+    public static final int CONTENT_CLASS_IMAGE_BASIC       = 0x81;
+    public static final int CONTENT_CLASS_IMAGE_RICH        = 0x82;
+    public static final int CONTENT_CLASS_VIDEO_BASIC       = 0x83;
+    public static final int CONTENT_CLASS_VIDEO_RICH        = 0x84;
+    public static final int CONTENT_CLASS_MEGAPIXEL         = 0x85;
+    public static final int CONTENT_CLASS_CONTENT_BASIC     = 0x86;
+    public static final int CONTENT_CLASS_CONTENT_RICH      = 0x87;
+
+    /**
+     *  X-Mms-Store-Status field types.
+     */
+    public static final int STORE_STATUS_SUCCESS                                = 0x80;
+    public static final int STORE_STATUS_ERROR_TRANSIENT_FAILURE                = 0xC0;
+    public static final int STORE_STATUS_ERROR_TRANSIENT_NETWORK_PROBLEM        = 0xC1;
+    public static final int STORE_STATUS_ERROR_PERMANENT_FAILURE                = 0xE0;
+    public static final int STORE_STATUS_ERROR_PERMANENT_SERVICE_DENIED         = 0xE1;
+    public static final int STORE_STATUS_ERROR_PERMANENT_MESSAGE_FORMAT_CORRUPT = 0xE2;
+    public static final int STORE_STATUS_ERROR_PERMANENT_MESSAGE_NOT_FOUND      = 0xE3;
+    public static final int STORE_STATUS_ERROR_PERMANENT_MMBOX_FULL             = 0xE4;
+    public static final int STORE_STATUS_ERROR_END                              = 0xFF;
+
+    /**
+     * The map contains the value of all headers.
+     */
+    private HashMap<Integer, Object> mHeaderMap = null;
+
+    /**
+     * Constructor of PduHeaders.
+     */
+    public PduHeaders() {
+        mHeaderMap = new HashMap<Integer, Object>();
+    }
+
+    /**
+     * Get octet value by header field.
+     *
+     * @param field the field
+     * @return the octet value of the pdu header
+     *          with specified header field. Return 0 if
+     *          the value is not set.
+     */
+    protected int getOctet(int field) {
+        Integer octet = (Integer) mHeaderMap.get(field);
+        if (null == octet) {
+            return 0;
+        }
+
+        return octet;
+    }
+
+    /**
+     * Set octet value to pdu header by header field.
+     *
+     * @param value the value
+     * @param field the field
+     * @throws InvalidHeaderValueException if the value is invalid.
+     */
+    protected void setOctet(int value, int field)
+            throws InvalidHeaderValueException{
+        /*
+         * Check whether this field can be set for specific
+         * header and check validity of the field.
+         */
+        switch (field) {
+            case REPORT_ALLOWED:
+            case ADAPTATION_ALLOWED:
+            case DELIVERY_REPORT:
+            case DRM_CONTENT:
+            case DISTRIBUTION_INDICATOR:
+            case QUOTAS:
+            case READ_REPORT:
+            case STORE:
+            case STORED:
+            case TOTALS:
+            case SENDER_VISIBILITY:
+                if ((VALUE_YES != value) && (VALUE_NO != value)) {
+                    // Invalid value.
+                    throw new InvalidHeaderValueException("Invalid Octet value!");
+                }
+                break;
+            case READ_STATUS:
+                if ((READ_STATUS_READ != value) &&
+                        (READ_STATUS__DELETED_WITHOUT_BEING_READ != value)) {
+                    // Invalid value.
+                    throw new InvalidHeaderValueException("Invalid Octet value!");
+                }
+                break;
+            case CANCEL_STATUS:
+                if ((CANCEL_STATUS_REQUEST_SUCCESSFULLY_RECEIVED != value) &&
+                        (CANCEL_STATUS_REQUEST_CORRUPTED != value)) {
+                    // Invalid value.
+                    throw new InvalidHeaderValueException("Invalid Octet value!");
+                }
+                break;
+            case PRIORITY:
+                if ((value < PRIORITY_LOW) || (value > PRIORITY_HIGH)) {
+                    // Invalid value.
+                    throw new InvalidHeaderValueException("Invalid Octet value!");
+                }
+                break;
+            case STATUS:
+                if ((value < STATUS_EXPIRED) || (value > STATUS_UNREACHABLE)) {
+                    // Invalid value.
+                    throw new InvalidHeaderValueException("Invalid Octet value!");
+                }
+                break;
+            case REPLY_CHARGING:
+                if ((value < REPLY_CHARGING_REQUESTED)
+                        || (value > REPLY_CHARGING_ACCEPTED_TEXT_ONLY)) {
+                    // Invalid value.
+                    throw new InvalidHeaderValueException("Invalid Octet value!");
+                }
+                break;
+            case MM_STATE:
+                if ((value < MM_STATE_DRAFT) || (value > MM_STATE_FORWARDED)) {
+                    // Invalid value.
+                    throw new InvalidHeaderValueException("Invalid Octet value!");
+                }
+                break;
+            case RECOMMENDED_RETRIEVAL_MODE:
+                if (RECOMMENDED_RETRIEVAL_MODE_MANUAL != value) {
+                    // Invalid value.
+                    throw new InvalidHeaderValueException("Invalid Octet value!");
+                }
+                break;
+            case CONTENT_CLASS:
+                if ((value < CONTENT_CLASS_TEXT)
+                        || (value > CONTENT_CLASS_CONTENT_RICH)) {
+                    // Invalid value.
+                    throw new InvalidHeaderValueException("Invalid Octet value!");
+                }
+                break;
+            case RETRIEVE_STATUS:
+                // According to oma-ts-mms-enc-v1_3, section 7.3.50, we modify the invalid value.
+                if ((value > RETRIEVE_STATUS_ERROR_TRANSIENT_NETWORK_PROBLEM) &&
+                        (value < RETRIEVE_STATUS_ERROR_PERMANENT_FAILURE)) {
+                    value = RETRIEVE_STATUS_ERROR_TRANSIENT_FAILURE;
+                } else if ((value > RETRIEVE_STATUS_ERROR_PERMANENT_CONTENT_UNSUPPORTED) &&
+                        (value <= RETRIEVE_STATUS_ERROR_END)) {
+                    value = RETRIEVE_STATUS_ERROR_PERMANENT_FAILURE;
+                } else if ((value < RETRIEVE_STATUS_OK) ||
+                        ((value > RETRIEVE_STATUS_OK) &&
+                                (value < RETRIEVE_STATUS_ERROR_TRANSIENT_FAILURE)) ||
+                                (value > RETRIEVE_STATUS_ERROR_END)) {
+                    value = RETRIEVE_STATUS_ERROR_PERMANENT_FAILURE;
+                }
+                break;
+            case STORE_STATUS:
+                // According to oma-ts-mms-enc-v1_3, section 7.3.58, we modify the invalid value.
+                if ((value > STORE_STATUS_ERROR_TRANSIENT_NETWORK_PROBLEM) &&
+                        (value < STORE_STATUS_ERROR_PERMANENT_FAILURE)) {
+                    value = STORE_STATUS_ERROR_TRANSIENT_FAILURE;
+                } else if ((value > STORE_STATUS_ERROR_PERMANENT_MMBOX_FULL) &&
+                        (value <= STORE_STATUS_ERROR_END)) {
+                    value = STORE_STATUS_ERROR_PERMANENT_FAILURE;
+                } else if ((value < STORE_STATUS_SUCCESS) ||
+                        ((value > STORE_STATUS_SUCCESS) &&
+                                (value < STORE_STATUS_ERROR_TRANSIENT_FAILURE)) ||
+                                (value > STORE_STATUS_ERROR_END)) {
+                    value = STORE_STATUS_ERROR_PERMANENT_FAILURE;
+                }
+                break;
+            case RESPONSE_STATUS:
+                // According to oma-ts-mms-enc-v1_3, section 7.3.48, we modify the invalid value.
+                if ((value > RESPONSE_STATUS_ERROR_TRANSIENT_PARTIAL_SUCCESS) &&
+                        (value < RESPONSE_STATUS_ERROR_PERMANENT_FAILURE)) {
+                    value = RESPONSE_STATUS_ERROR_TRANSIENT_FAILURE;
+                } else if (((value > RESPONSE_STATUS_ERROR_PERMANENT_LACK_OF_PREPAID) &&
+                        (value <= RESPONSE_STATUS_ERROR_PERMANENT_END)) ||
+                        (value < RESPONSE_STATUS_OK) ||
+                        ((value > RESPONSE_STATUS_ERROR_UNSUPPORTED_MESSAGE) &&
+                                (value < RESPONSE_STATUS_ERROR_TRANSIENT_FAILURE)) ||
+                                (value > RESPONSE_STATUS_ERROR_PERMANENT_END)) {
+                    value = RESPONSE_STATUS_ERROR_PERMANENT_FAILURE;
+                }
+                break;
+            case MMS_VERSION:
+                if ((value < MMS_VERSION_1_0)|| (value > MMS_VERSION_1_3)) {
+                    value = CURRENT_MMS_VERSION; // Current version is the default value.
+                }
+                break;
+            case MESSAGE_TYPE:
+                if ((value < MESSAGE_TYPE_SEND_REQ) || (value > MESSAGE_TYPE_CANCEL_CONF)) {
+                    // Invalid value.
+                    throw new InvalidHeaderValueException("Invalid Octet value!");
+                }
+                break;
+            default:
+                // This header value should not be Octect.
+                throw new RuntimeException("Invalid header field!");
+        }
+        mHeaderMap.put(field, value);
+    }
+
+    /**
+     * Get TextString value by header field.
+     *
+     * @param field the field
+     * @return the TextString value of the pdu header
+     *          with specified header field
+     */
+    protected byte[] getTextString(int field) {
+        return (byte[]) mHeaderMap.get(field);
+    }
+
+    /**
+     * Set TextString value to pdu header by header field.
+     *
+     * @param value the value
+     * @param field the field
+     * @return the TextString value of the pdu header
+     *          with specified header field
+     * @throws NullPointerException if the value is null.
+     */
+    protected void setTextString(byte[] value, int field) {
+        /*
+         * Check whether this field can be set for specific
+         * header and check validity of the field.
+         */
+        if (null == value) {
+            throw new NullPointerException();
+        }
+
+        switch (field) {
+            case TRANSACTION_ID:
+            case REPLY_CHARGING_ID:
+            case AUX_APPLIC_ID:
+            case APPLIC_ID:
+            case REPLY_APPLIC_ID:
+            case MESSAGE_ID:
+            case REPLACE_ID:
+            case CANCEL_ID:
+            case CONTENT_LOCATION:
+            case MESSAGE_CLASS:
+            case CONTENT_TYPE:
+                break;
+            default:
+                // This header value should not be Text-String.
+                throw new RuntimeException("Invalid header field!");
+        }
+        mHeaderMap.put(field, value);
+    }
+
+    /**
+     * Get EncodedStringValue value by header field.
+     *
+     * @param field the field
+     * @return the EncodedStringValue value of the pdu header
+     *          with specified header field
+     */
+    protected EncodedStringValue getEncodedStringValue(int field) {
+        return (EncodedStringValue) mHeaderMap.get(field);
+    }
+
+    /**
+     * Get TO, CC or BCC header value.
+     *
+     * @param field the field
+     * @return the EncodeStringValue array of the pdu header
+     *          with specified header field
+     */
+    protected EncodedStringValue[] getEncodedStringValues(int field) {
+        ArrayList<EncodedStringValue> list =
+                (ArrayList<EncodedStringValue>) mHeaderMap.get(field);
+        if (null == list) {
+            return null;
+        }
+        EncodedStringValue[] values = new EncodedStringValue[list.size()];
+        return list.toArray(values);
+    }
+
+    /**
+     * Set EncodedStringValue value to pdu header by header field.
+     *
+     * @param value the value
+     * @param field the field
+     * @return the EncodedStringValue value of the pdu header
+     *          with specified header field
+     * @throws NullPointerException if the value is null.
+     */
+    protected void setEncodedStringValue(EncodedStringValue value, int field) {
+        /*
+         * Check whether this field can be set for specific
+         * header and check validity of the field.
+         */
+        if (null == value) {
+            throw new NullPointerException();
+        }
+
+        switch (field) {
+            case SUBJECT:
+            case RECOMMENDED_RETRIEVAL_MODE_TEXT:
+            case RETRIEVE_TEXT:
+            case STATUS_TEXT:
+            case STORE_STATUS_TEXT:
+            case RESPONSE_TEXT:
+            case FROM:
+            case PREVIOUSLY_SENT_BY:
+            case MM_FLAGS:
+                break;
+            default:
+                // This header value should not be Encoded-String-Value.
+                throw new RuntimeException("Invalid header field!");
+        }
+
+        mHeaderMap.put(field, value);
+    }
+
+    /**
+     * Set TO, CC or BCC header value.
+     *
+     * @param value the value
+     * @param field the field
+     * @return the EncodedStringValue value array of the pdu header
+     *          with specified header field
+     * @throws NullPointerException if the value is null.
+     */
+    protected void setEncodedStringValues(EncodedStringValue[] value, int field) {
+        /*
+         * Check whether this field can be set for specific
+         * header and check validity of the field.
+         */
+        if (null == value) {
+            throw new NullPointerException();
+        }
+
+        switch (field) {
+            case BCC:
+            case CC:
+            case TO:
+                break;
+            default:
+                // This header value should not be Encoded-String-Value.
+                throw new RuntimeException("Invalid header field!");
+        }
+
+        ArrayList<EncodedStringValue> list = new ArrayList<EncodedStringValue>();
+        for (int i = 0; i < value.length; i++) {
+            list.add(value[i]);
+        }
+        mHeaderMap.put(field, list);
+    }
+
+    /**
+     * Append one EncodedStringValue to another.
+     *
+     * @param value the EncodedStringValue to append
+     * @param field the field
+     * @throws NullPointerException if the value is null.
+     */
+    protected void appendEncodedStringValue(EncodedStringValue value,
+                                    int field) {
+        if (null == value) {
+            throw new NullPointerException();
+        }
+
+        switch (field) {
+            case BCC:
+            case CC:
+            case TO:
+                break;
+            default:
+                throw new RuntimeException("Invalid header field!");
+        }
+
+        ArrayList<EncodedStringValue> list =
+            (ArrayList<EncodedStringValue>) mHeaderMap.get(field);
+        if (null == list) {
+            list  = new ArrayList<EncodedStringValue>();
+        }
+        list.add(value);
+        mHeaderMap.put(field, list);
+    }
+
+    /**
+     * Get LongInteger value by header field.
+     *
+     * @param field the field
+     * @return the LongInteger value of the pdu header
+     *          with specified header field. if return -1, the
+     *          field is not existed in pdu header.
+     */
+    protected long getLongInteger(int field) {
+        Long longInteger = (Long) mHeaderMap.get(field);
+        if (null == longInteger) {
+            return -1;
+        }
+
+        return longInteger.longValue();
+    }
+
+    /**
+     * Set LongInteger value to pdu header by header field.
+     *
+     * @param value the value
+     * @param field the field
+     */
+    protected void setLongInteger(long value, int field) {
+        /*
+         * Check whether this field can be set for specific
+         * header and check validity of the field.
+         */
+        switch (field) {
+            case DATE:
+            case REPLY_CHARGING_SIZE:
+            case MESSAGE_SIZE:
+            case MESSAGE_COUNT:
+            case START:
+            case LIMIT:
+            case DELIVERY_TIME:
+            case EXPIRY:
+            case REPLY_CHARGING_DEADLINE:
+            case PREVIOUSLY_SENT_DATE:
+                break;
+            default:
+                // This header value should not be LongInteger.
+                throw new RuntimeException("Invalid header field!");
+        }
+        mHeaderMap.put(field, value);
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/PduPart.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/PduPart.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright (C) 2007-2008 Esmertec AG.
+ * Copyright (C) 2007-2008 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+import android.net.Uri;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The pdu part.
+ */
+public class PduPart {
+    /**
+     * Well-Known Parameters.
+     */
+    public static final int P_Q = 0x80;
+    public static final int P_CHARSET = 0x81;
+    public static final int P_LEVEL = 0x82;
+    public static final int P_TYPE = 0x83;
+    public static final int P_DEP_NAME = 0x85;
+    public static final int P_DEP_FILENAME = 0x86;
+    public static final int P_DIFFERENCES = 0x87;
+    public static final int P_PADDING = 0x88;
+    // This value of "TYPE" s used with Content-Type: multipart/related
+    public static final int P_CT_MR_TYPE = 0x89;
+    public static final int P_DEP_START = 0x8A;
+    public static final int P_DEP_START_INFO = 0x8B;
+    public static final int P_DEP_COMMENT = 0x8C;
+    public static final int P_DEP_DOMAIN = 0x8D;
+    public static final int P_MAX_AGE = 0x8E;
+    public static final int P_DEP_PATH = 0x8F;
+    public static final int P_SECURE = 0x90;
+    public static final int P_SEC = 0x91;
+    public static final int P_MAC = 0x92;
+    public static final int P_CREATION_DATE = 0x93;
+    public static final int P_MODIFICATION_DATE = 0x94;
+    public static final int P_READ_DATE = 0x95;
+    public static final int P_SIZE = 0x96;
+    public static final int P_NAME = 0x97;
+    public static final int P_FILENAME = 0x98;
+    public static final int P_START = 0x99;
+    public static final int P_START_INFO = 0x9A;
+    public static final int P_COMMENT = 0x9B;
+    public static final int P_DOMAIN = 0x9C;
+    public static final int P_PATH = 0x9D;
+
+    /**
+     * Header field names.
+     */
+    public static final int P_CONTENT_TYPE = 0x91;
+    public static final int P_CONTENT_LOCATION = 0x8E;
+    public static final int P_CONTENT_ID = 0xC0;
+    public static final int P_DEP_CONTENT_DISPOSITION = 0xAE;
+    public static final int P_CONTENT_DISPOSITION = 0xC5;
+    // The next header is unassigned header, use reserved header(0x48) value.
+    public static final int P_CONTENT_TRANSFER_ENCODING = 0xC8;
+
+    /**
+     * Content=Transfer-Encoding string.
+     */
+    public static final String CONTENT_TRANSFER_ENCODING =
+            "Content-Transfer-Encoding";
+
+    /**
+     * Value of Content-Transfer-Encoding.
+     */
+    public static final String P_BINARY = "binary";
+    public static final String P_7BIT = "7bit";
+    public static final String P_8BIT = "8bit";
+    public static final String P_BASE64 = "base64";
+    public static final String P_QUOTED_PRINTABLE = "quoted-printable";
+    /**
+     * Content-Disposition value.
+     */
+    public static final int P_DISPOSITION_FROM_DATA = 0x80;
+    public static final int P_DISPOSITION_ATTACHMENT = 0x81;
+    public static final int P_DISPOSITION_INLINE = 0x82;
+    /**
+     * Value of disposition can be set to PduPart when the value is octet in
+     * the PDU.
+     * "from-data" instead of Form-data<Octet 128>.
+     * "attachment" instead of Attachment<Octet 129>.
+     * "inline" instead of Inline<Octet 130>.
+     */
+    static final byte[] DISPOSITION_FROM_DATA = "from-data".getBytes();
+    static final byte[] DISPOSITION_ATTACHMENT = "attachment".getBytes();
+    static final byte[] DISPOSITION_INLINE = "inline".getBytes();
+    private static final String TAG = "PduPart";
+    /**
+     * Header of part.
+     */
+    private Map<Integer, Object> mPartHeader = null;
+    /**
+     * Data uri.
+     */
+    private Uri mUri = null;
+    /**
+     * Part data.
+     */
+    private byte[] mPartData = null;
+
+    /**
+     * Empty Constructor.
+     */
+    public PduPart() {
+        mPartHeader = new HashMap<Integer, Object>();
+    }
+
+    /**
+     * @return A copy of the part data or null if the data wasn't set or
+     * the data is stored as Uri.
+     * @see #getDataUri
+     */
+    public byte[] getData() {
+        if (mPartData == null) {
+            return null;
+        }
+
+        byte[] byteArray = new byte[mPartData.length];
+        System.arraycopy(mPartData, 0, byteArray, 0, mPartData.length);
+        return byteArray;
+    }
+
+    /**
+     * Set part data. The data are stored as byte array.
+     *
+     * @param data the data
+     */
+    public void setData(byte[] data) {
+        if (data == null) {
+            return;
+        }
+
+        mPartData = new byte[data.length];
+        System.arraycopy(data, 0, mPartData, 0, data.length);
+    }
+
+    /**
+     * @return The length of the data, if this object have data, else 0.
+     */
+    public int getDataLength() {
+        if (mPartData != null) {
+            return mPartData.length;
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * @return The Uri of the part data or null if the data wasn't set or
+     * the data is stored as byte array.
+     * @see #getData
+     */
+    public Uri getDataUri() {
+        return mUri;
+    }
+
+    /**
+     * Set data uri. The data are stored as Uri.
+     *
+     * @param uri the uri
+     */
+    public void setDataUri(Uri uri) {
+        mUri = uri;
+    }
+
+    /**
+     * Get Content-id value.
+     *
+     * @return the value
+     */
+    public byte[] getContentId() {
+        return (byte[]) mPartHeader.get(P_CONTENT_ID);
+    }
+
+    /**
+     * Set Content-id value
+     *
+     * @param contentId the content-id value
+     * @throws NullPointerException if the value is null.
+     */
+    public void setContentId(byte[] contentId) {
+        if ((contentId == null) || (contentId.length == 0)) {
+            throw new IllegalArgumentException(
+                    "Content-Id may not be null or empty.");
+        }
+
+        if ((contentId.length > 1)
+                && ((char) contentId[0] == '<')
+                && ((char) contentId[contentId.length - 1] == '>')) {
+            mPartHeader.put(P_CONTENT_ID, contentId);
+            return;
+        }
+
+        // Insert beginning '<' and trailing '>' for Content-Id.
+        byte[] buffer = new byte[contentId.length + 2];
+        buffer[0] = (byte) (0xff & '<');
+        buffer[buffer.length - 1] = (byte) (0xff & '>');
+        System.arraycopy(contentId, 0, buffer, 1, contentId.length);
+        mPartHeader.put(P_CONTENT_ID, buffer);
+    }
+
+    /**
+     * Get Char-set value
+     *
+     * @return the charset value. Return 0 if charset was not set.
+     */
+    public int getCharset() {
+        Integer charset = (Integer) mPartHeader.get(P_CHARSET);
+        if (charset == null) {
+            return 0;
+        } else {
+            return charset.intValue();
+        }
+    }
+
+    /**
+     * Set Char-set value.
+     *
+     * @param charset the value
+     */
+    public void setCharset(int charset) {
+        mPartHeader.put(P_CHARSET, charset);
+    }
+
+    /**
+     * Get Content-Location value.
+     *
+     * @return the value
+     * return PduPart.disposition[0] instead of <Octet 128> (Form-data).
+     * return PduPart.disposition[1] instead of <Octet 129> (Attachment).
+     * return PduPart.disposition[2] instead of <Octet 130> (Inline).
+     */
+    public byte[] getContentLocation() {
+        return (byte[]) mPartHeader.get(P_CONTENT_LOCATION);
+    }
+
+    /**
+     * Set Content-Location value.
+     *
+     * @param contentLocation the value
+     * @throws NullPointerException if the value is null.
+     */
+    public void setContentLocation(byte[] contentLocation) {
+        if (contentLocation == null) {
+            throw new NullPointerException("null content-location");
+        }
+
+        mPartHeader.put(P_CONTENT_LOCATION, contentLocation);
+    }
+
+    /**
+     * Get Content-Disposition value.
+     *
+     * @return the value
+     */
+    public byte[] getContentDisposition() {
+        return (byte[]) mPartHeader.get(P_CONTENT_DISPOSITION);
+    }
+
+    /**
+     * Set Content-Disposition value.
+     * Use PduPart.disposition[0] instead of <Octet 128> (Form-data).
+     * Use PduPart.disposition[1] instead of <Octet 129> (Attachment).
+     * Use PduPart.disposition[2] instead of <Octet 130> (Inline).
+     *
+     * @param contentDisposition the value
+     * @throws NullPointerException if the value is null.
+     */
+    public void setContentDisposition(byte[] contentDisposition) {
+        if (contentDisposition == null) {
+            throw new NullPointerException("null content-disposition");
+        }
+
+        mPartHeader.put(P_CONTENT_DISPOSITION, contentDisposition);
+    }
+
+    /**
+     * Get Content-Type value of part.
+     *
+     * @return the value
+     */
+    public byte[] getContentType() {
+        return (byte[]) mPartHeader.get(P_CONTENT_TYPE);
+    }
+
+    /**
+     * Set Content-Type value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+    public void setContentType(byte[] contentType) {
+        if (contentType == null) {
+            throw new NullPointerException("null content-type");
+        }
+
+        mPartHeader.put(P_CONTENT_TYPE, contentType);
+    }
+
+    /**
+     * Get Content-Transfer-Encoding value.
+     *
+     * @return the value
+     */
+    public byte[] getContentTransferEncoding() {
+        return (byte[]) mPartHeader.get(P_CONTENT_TRANSFER_ENCODING);
+    }
+
+    /**
+     * Set Content-Transfer-Encoding value
+     *
+     * @param contentId the content-id value
+     * @throws NullPointerException if the value is null.
+     */
+    public void setContentTransferEncoding(byte[] contentTransferEncoding) {
+        if (contentTransferEncoding == null) {
+            throw new NullPointerException("null content-transfer-encoding");
+        }
+
+        mPartHeader.put(P_CONTENT_TRANSFER_ENCODING, contentTransferEncoding);
+    }
+
+    /**
+     * Get content-type parameter: name.
+     *
+     * @return the name
+     */
+    public byte[] getName() {
+        return (byte[]) mPartHeader.get(P_NAME);
+    }
+
+    /**
+     * Set Content-type parameter: name.
+     *
+     * @param name the name value
+     * @throws NullPointerException if the value is null.
+     */
+    public void setName(byte[] name) {
+        if (null == name) {
+            throw new NullPointerException("null content-id");
+        }
+
+        mPartHeader.put(P_NAME, name);
+    }
+
+    /**
+     * Set Content-disposition parameter: filename
+     *
+     * @return the filename
+     */
+    public byte[] getFilename() {
+        return (byte[]) mPartHeader.get(P_FILENAME);
+    }
+
+    /**
+     * Get Content-disposition parameter: filename
+     *
+     * @param fileName the filename value
+     * @throws NullPointerException if the value is null.
+     */
+    public void setFilename(byte[] fileName) {
+        if (null == fileName) {
+            throw new NullPointerException("null content-id");
+        }
+
+        mPartHeader.put(P_FILENAME, fileName);
+    }
+
+    public String generateLocation() {
+        // Assumption: At least one of the content-location / name / filename
+        // or content-id should be set. This is guaranteed by the PduParser
+        // for incoming messages and by MM composer for outgoing messages.
+        byte[] location = (byte[]) mPartHeader.get(P_NAME);
+        if (null == location) {
+            location = (byte[]) mPartHeader.get(P_FILENAME);
+
+            if (null == location) {
+                location = (byte[]) mPartHeader.get(P_CONTENT_LOCATION);
+            }
+        }
+
+        if (null == location) {
+            byte[] contentId = (byte[]) mPartHeader.get(P_CONTENT_ID);
+            return "cid:" + new String(contentId);
+        } else {
+            return new String(location);
+        }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsContentObserver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsContentObserver.kt
@@ -1,10 +1,12 @@
 package me.capcom.smsgateway.modules.receiver
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.database.ContentObserver
 import android.net.Uri
 import android.os.Handler
 import android.os.HandlerThread
+import androidx.core.content.ContextCompat
 import me.capcom.smsgateway.modules.logs.LogsService
 import me.capcom.smsgateway.modules.logs.db.LogEntry
 import me.capcom.smsgateway.modules.receiver.data.InboxMessage
@@ -25,6 +27,15 @@ class MmsContentObserver : KoinComponent {
             return
         }
 
+        if (!canReadSms()) {
+            logsService.insert(
+                LogEntry.Priority.WARN,
+                MODULE_NAME,
+                "MMS inbox observer not started because READ_SMS is not granted",
+            )
+            return
+        }
+
         // Initialize high-water mark to current max ID if not set
         if (storage.mmsLastProcessedID == 0L) {
             storage.mmsLastProcessedID = queryMaxMmsId()
@@ -32,8 +43,9 @@ class MmsContentObserver : KoinComponent {
 
         val thread = HandlerThread("MmsContentObserver").apply { start() }
         handlerThread = thread
+        val handler = Handler(thread.looper)
 
-        val obs = object : ContentObserver(Handler(thread.looper)) {
+        val obs = object : ContentObserver(handler) {
             override fun onChange(selfChange: Boolean) {
                 super.onChange(selfChange)
                 processNewMessages()
@@ -44,8 +56,13 @@ class MmsContentObserver : KoinComponent {
         context.contentResolver.registerContentObserver(
             Uri.parse("content://mms"),
             true,
-            obs
+            obs,
         )
+
+        // Catch up rows that arrived while the app process was stopped or before
+        // READ_SMS was granted. ContentObserver callbacks are edge-triggered, so
+        // already-inserted MMS rows would otherwise remain pending forever.
+        handler.post { processNewMessages() }
     }
 
     fun stop() {
@@ -56,12 +73,24 @@ class MmsContentObserver : KoinComponent {
     }
 
     private fun queryMaxMmsId(): Long {
-        val cursor = context.contentResolver.query(
-            Uri.parse("content://mms"),
-            arrayOf("_id"),
-            null, null,
-            "_id DESC LIMIT 1"
-        ) ?: return 0
+        if (!canReadSms()) return 0
+
+        val cursor = try {
+            context.contentResolver.query(
+                Uri.parse("content://mms"),
+                arrayOf("_id"),
+                null, null,
+                "_id DESC LIMIT 1"
+            )
+        } catch (e: SecurityException) {
+            logsService.insert(
+                LogEntry.Priority.WARN,
+                MODULE_NAME,
+                "Unable to initialize MMS inbox high-water mark because provider access was denied",
+                mapOf("error" to (e.message ?: e.toString())),
+            )
+            return 0
+        } ?: return 0
 
         return cursor.use { c ->
             if (c.moveToFirst()) c.getLong(0) else 0
@@ -69,15 +98,34 @@ class MmsContentObserver : KoinComponent {
     }
 
     private fun processNewMessages() {
+        if (!canReadSms()) {
+            logsService.insert(
+                LogEntry.Priority.WARN,
+                MODULE_NAME,
+                "Skipping MMS inbox processing because READ_SMS is not granted",
+            )
+            return
+        }
+
         val mark = storage.mmsLastProcessedID
         // msg_type 132 = retrieve-conf (fully downloaded), msg_box 1 = inbox
-        val cursor = context.contentResolver.query(
-            Uri.parse("content://mms"),
-            arrayOf("_id"),
-            "_id > ? AND m_type = 132 AND msg_box = 1",
-            arrayOf(mark.toString()),
-            "_id ASC"
-        ) ?: return
+        val cursor = try {
+            context.contentResolver.query(
+                Uri.parse("content://mms"),
+                arrayOf("_id"),
+                "_id > ? AND m_type = 132 AND msg_box = 1",
+                arrayOf(mark.toString()),
+                "_id ASC"
+            )
+        } catch (e: SecurityException) {
+            logsService.insert(
+                LogEntry.Priority.WARN,
+                MODULE_NAME,
+                "Skipping MMS inbox processing because provider access was denied",
+                mapOf("error" to (e.message ?: e.toString())),
+            )
+            return
+        } ?: return
 
         cursor.use { c ->
             while (c.moveToNext()) {
@@ -89,9 +137,10 @@ class MmsContentObserver : KoinComponent {
                         LogEntry.Priority.ERROR,
                         MODULE_NAME,
                         "Failed processing downloaded MMS (id=$mmsId)",
-                        mapOf("mmsId" to mmsId)
+                        mapOf("mmsId" to mmsId, "error" to (e.message ?: e.toString())),
                     )
                 }
+                // Always advance mark to prevent one corrupt MMS from blocking the pipeline
                 storage.mmsLastProcessedID = mmsId
             }
         }
@@ -121,6 +170,11 @@ class MmsContentObserver : KoinComponent {
             true,
         )
     }
+
+    private fun canReadSms(): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        android.Manifest.permission.READ_SMS,
+    ) == PackageManager.PERMISSION_GRANTED
 
     companion object {
         private const val TAG = "MmsContentObserver"

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
@@ -14,6 +14,7 @@ import me.capcom.smsgateway.modules.receiver.data.InboxMessage
 import me.capcom.smsgateway.modules.receiver.parsers.MMSParser
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.security.MessageDigest
 import java.util.Date
 
 class MmsReceiver : BroadcastReceiver(), KoinComponent {
@@ -56,7 +57,10 @@ class MmsReceiver : BroadcastReceiver(), KoinComponent {
                     "uri" to intent.extras?.getString("uri"),
                     "header" to intent.extras?.getByteArray("header")
                         ?.joinToString("") { "%02x".format(it) },
-                    "pdu" to pdu.joinToString("") { "%02x".format(it) },
+                    "pduSizeBytes" to pdu.size,
+                    "pduSha256" to MessageDigest.getInstance("SHA-256")
+                        .digest(pdu)
+                        .joinToString("") { "%02x".format(it) },
                 )
             )
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
@@ -81,7 +81,11 @@ class ReceiverService : KoinComponent {
             LogEntry.Priority.DEBUG,
             MODULE_NAME,
             "ReceiverService::process - message received",
-            mapOf("message" to message)
+            mapOf(
+                "messageType" to message.javaClass.simpleName,
+                "date" to message.date,
+                "subscriptionId" to message.subscriptionId,
+            )
         )
 
         // Dedup safety net: skip if this exact message was already processed
@@ -90,7 +94,11 @@ class ReceiverService : KoinComponent {
                 LogEntry.Priority.DEBUG,
                 MODULE_NAME,
                 "ReceiverService::process - duplicate message, skipping",
-                mapOf("message" to message)
+                mapOf(
+                    "messageType" to message.javaClass.simpleName,
+                    "date" to message.date,
+                    "subscriptionId" to message.subscriptionId,
+                )
             )
             return
         }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParser.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParser.kt
@@ -62,7 +62,8 @@ object MMSParser {
         val from: String,
         val subject: String?,
         val messageSize: Long,
-        val contentClass: ContentClass?
+        val contentClass: ContentClass?,
+        val contentLocation: String?,
     )
 
     fun parseMNotificationInd(pdu: ByteArray): MNotificationInd {
@@ -119,7 +120,8 @@ object MMSParser {
             from = headers[HEADER_FROM] as String,
             subject = headers[HEADER_SUBJECT] as String?,
             messageSize = headers[HEADER_MESSAGE_SIZE] as Long,
-            contentClass = headers[HEADER_CONTENT_CLASS] as ContentClass?
+            contentClass = headers[HEADER_CONTENT_CLASS] as ContentClass?,
+            contentLocation = headers[HEADER_CONTENT_LOCATION] as String?,
         )
     }
 

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path
+        name="mms_out"
+        path="mms-out/" />
+    <cache-path
+        name="mms_cache"
+        path="mms-cache/" />
+</paths>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Inbox API now supports `includeAttachments` on `GET /inbox` (default `false`) to include MMS attachment metadata in results.
  * Added `GET /inbox/{id}/attachments/{partId}` to download a specific MMS attachment (secured via the new `inbox:read` scope).

* **Bug Fixes / Improvements**
  * Invalid `includeAttachments` values now return `400 BadRequest`.
  * MMS observation now requires runtime permission and stops gracefully if denied.
  * MMS attachment storage includes retention-based cleanup; receiver logging is reduced for privacy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->