### PR TITLE
[messages] add work hours support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ SMS Gateway turns your Android smartphone into an SMS gateway. It's a lightweigh
 - 💳 **Multiple SIM card support:** Supports devices with [multiple SIM cards](https://docs.sms-gate.app/features/multi-sim/).
 - 📱📱 **Multiple device support:** Connect [multiple devices](https://docs.sms-gate.app/features/multi-device/) to the same account with Cloud or Private server. Messages sent via the server are distributed across all connected devices.
 - 💾 **Data SMS support:** Send and receive binary [data payloads](https://docs.sms-gate.app/features/data-sms.md) via SMS for IoT commands, encrypted messages, and other specialized use cases.
+- 🕐 **Working hours scheduling:** Restrict message delivery to configurable time windows, automatically pausing the queue outside of them
 
 🔌 Integration:
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -135,17 +135,27 @@ class MessagesService(
             throw ConflictException()
         }
 
-        if (scheduleAt != null
-            && scheduleAt > System.currentTimeMillis()
-            && scheduleAt < (nextScheduled ?: 0)
-        ) {
-            SendMessagesWorker.start(context, true, scheduleAt)
+        val workHoursStart = if (priority < Message.PRIORITY_EXPEDITED) {
+            settings.nextWorkHoursStart()
         } else {
+            null
+        }
+        val startTime = when {
+            workHoursStart != null && workHoursStart < (nextScheduled ?: 0) -> workHoursStart
+            scheduleAt != null
+                && scheduleAt > System.currentTimeMillis()
+                && scheduleAt < (nextScheduled ?: 0) -> scheduleAt
+            else -> SendMessagesWorker.IMMEDIATE
+        }
+
+        if (startTime == SendMessagesWorker.IMMEDIATE) {
             SendMessagesWorker.start(
                 context,
                 nextScheduled == null || priority >= Message.PRIORITY_EXPEDITED,
                 SendMessagesWorker.IMMEDIATE
             )
+        } else {
+            SendMessagesWorker.start(context, true, startTime)
         }
 
         return message
@@ -254,13 +264,18 @@ class MessagesService(
 
                 val priority = message.params.priority ?: Message.PRIORITY_DEFAULT
 
-                // apply limits if:
+                // apply rate limit if:
                 // - message is not expedited
                 // - message is expedited and previous message had higher or equal priority
                 if (priority < Message.PRIORITY_EXPEDITED
                     || previousPriority >= priority
                 ) {
                     applyLimit()
+                }
+
+                // skip work hours for expedited messages
+                if (priority < Message.PRIORITY_EXPEDITED) {
+                    applyWorkHoursLimit()
                 }
 
                 if (!withContext(NonCancellable) { sendMessage(message) }) {
@@ -303,6 +318,16 @@ class MessagesService(
         }
 
         delay(settings.limitPeriod.duration - (System.currentTimeMillis() - processedStats.lastTimestamp) + 1000L)
+    }
+
+    private suspend fun applyWorkHoursLimit() {
+        val nextStart = settings.nextWorkHoursStart() ?: return
+
+        val delayMs = nextStart - System.currentTimeMillis()
+        if (delayMs > 0) {
+            SendMessagesWorker.start(context, true, nextStart)
+            delay(delayMs)
+        }
     }
 
     /**

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesSettings.kt
@@ -61,6 +61,76 @@ class MessagesSettings(
     val processingOrder: ProcessingOrder
         get() = storage.get<ProcessingOrder>(PROCESSING_ORDER) ?: ProcessingOrder.LIFO
 
+    val workHoursEnabled: Boolean
+        get() = storage.get<Boolean>(WORK_HOURS_ENABLED) ?: false
+    val workHoursStart: String
+        get() = storage.get(WORK_HOURS_START) ?: "09:00"
+    val workHoursEnd: String
+        get() = storage.get(WORK_HOURS_END) ?: "19:00"
+
+    private fun isInWorkHours(): Boolean {
+        if (!workHoursEnabled) return true
+
+        val now = java.util.Calendar.getInstance()
+        val nowMinutes =
+            now.get(java.util.Calendar.HOUR_OF_DAY) * 60 + now.get(java.util.Calendar.MINUTE)
+        val startMinutes = parseTimeMinutes(workHoursStart)
+        val endMinutes = parseTimeMinutes(workHoursEnd)
+
+        if (startMinutes == endMinutes) return true
+
+        return if (startMinutes < endMinutes) {
+            nowMinutes in startMinutes until endMinutes
+        } else {
+            nowMinutes >= startMinutes || nowMinutes < endMinutes
+        }
+    }
+
+    fun nextWorkHoursStart(): Long? {
+        if (!workHoursEnabled) return null
+        if (isInWorkHours()) return null
+
+        val now = java.util.Calendar.getInstance()
+        val nowMinutes =
+            now.get(java.util.Calendar.HOUR_OF_DAY) * 60 + now.get(java.util.Calendar.MINUTE)
+        val startMinutes = parseTimeMinutes(workHoursStart)
+        val endMinutes = parseTimeMinutes(workHoursEnd)
+
+        val todayStart = java.util.Calendar.getInstance().apply {
+            set(java.util.Calendar.HOUR_OF_DAY, startMinutes / 60)
+            set(java.util.Calendar.MINUTE, startMinutes % 60)
+            set(java.util.Calendar.SECOND, 0)
+            set(java.util.Calendar.MILLISECOND, 0)
+        }
+
+        return if (startMinutes <= endMinutes) {
+            if (nowMinutes < startMinutes) {
+                todayStart.timeInMillis
+            } else {
+                todayStart.add(java.util.Calendar.DAY_OF_MONTH, 1)
+                todayStart.timeInMillis
+            }
+        } else {
+            todayStart.timeInMillis
+        }
+    }
+
+    private fun parseTimeMinutes(value: String): Int {
+        val parts = value.split(":")
+        return parts.getOrNull(0)?.toIntOrNull()?.let { h ->
+            h * 60 + (parts.getOrNull(1)?.toIntOrNull() ?: 0)
+        } ?: 0
+    }
+
+    private fun isValidTimeFormat(value: String): Boolean {
+        val regex = Regex("^\\d{2}:\\d{2}$")
+        if (!regex.matches(value)) return false
+        val parts = value.split(":")
+        val h = parts.getOrNull(0)?.toIntOrNull() ?: return false
+        val m = parts.getOrNull(1)?.toIntOrNull() ?: return false
+        return h in 0..23 && m in 0..59
+    }
+
     init {
         migrate()
     }
@@ -94,6 +164,10 @@ class MessagesSettings(
         private const val LOG_LIFETIME_DAYS = "log_lifetime_days"
 
         private const val PROCESSING_ORDER = "processing_order"
+
+        private const val WORK_HOURS_ENABLED = "work_hours_enabled"
+        private const val WORK_HOURS_START = "work_hours_start"
+        private const val WORK_HOURS_END = "work_hours_end"
     }
 
     override fun export(): Map<String, *> {
@@ -105,6 +179,9 @@ class MessagesSettings(
             SIM_SELECTION_MODE to simSelectionMode.name,
             LOG_LIFETIME_DAYS to logLifetimeDays,
             PROCESSING_ORDER to processingOrder.name,
+            WORK_HOURS_ENABLED to workHoursEnabled,
+            WORK_HOURS_START to workHoursStart,
+            WORK_HOURS_END to workHoursEnd,
         )
     }
 
@@ -188,6 +265,41 @@ class MessagesSettings(
 
                     val changed = this.logLifetimeDays != logLifetimeDays
                     storage.set(key, logLifetimeDays?.toString())
+
+                    changed
+                }
+
+                WORK_HOURS_ENABLED -> {
+                    val newValue = value?.toString()?.toBooleanStrictOrNull() ?: false
+                    val changed = this.workHoursEnabled != newValue
+
+                    storage.set(key, newValue)
+
+                    changed
+                }
+
+                WORK_HOURS_START -> {
+                    val raw = value?.toString()
+                    if (raw != null && !isValidTimeFormat(raw)) {
+                        throw IllegalArgumentException("Invalid time format: $raw")
+                    }
+                    val newValue = if (raw != null && isValidTimeFormat(raw)) raw else "09:00"
+                    val changed = this.workHoursStart != newValue
+
+                    storage.set(key, newValue)
+
+                    changed
+                }
+
+                WORK_HOURS_END -> {
+                    val raw = value?.toString()
+                    if (raw != null && !isValidTimeFormat(raw)) {
+                        throw IllegalArgumentException("Invalid time format: $raw")
+                    }
+                    val newValue = if (raw != null && isValidTimeFormat(raw)) raw else "19:00"
+                    val changed = this.workHoursEnd != newValue
+
+                    storage.set(key, newValue)
 
                     changed
                 }

--- a/app/src/main/java/me/capcom/smsgateway/ui/settings/MessagesSettingsFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/settings/MessagesSettingsFragment.kt
@@ -1,5 +1,6 @@
 package me.capcom.smsgateway.ui.settings
 
+import android.app.TimePickerDialog
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.text.InputType
@@ -44,6 +45,25 @@ class MessagesSettingsFragment : BasePreferenceFragment() {
                     it.setSelectAllOnFocus(true)
                     it.selectAll()
                 }
+            }
+
+            "messages.work_hours_start", "messages.work_hours_end" -> {
+                val pref = preference as EditTextPreference
+                val currentText = pref.text ?: "09:00"
+                val parts = currentText.split(":")
+                val hour = parts.getOrNull(0)?.toIntOrNull()?.coerceIn(0, 23) ?: 9
+                val minute = parts.getOrNull(1)?.toIntOrNull()?.coerceIn(0, 59) ?: 0
+
+                TimePickerDialog(
+                    requireContext(),
+                    { _, h, m ->
+                        pref.text = String.format(java.util.Locale.US, "%02d:%02d", h, m)
+                    },
+                    hour,
+                    minute,
+                    true
+                ).show()
+                return
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,4 +181,9 @@
     <string name="language">Language</string>
     <string name="language_system">System default</string>
     <string name="password_must_not_be_empty">Password must not be empty</string>
+    <string name="working_hours">Working Hours</string>
+    <string name="working_hours_enable">Enable working hours</string>
+    <string name="working_hours_summary">Only send messages within the defined time window</string>
+    <string name="working_hours_start">Start time</string>
+    <string name="working_hours_end">End time</string>
 </resources>

--- a/app/src/main/res/xml/messages_preferences.xml
+++ b/app/src/main/res/xml/messages_preferences.xml
@@ -59,4 +59,27 @@
             app:title="@string/messages_count"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
+
+    <PreferenceCategory app:title="@string/working_hours">
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="messages.work_hours_enabled"
+            app:icon="@drawable/ic_timer"
+            app:title="@string/working_hours_enable"
+            app:summary="@string/working_hours_summary" />
+        <EditTextPreference
+            android:defaultValue="09:00"
+            android:key="messages.work_hours_start"
+            app:icon="@drawable/ic_timer"
+            app:title="@string/working_hours_start"
+            app:useSimpleSummaryProvider="true"
+            android:dependency="messages.work_hours_enabled" />
+        <EditTextPreference
+            android:defaultValue="19:00"
+            android:key="messages.work_hours_end"
+            app:icon="@drawable/ic_timer"
+            app:title="@string/working_hours_end"
+            app:useSimpleSummaryProvider="true"
+            android:dependency="messages.work_hours_enabled" />
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable **Working Hours** scheduling (default **09:00–19:00**) with an enable toggle and start/end time settings.
  * Added a time-picker UI for **Working Hours** start/end; values are saved and validated.
* **Behavior Updates**
  * **Non-expedited** messages are now limited to the configured window (including **wrap-around** past midnight) and resume at the **next** start time.
  * **Expedited** messages remain **unconstrained**.
  * When **start == end**, the window is treated as **always active**.
* **Documentation**
  * Updated README to mention working-hours scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a configurable "Working Hours" scheduling feature that restricts non-expedited message delivery to a user-defined daily time window (default 09:00–19:00), with wrap-around support (e.g., 22:00–06:00). Expedited messages remain unconstrained.

- `MessagesSettings` gains `workHoursEnabled`, `workHoursStart`, `workHoursEnd` properties backed by `PreferencesStorage`, plus `isInWorkHours()` and `nextWorkHoursStart()` helpers used both at enqueue time and inside the processing loop.
- `MessagesService.sendPendingMessages()` calls the new `applyWorkHoursLimit()` suspend function before each non-expedited message; the function computes the delay, re-schedules the worker at the next work-hours boundary (via `SendMessagesWorker.start` with REPLACE), then suspends until that time.
- The settings UI replaces the `EditTextPreference` dialog for the start/end fields with a `TimePickerDialog`, and the XML adds a `PreferenceCategory` with a `SwitchPreference` plus two `EditTextPreference` fields gated by the switch's dependency.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the work hours feature is correctly isolated behind a disabled-by-default toggle, and all critical paths (expedited messages, export/import, UI persistence) work as intended.

The core time logic in isInWorkHours() and nextWorkHoursStart() handles all cases correctly: normal windows, wrap-around windows, and the start==end always-active edge case. applyWorkHoursLimit() acts as a reliable runtime safety net inside the processing loop. Boolean storage for work_hours_enabled passes the value directly to PreferencesStorage.set() dispatching to putBoolean(), so the SwitchPreference and getFallback() read-back both work correctly.

**Files Needing Attention:** MessagesSettings.kt and MessagesService.kt carry the non-trivial scheduling logic and are the files most worth a second read, but no blocking issues were found.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesSettings.kt | Adds workHoursEnabled/Start/End properties, isInWorkHours(), nextWorkHoursStart(), and import/export support. Core time logic is correct; isValidTimeFormat() is called twice in the import handler for START/END (redundant post-throw check, flagged in previous review). |
| app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt | Adds applyWorkHoursLimit() and integrates work-hours logic into enqueueMessage() and sendPendingMessages(). The startTime calculation correctly defers scheduling to applyWorkHoursLimit() when no prior scheduled work exists. |
| app/src/main/java/me/capcom/smsgateway/ui/settings/MessagesSettingsFragment.kt | Intercepts onDisplayPreferenceDialog for work_hours_start/end to show a TimePickerDialog instead of the plain EditText; setting pref.text directly persists correctly via EditTextPreference. |
| app/src/main/res/xml/messages_preferences.xml | Adds a Working Hours PreferenceCategory with SwitchPreference and two EditTextPreference fields gated by android:dependency. Keys align with the messages. prefix used by PreferencesStorage. |
| app/src/main/res/values/strings.xml | Adds five string resources for the Working Hours UI; missing trailing newline is a pre-existing formatting issue. |
| README.md | One-line addition advertising the working-hours scheduling feature in the feature list. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant MessagesService
    participant MessagesSettings
    participant SendMessagesWorker
    participant DB

    Client->>MessagesService: enqueueMessage(request)
    MessagesService->>DB: enqueue(request)
    MessagesService->>MessagesSettings: nextWorkHoursStart()
    MessagesSettings-->>MessagesService: workHoursStart (null if in hours or disabled)
    note over MessagesService: Compute startTime
    MessagesService->>SendMessagesWorker: start(context, force, startTime)

    SendMessagesWorker->>MessagesService: sendPendingMessages()
    loop for each pending message
        MessagesService->>MessagesSettings: nextWorkHoursStart()
        alt non-expedited and outside work hours
            MessagesSettings-->>MessagesService: nextStart (future timestamp)
            MessagesService->>SendMessagesWorker: start(context, true, nextStart)
            note over MessagesService: delay until work hours
        else in work hours or expedited
            MessagesSettings-->>MessagesService: null
            MessagesService->>MessagesService: sendMessage()
        end
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["\[messages\] add work hours support"](https://github.com/capcom6/android-sms-gateway/commit/16c84dc2a0deca560437b6288bed55345af3df3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46602666)</sub>

<!-- /greptile_comment -->