### PR TITLE
[ui] improve start/stop button

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt
@@ -5,6 +5,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.pm.PackageManager
+import android.content.res.ColorStateList
 import android.os.Build
 import android.os.Bundle
 import android.text.Html
@@ -63,8 +64,7 @@ class HomeFragment : Fragment() {
         super.onCreate(savedInstanceState)
 
         setFragmentResultListener(FirstStartDialogFragment.REQUEST_KEY) { _, data ->
-            val result = FirstStartDialogFragment.getResult(data)
-            when (result) {
+            when (FirstStartDialogFragment.getResult(data)) {
                 FirstStartDialogFragment.Result.Canceled -> {
                     Toast.makeText(
                         requireContext(),
@@ -72,7 +72,6 @@ class HomeFragment : Fragment() {
                         Toast.LENGTH_SHORT
                     )
                         .show()
-                    binding.buttonStart.isChecked = false
                     return@setFragmentResultListener
                 }
 
@@ -164,7 +163,8 @@ class HomeFragment : Fragment() {
         }
 
         binding.buttonStart.setOnClickListener {
-            actionStart(binding.buttonStart.isChecked)
+            val isRunning = stateLiveData.value ?: false
+            actionStart(!isRunning)
         }
 
 //        if (settingsHelper.autostart) {
@@ -278,8 +278,19 @@ class HomeFragment : Fragment() {
             }
         }
 
-        stateLiveData.observe(viewLifecycleOwner) {
-            binding.buttonStart.isChecked = it
+        stateLiveData.observe(viewLifecycleOwner) { isRunning ->
+            binding.buttonStart.apply {
+                text = getString(
+                    if (isRunning) R.string.button_stop_service
+                    else R.string.button_start_service
+                )
+                backgroundTintList = ColorStateList.valueOf(
+                    ContextCompat.getColor(
+                        requireContext(),
+                        if (isRunning) R.color.red_800 else R.color.grey_700
+                    )
+                )
+            }
         }
 
         connectionService.status.observe(viewLifecycleOwner) {
@@ -435,6 +446,7 @@ class HomeFragment : Fragment() {
             }
         }
     }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     tools:context=".ui.HomeFragment">
 
@@ -56,14 +56,14 @@
                         android:id="@+id/headerLocalServer"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
                         android:ellipsize="end"
                         android:lines="1"
-                        android:layout_marginStart="8dp"
                         android:text="@string/settings_local_server"
                         android:textAppearance="@style/TextAppearance.AppCompat.Headline"
                         app:layout_constraintBottom_toBottomOf="@id/imageLocalServer"
-                        app:layout_constraintStart_toEndOf="@id/imageLocalServer"
                         app:layout_constraintEnd_toStartOf="@+id/switchUseLocalServer"
+                        app:layout_constraintStart_toEndOf="@id/imageLocalServer"
                         app:layout_constraintTop_toTopOf="@id/imageLocalServer" />
 
                     <androidx.appcompat.widget.SwitchCompat
@@ -82,10 +82,10 @@
                         android:layout_marginStart="4dp"
                         android:columnCount="2"
                         android:visibility="gone"
-                        tools:visibility="visible"
                         app:layout_constraintEnd_toEndOf="@+id/switchUseLocalServer"
                         app:layout_constraintStart_toEndOf="@id/imageLocalServer"
-                        app:layout_constraintTop_toBottomOf="@id/headerLocalServer">
+                        app:layout_constraintTop_toBottomOf="@id/headerLocalServer"
+                        tools:visibility="visible">
 
                         <TextView
                             style="@style/HomeCardLabel"
@@ -162,14 +162,14 @@
                         android:id="@+id/headerRemoteServer"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
+                        android:layout_margin="8dp"
                         android:ellipsize="end"
                         android:lines="1"
-                        android:layout_margin="8dp"
                         android:text="@string/cloud_server"
                         android:textAppearance="@style/TextAppearance.AppCompat.Headline"
                         app:layout_constraintBottom_toBottomOf="@id/imageRemoteServer"
-                        app:layout_constraintStart_toEndOf="@id/imageRemoteServer"
                         app:layout_constraintEnd_toStartOf="@+id/switchUseRemoteServer"
+                        app:layout_constraintStart_toEndOf="@id/imageRemoteServer"
                         app:layout_constraintTop_toTopOf="@id/imageRemoteServer" />
 
                     <androidx.appcompat.widget.SwitchCompat
@@ -188,10 +188,10 @@
                         android:layout_marginStart="4dp"
                         android:columnCount="2"
                         android:visibility="gone"
-                        tools:visibility="visible"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toEndOf="@id/imageRemoteServer"
-                        app:layout_constraintTop_toBottomOf="@id/headerRemoteServer">
+                        app:layout_constraintTop_toBottomOf="@id/headerRemoteServer"
+                        tools:visibility="visible">
 
 
                         <TextView
@@ -251,10 +251,12 @@
         android:layout_width="match_parent"
         android:layout_height="8dp" />
 
-    <ToggleButton
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonStart"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textOff="@string/settings_offline"
-        android:textOn="@string/settings_online" />
+        android:layout_margin="8dp"
+        android:backgroundTint="@color/grey_700"
+        android:text="@string/button_start_service"
+        app:cornerRadius="8dp" />
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="black">#FF000000</color>
+    <color name="grey_700">#FF616161</color>
+    <color name="progressBarOverlay">#33FFFFFF</color>
     <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>
     <color name="purple_700">#FF3700B3</color>
+    <color name="red_800">#FFD32F2F</color>
     <color name="teal_200">#FF03DAC5</color>
     <color name="teal_700">#FF018786</color>
-    <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="progressBarOverlay">#33FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,8 @@
     <string name="settings_local_address_is" translatable="false">&lt;a href>%1$s:%2$d&lt;/a></string>
     <string name="settings_local_address_not_found">Not available</string>
     <string name="settings_local_server">Local server</string>
+    <string name="button_start_service">Start Service</string>
+    <string name="button_stop_service">Stop Service</string>
     <string name="settings_offline">Offline</string>
     <string name="settings_online">Online</string>
     <string name="settings_public_address_is" translatable="false">&lt;a href>%1$s:%2$d&lt;/a></string>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Start/Stop control now reflects the actual service running state by syncing from live status (instead of the previous checked state).
* **UI Updates**
  * Replaced the Start/Stop ToggleButton with a MaterialButton.
  * Button label and background tint now update dynamically (green when running, grey when stopped).
* **Resource Updates**
  * Added new colors for running/non-running states.
  * Added “Start Service” and “Stop Service” labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the `ToggleButton` start/stop control with a `MaterialButton` whose label ("Start Service" / "Stop Service") and background tint (grey / red-800) are driven entirely by `stateLiveData`, which reflects the actual running state of the gateway and local-server services.

- The click handler now reads `stateLiveData.value ?: false` to determine current state and inverts it, eliminating the previous reliance on the button's own checked state — which could fall out of sync with the real service state.
- Dead code (`binding.buttonStart.isChecked = false`, only meaningful for a ToggleButton) has been cleaned up alongside the widget replacement.
- Two new color resources (`grey_700`, `red_800`) and two new string resources (`button_start_service`, `button_stop_service`) support the dynamic button appearance.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the change correctly decouples button visual state from the widget's own checked state and ties it to the actual service LiveData.
- The button click handler and LiveData observer are straightforward and correctly implemented. The `?: false` default for a null LiveData value is intentional and safe. The replaced ToggleButton dead code is properly cleaned up. New color resources pass WCAG AA contrast requirements against white text.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt | Button click handler and LiveData observer updated to drive state from `stateLiveData` instead of the widget's own checked state; dead ToggleButton code removed. Logic is correct. |
| app/src/main/res/layout/fragment_home.xml | ToggleButton replaced with MaterialButton; cosmetic XML attribute reordering with no functional impact. |
| app/src/main/res/values/colors.xml | Added `grey_700` (#616161) and `red_800` (#D32F2F) for stopped/running button states. Both colours provide sufficient contrast against white text (≥ 4.5:1). |
| app/src/main/res/values/strings.xml | Added `button_start_service` and `button_stop_service` string resources for the new button labels. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User taps buttonStart]) --> B[Read stateLiveData.value]
    B --> C{value is null?}
    C -- yes --> D[assume isRunning = false]
    C -- no --> E[use actual isRunning]
    D --> F[actionStart true]
    E --> G{isRunning?}
    G -- true --> H[actionStart false → stop]
    G -- false --> F

    F --> I{Gateway enabled\nbut not registered?}
    I -- yes --> J[cloudFirstStart dialog]
    I -- no --> K[requestPermissionsAndStart]
    H --> L[orchestratorSvc.stop]

    M([stateLiveData emits]) --> N[Update button text\nStart Service / Stop Service]
    M --> O[Update backgroundTintList\ngrey_700 / red_800]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["\[ui\] improve start/stop button"](https://github.com/capcom6/android-sms-gateway/commit/7a095803a9329958cc260bd56f4cdf5448431193) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46602665)</sub>

<!-- /greptile_comment -->