### PR TITLE
[receiver] include date in message ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
-### Changed
+- SMS Receiver settings section with Content Provider Monitoring toggle to disable fallback content observer
 
 ### Fixed
+- Duplicate SMS detection when a message arrives via both broadcast receiver and content observer — use `DATE_SENT` instead of `DATE` in both paths so timestamps match consistently
+- Export (`POST /messages/inbox/export`) no longer produces duplicates of messages already received via broadcast
 
 ## [v1.66.1] - 2026-06-24
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
@@ -200,19 +200,19 @@ class ReceiverService : KoinComponent {
         val projection = mutableListOf(
             Telephony.Sms._ID,
             Telephony.Sms.ADDRESS,
-            Telephony.Sms.DATE,
+            Telephony.Sms.DATE_SENT,
             Telephony.Sms.BODY,
         )
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
             projection += Telephony.Sms.SUBSCRIPTION_ID
         }
 
-        val selection = "${Telephony.Sms.DATE} >= ? AND ${Telephony.Sms.DATE} <= ?"
+        val selection = "${Telephony.Sms.DATE_SENT} >= ? AND ${Telephony.Sms.DATE_SENT} <= ?"
         val selectionArgs = arrayOf(
             period.first.time.toString(),
             period.second.time.toString()
         )
-        val sortOrder = Telephony.Sms.DATE
+        val sortOrder = Telephony.Sms.DATE_SENT
 
         val contentResolver = context.contentResolver
         val cursor = contentResolver.query(

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
@@ -25,6 +25,7 @@ class ReceiverService : KoinComponent {
     private val webHooksService: WebHooksService by inject()
     private val logsService: LogsService by inject()
     private val incomingMessagesService: IncomingMessagesService by inject()
+    private val receiverSettings: ReceiverSettings by inject()
 
     private val eventsReceiver by lazy { EventsReceiver() }
     private val mmsContentObserver by lazy { MmsContentObserver() }
@@ -35,7 +36,9 @@ class ReceiverService : KoinComponent {
         MmsReceiver.register(context)
         eventsReceiver.start()
         mmsContentObserver.start()
-        smsContentObserver.start()
+        if (receiverSettings.contentProviderEnabled) {
+            smsContentObserver.start()
+        }
     }
 
     fun stop(context: Context) {

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverSettings.kt
@@ -1,0 +1,16 @@
+package me.capcom.smsgateway.modules.receiver
+
+import me.capcom.smsgateway.modules.settings.KeyValueStorage
+import me.capcom.smsgateway.modules.settings.get
+
+class ReceiverSettings(
+    private val storage: KeyValueStorage,
+) {
+    var contentProviderEnabled: Boolean
+        get() = storage.get<Boolean>(CONTENT_PROVIDER_ENABLED) ?: true
+        set(value) = storage.set(CONTENT_PROVIDER_ENABLED, value)
+
+    companion object {
+        private const val CONTENT_PROVIDER_ENABLED = "content_provider_enabled"
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/SmsContentObserver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/SmsContentObserver.kt
@@ -130,7 +130,7 @@ class SmsContentObserver : KoinComponent {
         val projection = mutableListOf(
             Telephony.Sms._ID,
             Telephony.Sms.ADDRESS,
-            Telephony.Sms.DATE,
+            Telephony.Sms.DATE_SENT,
             Telephony.Sms.BODY,
         )
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/data/InboxMessage.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/data/InboxMessage.kt
@@ -80,10 +80,14 @@ sealed class InboxMessage(
         if (other !is InboxMessage) return false
 
         if (address != other.address) return false
+        if (date != other.date) return false
         return subscriptionId == other.subscriptionId
     }
 
     override fun hashCode(): Int {
-        return 31 * address.hashCode() + subscriptionId.hashCode()
+        var result = address.hashCode()
+        result = 31 * result + date.hashCode()
+        result = 31 * result + (subscriptionId ?: 0)
+        return result
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/settings/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/settings/Module.kt
@@ -8,6 +8,7 @@ import me.capcom.smsgateway.modules.localserver.LocalServerSettings
 import me.capcom.smsgateway.modules.logs.LogsSettings
 import me.capcom.smsgateway.modules.messages.MessagesSettings
 import me.capcom.smsgateway.modules.ping.PingSettings
+import me.capcom.smsgateway.modules.receiver.ReceiverSettings
 import me.capcom.smsgateway.modules.receiver.StateStorage
 import me.capcom.smsgateway.modules.webhooks.TemporaryStorage
 import me.capcom.smsgateway.modules.webhooks.WebhooksSettings
@@ -58,6 +59,11 @@ val settingsModule = module {
     single {
         TemporaryStorage(
             PreferencesStorage(get(), "webhooks")
+        )
+    }
+    factory {
+        ReceiverSettings(
+            PreferencesStorage(get(), "receiver")
         )
     }
     single {

--- a/app/src/main/java/me/capcom/smsgateway/ui/settings/ReceiverSettingsFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/settings/ReceiverSettingsFragment.kt
@@ -1,0 +1,10 @@
+package me.capcom.smsgateway.ui.settings
+
+import android.os.Bundle
+import me.capcom.smsgateway.R
+
+class ReceiverSettingsFragment : BasePreferenceFragment() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.receiver_preferences, rootKey)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,6 +146,11 @@
     </plurals>
     <string name="processing">Processing</string>
     <string name="processing_order_title">Processing order</string>
+    <string name="receiver">Receiver</string>
+    <string name="receiver_summary">Content provider monitoring, fallback, etc.</string>
+    <string name="receiver_content_provider_monitoring">Content Provider Monitoring</string>
+    <string name="receiver_content_provider_monitoring_summary">Also detect incoming SMS via content
+        provider</string>
     <string name="queue_status">📊 Queue Status</string>
     <string name="total_messages">Total: %1$d</string>
     <string name="pending_messages">Pending: %1$d</string>

--- a/app/src/main/res/xml/receiver_preferences.xml
+++ b/app/src/main/res/xml/receiver_preferences.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <PreferenceCategory app:title="@string/receiver">
+        <SwitchPreference
+            android:defaultValue="true"
+            android:icon="@drawable/ic_advanced"
+            android:key="receiver.content_provider_enabled"
+            app:summary="@string/receiver_content_provider_monitoring_summary"
+            app:title="@string/receiver_content_provider_monitoring" />
+    </PreferenceCategory>
+</androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -18,6 +18,12 @@
         app:summary="@string/delays_limits_etc" />
 
     <Preference
+        android:icon="@drawable/ic_sms"
+        app:fragment="me.capcom.smsgateway.ui.settings.ReceiverSettingsFragment"
+        app:summary="@string/receiver_summary"
+        app:title="@string/receiver" />
+
+    <Preference
         android:icon="@drawable/ic_webhook"
         app:fragment="me.capcom.smsgateway.ui.settings.WebhooksSettingsFragment"
         app:summary="@string/retries_signing_etc"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Receiver” settings screen with a toggle to enable or disable content-provider monitoring.
* **Bug Fixes**
  * Improved inbox message matching by considering message date when comparing entries.
  * Updated SMS handling to consistently use “date sent” for ordering and export/query results, reducing duplicate detections/exports.
* **Configuration / UI**
  * Added localized Receiver strings and added the Receiver settings entry to the root preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->