### PR TITLE
[messages] add per 30 minutes limit

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesSettings.kt
@@ -11,6 +11,7 @@ class MessagesSettings(
     enum class Period(val duration: Long) {
         Disabled(0L),
         PerMinute(60000L),
+        Per30Minutes(1800000L),
         PerHour(3600000L),
         PerDay(86400000L),
     }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -2,12 +2,14 @@
     <string-array name="limit_periods_titles">
         <item>disabled</item>
         <item>minute</item>
+        <item>30 minutes</item>
         <item>hour</item>
         <item>day</item>
     </string-array>
     <string-array name="limit_periods_values">
         <item>Disabled</item>
         <item>PerMinute</item>
+        <item>Per30Minutes</item>
         <item>PerHour</item>
         <item>PerDay</item>
     </string-array>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **30 minutes** interval option for message rate limiting, giving users an additional choice when configuring message limits.
* **User Experience**
  * Expanded the available “limit period” choices in the settings UI to include the new 30-minute option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->