### PR TITLE
[inbox] ordered batch webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.70.3] - 2026-08-11
 
-### Added
-- SMS Receiver settings section with Content Provider Monitoring toggle to disable fallback content observer
+### Changed
+- Process sent/delivered broadcasts asynchronously so message status updates aren't dropped [b08ebe6]
+
+## [v1.70.2] - 2026-08-08
+
+### Changed
+- Improve start/stop button [89c5635]
+
+## [v1.70.1] - 2026-08-06
 
 ### Fixed
-- Duplicate SMS detection when a message arrives via both broadcast receiver and content observer — use `DATE_SENT` instead of `DATE` in both paths so timestamps match consistently
-- Export (`POST /messages/inbox/export`) no longer produces duplicates of messages already received via broadcast
+- Sent message status updates no longer dropped when the broadcast is missing a URI extra [1575024]
+
+## [v1.70.0] - 2026-08-05
+
+### Changed
+- Periodically clean up incoming messages [697ec79]
+
+## [v1.69.0] - 2026-08-03
+
+### Added
+- Work hours support for outgoing messages [4bb53ab]
+
+## [v1.68.0] - 2026-07-14
+
+### Added
+- Incoming MMS attachments support [0cdc5d8]
+
+### Changed
+- Delay MMS parsing until download completes [90d16d9]
+
+## [v1.67.0] - 2026-07-08
+
+### Added
+- `sms:cancelled` webhook event [cd6c30a]
+- Ability to cancel pending messages [3820815]
+- Per 30 minutes sending limit option [11580ad]
+- SMS Receiver settings section with Content Provider Monitoring toggle to disable fallback content observer [d682d6f]
+
+### Fixed
+- Duplicate SMS detection when a message arrives via both broadcast receiver and content observer — use `DATE_SENT` instead of `DATE` in both paths so timestamps match consistently [89bf4f5]
+- Export (`POST /messages/inbox/export`) no longer produces duplicates of messages already received via broadcast [64ce33b]
 
 ## [v1.66.1] - 2026-06-24
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ SMS Gateway turns your Android smartphone into an SMS gateway. It's a lightweigh
 - 🔔 **Real-time incoming message notifications:** Receive instant SMS and MMS notifications via webhooks.
 - 📖 **Read received messages:** Access [previously received messages](https://docs.sms-gate.app/features/reading-messages/) via the same webhooks used for real-time notifications.
 - 📎 **MMS download notifications:** Receive webhook notifications when MMS messages are fully downloaded, including message body and attachments.
+- 📦 **Batch webhook events:** Receive batched webhook deliveries when multiple messages arrive at once, reducing the number of requests.
+- 🛑 **Cancel pending messages:** Cancel queued messages before they are sent.
+- ⏳ **Send rate limiting:** Restrict the number of messages sent per period (e.g., per 30 minutes) to avoid operator throttling.
 
 🔒 Security and Privacy:
 
@@ -105,7 +108,7 @@ SMS Gateway turns your Android smartphone into an SMS gateway. It's a lightweigh
 
 - 💳 **Multiple SIM card support:** Supports devices with [multiple SIM cards](https://docs.sms-gate.app/features/multi-sim/).
 - 📱📱 **Multiple device support:** Connect [multiple devices](https://docs.sms-gate.app/features/multi-device/) to the same account with Cloud or Private server. Messages sent via the server are distributed across all connected devices.
-- 💾 **Data SMS support:** Send and receive binary [data payloads](https://docs.sms-gate.app/features/data-sms.md) via SMS for IoT commands, encrypted messages, and other specialized use cases.
+- 💾 **Data SMS support:** Send and receive binary [data payloads](https://docs.sms-gate.app/features/data-sms/) via SMS for IoT commands, encrypted messages, and other specialized use cases.
 - 🕐 **Working hours scheduling:** Restrict message delivery to configurable time windows, automatically pausing the queue outside of them
 
 🔌 Integration:
@@ -208,6 +211,8 @@ This mode is ideal for sending messages from a local network.
       send --phones '+19162255887,+19162255888' 'Hello, doctors!'
     ```
 
+The full API reference is available as interactive Swagger documentation at `http://<device_local_ip>:8080/docs`.
+
 ### Cloud Server
 
 <div align="center">
@@ -244,16 +249,22 @@ Use webhooks to receive notifications for messaging events (e.g., incoming SMS a
 
 #### Supported Events
 
-| Event               | Description                                                                 |
-| ------------------- | --------------------------------------------------------------------------- |
-| `sms:received`      | Triggered when an SMS message is received                                   |
-| `sms:sent`          | Triggered when an SMS message is sent                                       |
-| `sms:delivered`     | Triggered when an SMS message is delivered                                  |
-| `sms:failed`        | Triggered when an SMS message fails to send                                 |
-| `sms:data-received` | Triggered when a data SMS is received                                       |
-| `mms:received`      | Triggered when an MMS notification is received (before download)            |
-| `mms:downloaded`    | Triggered when an MMS message is fully downloaded with body and attachments |
-| `system:ping`       | Periodic heartbeat event                                                    |
+| Event                     | Description                                                                 |
+| ------------------------- | --------------------------------------------------------------------------- |
+| `sms:received`            | Triggered when an SMS message is received                                   |
+| `sms:batch:received`      | Triggered when multiple SMS messages are received at once (batched)         |
+| `sms:sent`                | Triggered when an SMS message is sent                                       |
+| `sms:delivered`           | Triggered when an SMS message is delivered                                  |
+| `sms:failed`              | Triggered when an SMS message fails to send                                 |
+| `sms:cancelled`           | Triggered when a pending SMS message is cancelled                           |
+| `sms:data-received`       | Triggered when a data SMS is received                                       |
+| `sms:batch:data-received` | Triggered when multiple data SMS messages are received at once (batched)    |
+| `mms:received`            | Triggered when an MMS notification is received (before download)            |
+| `mms:batch:received`      | Triggered when multiple MMS notifications are received at once (batched)    |
+| `mms:downloaded`          | Triggered when an MMS message is fully downloaded with body and attachments |
+| `mms:batch:downloaded`    | Triggered when multiple MMS messages are fully downloaded (batched)         |
+| `app:started`             | Triggered when the app is started, with the list of active SIM cards        |
+| `system:ping`             | Periodic heartbeat event                                                    |
 
 #### Setting Up Webhooks
 
@@ -308,7 +319,7 @@ For cloud mode the process is similar, simply change the URL to https://api.sms-
 - [x] Send notifications to an external server when the status of a message changes.
 - [ ] Incorporate scheduling capabilities for dispatching messages at specific times.
 - [ ] Implement region-based restrictions to prevent international SMS.
-- [ ] Provide an API endpoint to retrieve the list of available SIM cards on the device.
+- [x] Provide an API endpoint to retrieve the list of available SIM cards on the device.
 - [x] Include detailed error messages in responses and logs.
 
 See the [open issues](https://github.com/capcom6/android-sms-gateway/issues) for a full list of proposed features (and known issues).

--- a/app/src/main/assets/api/swagger.json
+++ b/app/src/main/assets/api/swagger.json
@@ -235,32 +235,39 @@
       "smsgateway.Device": {
         "properties": {
           "createdAt": {
-            "description": "Created at (read only)",
+            "description": "Time at which the device was created, read only.",
             "example": "2020-01-01T00:00:00Z",
             "type": "string"
           },
           "deletedAt": {
-            "description": "Deleted at (read only)",
+            "description": "Time at which the device was deleted, read only.",
             "example": "2020-01-01T00:00:00Z",
             "type": "string"
           },
           "id": {
-            "description": "ID",
+            "description": "Device ID, read only.",
             "example": "PyDmBQZZXYmyxMwED8Fzy",
             "type": "string"
           },
           "lastSeen": {
-            "description": "Last seen at (read only)",
+            "description": "Time at which the device was last seen, read only.",
             "example": "2020-01-01T00:00:00Z",
             "type": "string"
           },
           "name": {
-            "description": "Name",
+            "description": "Device name.",
             "example": "My Device",
             "type": "string"
           },
+          "simCards": {
+            "description": "List of SIM cards in the device.",
+            "items": {
+              "$ref": "#/components/schemas/smsgateway.SimCard"
+            },
+            "type": "array"
+          },
           "updatedAt": {
-            "description": "Updated at (read only)",
+            "description": "Time at which the device was last updated, read only.",
             "example": "2020-01-01T00:00:00Z",
             "type": "string"
           }
@@ -540,7 +547,7 @@
             "type": "string"
           },
           "triggerWebhooks": {
-            "description": "Indicates whether to trigger webhooks for the refreshed messages.",
+            "description": "Deprecated: use WebhookDelivery instead. Indicates whether to trigger webhooks for the refreshed messages.",
             "example": true,
             "type": "boolean"
           },
@@ -549,6 +556,16 @@
             "example": "2024-01-01T23:59:59Z",
             "format": "date-time",
             "type": "string"
+          },
+          "webhookDelivery": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/smsgateway.WebhookDelivery"
+              }
+            ],
+            "description": "Delivery mode for webhooks (overrides triggerWebhooks when set).",
+            "example": "Batch",
+            "type": "object"
           }
         },
         "required": [
@@ -679,6 +696,7 @@
           "inbox:read",
           "inbox:refresh",
           "logs:read",
+          "messages:cancel",
           "messages:send",
           "messages:read",
           "messages:list",
@@ -698,6 +716,7 @@
           "ScopeInboxRead",
           "ScopeInboxRefresh",
           "ScopeLogsRead",
+          "ScopeMessagesCancel",
           "ScopeMessagesSend",
           "ScopeMessagesRead",
           "ScopeMessagesList",
@@ -714,6 +733,7 @@
         "enum": [
           "Disabled",
           "PerMinute",
+          "Per30Minutes",
           "PerHour",
           "PerDay"
         ],
@@ -721,6 +741,7 @@
         "x-enum-varnames": [
           "Disabled",
           "PerMinute",
+          "Per30Minutes",
           "PerHour",
           "PerDay"
         ]
@@ -1003,6 +1024,8 @@
       "smsgateway.ProcessingState": {
         "enum": [
           "Pending",
+          "Cancelling",
+          "Cancelled",
           "Processed",
           "Sent",
           "Delivered",
@@ -1010,6 +1033,8 @@
         ],
         "type": "string",
         "x-enum-comments": {
+          "ProcessingStateCancelled": "Cancelled",
+          "ProcessingStateCancelling": "Cancelling (cancellation requested)",
           "ProcessingStateDelivered": "Delivered",
           "ProcessingStateFailed": "Failed",
           "ProcessingStatePending": "Pending",
@@ -1018,6 +1043,8 @@
         },
         "x-enum-descriptions": [
           "Pending",
+          "Cancelling (cancellation requested)",
+          "Cancelled",
           "Processed (received by device)",
           "Sent",
           "Delivered",
@@ -1025,6 +1052,8 @@
         ],
         "x-enum-varnames": [
           "ProcessingStatePending",
+          "ProcessingStateCancelling",
+          "ProcessingStateCancelled",
           "ProcessingStateProcessed",
           "ProcessingStateSent",
           "ProcessingStateDelivered",
@@ -1110,7 +1139,7 @@
                 "$ref": "#/components/schemas/smsgateway.LimitPeriod"
               }
             ],
-            "description": "LimitPeriod defines the period for message sending limits.\nValid values are \"Disabled\", \"PerMinute\", \"PerHour\", or \"PerDay\".",
+            "description": "LimitPeriod defines the period for message sending limits.\nValid values are \"Disabled\", \"PerMinute\", \"Per30Minutes\", \"PerHour\", or \"PerDay\".",
             "type": "object"
           },
           "limit_value": {
@@ -1150,6 +1179,18 @@
             ],
             "description": "SimSelectionMode defines how SIM cards are selected for sending messages.\nValid values are \"OSDefault\", \"RoundRobin\", or \"Random\".",
             "type": "object"
+          },
+          "work_hours_enabled": {
+            "description": "WorkHoursEnabled enables restricting message delivery to a configurable time window.",
+            "type": "boolean"
+          },
+          "work_hours_end": {
+            "description": "WorkHoursEnd is the end of the working hours window in HH:mm format (24-hour).",
+            "type": "string"
+          },
+          "work_hours_start": {
+            "description": "WorkHoursStart is the start of the working hours window in HH:mm format (24-hour).",
+            "type": "string"
           }
         },
         "type": "object"
@@ -1178,6 +1219,31 @@
           "signing_key": {
             "description": "SigningKey is the secret key used for signing webhook payloads. Must not be used with Cloud Server.",
             "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "smsgateway.SimCard": {
+        "properties": {
+          "carrierName": {
+            "description": "Carrier/network operator name (may be null).",
+            "type": "string"
+          },
+          "iccid": {
+            "description": "Integrated Circuit Card Identifier (may be null).",
+            "type": "string"
+          },
+          "phoneNumber": {
+            "description": "Phone number associated with the SIM.",
+            "type": "string"
+          },
+          "simNumber": {
+            "description": "1-based slot number (1, 2, or 3).",
+            "type": "integer"
+          },
+          "slotIndex": {
+            "description": "0-based physical slot index.",
+            "type": "integer"
           }
         },
         "type": "object"
@@ -1292,6 +1358,29 @@
         ],
         "type": "object"
       },
+      "smsgateway.WebhookDelivery": {
+        "enum": [
+          "Disabled",
+          "Individual",
+          "Batch"
+        ],
+        "type": "string",
+        "x-enum-comments": {
+          "WebhookDeliveryBatch": "Deliver webhooks as ordered batches.",
+          "WebhookDeliveryDisabled": "Disable webhook delivery.",
+          "WebhookDeliveryIndividual": "Deliver webhooks individually (one per message)."
+        },
+        "x-enum-descriptions": [
+          "Disable webhook delivery.",
+          "Deliver webhooks individually (one per message).",
+          "Deliver webhooks as ordered batches."
+        ],
+        "x-enum-varnames": [
+          "WebhookDeliveryDisabled",
+          "WebhookDeliveryIndividual",
+          "WebhookDeliveryBatch"
+        ]
+      },
       "smsgateway.WebhookEvent": {
         "enum": [
           "sms:received",
@@ -1299,14 +1388,26 @@
           "sms:sent",
           "sms:delivered",
           "sms:failed",
+          "sms:cancelled",
           "system:ping",
           "mms:received",
-          "mms:downloaded"
+          "mms:downloaded",
+          "app:started",
+          "sms:batch:received",
+          "sms:batch:data-received",
+          "mms:batch:received",
+          "mms:batch:downloaded"
         ],
         "type": "string",
         "x-enum-comments": {
+          "WebhookEventAppStarted": "Triggered when the application is started.",
+          "WebhookEventMmsBatchDownloaded": "Triggered when a batch of MMS messages is downloaded.",
+          "WebhookEventMmsBatchReceived": "Triggered when a batch of MMS messages is received.",
           "WebhookEventMmsDownloaded": "Triggered when an MMS is downloaded.",
           "WebhookEventMmsReceived": "Triggered when an MMS is received.",
+          "WebhookEventSmsBatchDataReceived": "Triggered when a batch of data SMS messages is received.",
+          "WebhookEventSmsBatchReceived": "Triggered when a batch of SMS messages is received.",
+          "WebhookEventSmsCancelled": "Triggered when an SMS is cancelled.",
           "WebhookEventSmsDataReceived": "Triggered when a data SMS is received.",
           "WebhookEventSmsDelivered": "Triggered when an SMS is delivered.",
           "WebhookEventSmsFailed": "Triggered when an SMS processing fails.",
@@ -1320,9 +1421,15 @@
           "Triggered when an SMS is sent.",
           "Triggered when an SMS is delivered.",
           "Triggered when an SMS processing fails.",
+          "Triggered when an SMS is cancelled.",
           "Triggered when the device pings the server.",
           "Triggered when an MMS is received.",
-          "Triggered when an MMS is downloaded."
+          "Triggered when an MMS is downloaded.",
+          "Triggered when the application is started.",
+          "Triggered when a batch of SMS messages is received.",
+          "Triggered when a batch of data SMS messages is received.",
+          "Triggered when a batch of MMS messages is received.",
+          "Triggered when a batch of MMS messages is downloaded."
         ],
         "x-enum-varnames": [
           "WebhookEventSmsReceived",
@@ -1330,9 +1437,15 @@
           "WebhookEventSmsSent",
           "WebhookEventSmsDelivered",
           "WebhookEventSmsFailed",
+          "WebhookEventSmsCancelled",
           "WebhookEventSystemPing",
           "WebhookEventMmsReceived",
-          "WebhookEventMmsDownloaded"
+          "WebhookEventMmsDownloaded",
+          "WebhookEventAppStarted",
+          "WebhookEventSmsBatchReceived",
+          "WebhookEventSmsBatchDataReceived",
+          "WebhookEventMmsBatchReceived",
+          "WebhookEventMmsBatchDownloaded"
         ]
       },
       "SmsReceivedPayload": {
@@ -2274,7 +2387,7 @@
     },
     "/inbox/refresh": {
       "post": {
-        "description": "Refreshes inbox messages. Webhooks are triggered when triggerWebhooks is true.",
+        "description": "Refreshes inbox messages. Webhook triggering depends on the `webhookDelivery` parameter.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2714,6 +2827,95 @@
       }
     },
     "/messages/{id}": {
+      "delete": {
+        "description": "Cancels a pending message by ID. The message must be in Pending state.",
+        "parameters": [
+          {
+            "description": "Message ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/smsgateway.GetMessageResponse"
+                }
+              }
+            },
+            "description": "Message state after cancellation"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/smsgateway.ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/smsgateway.ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/smsgateway.ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/smsgateway.ErrorResponse"
+                }
+              }
+            },
+            "description": "Message not found"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/smsgateway.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "ApiAuth": []
+          },
+          {
+            "JWTAuth": []
+          }
+        ],
+        "summary": "Cancel message",
+        "tags": [
+          "User",
+          "Messages"
+        ]
+      },
       "get": {
         "description": "Returns message state by ID",
         "parameters": [

--- a/app/src/main/java/me/capcom/smsgateway/domain/WebhookDelivery.kt
+++ b/app/src/main/java/me/capcom/smsgateway/domain/WebhookDelivery.kt
@@ -1,0 +1,14 @@
+package me.capcom.smsgateway.domain
+
+import com.google.gson.annotations.SerializedName
+
+enum class WebhookDelivery {
+    @SerializedName("Disabled")
+    Disabled,
+
+    @SerializedName("Individual")
+    Individual,
+
+    @SerializedName("Batch")
+    Batch,
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/InboxRefreshRequest.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/InboxRefreshRequest.kt
@@ -1,5 +1,6 @@
 package me.capcom.smsgateway.modules.localserver.domain
 
+import me.capcom.smsgateway.domain.WebhookDelivery
 import me.capcom.smsgateway.modules.incoming.db.IncomingMessageType
 import java.util.Date
 
@@ -7,7 +8,9 @@ data class InboxRefreshRequest(
     val since: Date,
     val until: Date,
     val messageTypes: Set<IncomingMessageType>? = null,
+    @Deprecated("Replaced with webhookDelivery")
     val triggerWebhooks: Boolean? = null,
+    val webhookDelivery: WebhookDelivery? = null,
 ) {
     val period: Pair<Date, Date>
         get() = since to until

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/InboxRoutes.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/InboxRoutes.kt
@@ -12,6 +12,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import kotlinx.coroutines.CancellationException
+import me.capcom.smsgateway.domain.WebhookDelivery
 import me.capcom.smsgateway.helpers.DateTimeParser
 import me.capcom.smsgateway.modules.incoming.IncomingMessagesService
 import me.capcom.smsgateway.modules.incoming.db.IncomingMessage
@@ -197,7 +198,9 @@ class InboxRoutes(
                     context,
                     request.period,
                     request.messageTypes ?: setOf(IncomingMessageType.SMS),
-                    request.triggerWebhooks ?: false,
+                    request.webhookDelivery
+                        ?: (if (request.triggerWebhooks == true) WebhookDelivery.Individual else null)
+                        ?: WebhookDelivery.Disabled,
                 )
                 call.respond(HttpStatusCode.Accepted)
             } catch (e: CancellationException) {

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
@@ -16,6 +16,7 @@ import me.capcom.smsgateway.data.entities.MessageWithRecipients
 import me.capcom.smsgateway.domain.EntitySource
 import me.capcom.smsgateway.domain.MessageContent
 import me.capcom.smsgateway.domain.ProcessingState
+import me.capcom.smsgateway.domain.WebhookDelivery
 import me.capcom.smsgateway.helpers.DateTimeParser
 import me.capcom.smsgateway.modules.incoming.db.IncomingMessageType
 import me.capcom.smsgateway.modules.localserver.LocalServerSettings
@@ -259,7 +260,9 @@ class MessagesRoutes(
                     context = context,
                     period = request.period,
                     messageTypes = request.messageTypes ?: setOf(IncomingMessageType.SMS),
-                    triggerWebhooks = request.triggerWebhooks ?: true,
+                    request.webhookDelivery
+                        ?: (if (request.triggerWebhooks == false) WebhookDelivery.Disabled else null)
+                        ?: WebhookDelivery.Individual,
                 )
                 call.respond(HttpStatusCode.Accepted)
             } catch (e: Exception) {

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/EventsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/EventsReceiver.kt
@@ -23,7 +23,7 @@ class EventsReceiver : EventsReceiver() {
                         context = get(),
                         period = event.since to event.until,
                         messageTypes = event.messageTypes,
-                        triggerWebhooks = event.triggerWebhooks,
+                        webhookDelivery = event.webhookDelivery
                     )
                 }
             }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt
@@ -6,6 +6,7 @@ import android.provider.Telephony
 import android.util.Base64
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import me.capcom.smsgateway.domain.WebhookDelivery
 import me.capcom.smsgateway.helpers.SubscriptionsHelper
 import me.capcom.smsgateway.modules.incoming.IncomingMessagesService
 import me.capcom.smsgateway.modules.incoming.db.IncomingMessageType
@@ -14,8 +15,12 @@ import me.capcom.smsgateway.modules.logs.db.LogEntry
 import me.capcom.smsgateway.modules.receiver.data.InboxMessage
 import me.capcom.smsgateway.modules.webhooks.WebHooksService
 import me.capcom.smsgateway.modules.webhooks.domain.WebHookEvent
+import me.capcom.smsgateway.modules.webhooks.payload.MmsBatchDownloadedPayload
+import me.capcom.smsgateway.modules.webhooks.payload.MmsBatchReceivedPayload
 import me.capcom.smsgateway.modules.webhooks.payload.MmsDownloadedPayload
 import me.capcom.smsgateway.modules.webhooks.payload.MmsReceivedPayload
+import me.capcom.smsgateway.modules.webhooks.payload.SmsBatchReceivedPayload
+import me.capcom.smsgateway.modules.webhooks.payload.SmsDataBatchReceivedPayload
 import me.capcom.smsgateway.modules.webhooks.payload.SmsEventPayload
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -53,19 +58,35 @@ class ReceiverService : KoinComponent {
         context: Context,
         period: Pair<Date, Date>,
         messageTypes: Set<IncomingMessageType>,
-        triggerWebhooks: Boolean
+        webhookDelivery: WebhookDelivery,
     ) = withContext(Dispatchers.IO) {
         logsService.insert(
             LogEntry.Priority.DEBUG,
             MODULE_NAME,
             "ReceiverService::export - start",
-            mapOf("period" to period, "messageTypes" to messageTypes)
+            mapOf(
+                "period" to period,
+                "messageTypes" to messageTypes,
+                "webhookDelivery" to webhookDelivery.name
+            )
         )
 
-        select(context, period, messageTypes)
-            .forEach {
-                process(context, it, triggerWebhooks)
+        val messages = select(context, period, messageTypes)
+
+        when (webhookDelivery) {
+            WebhookDelivery.Batch -> {
+                val payloads = messages.mapNotNull { saveAndBuildPayload(context, it) }
+                emitBatchWebhooks(context, payloads)
             }
+
+            WebhookDelivery.Individual -> {
+                messages.forEach { process(context, it, triggerWebhooks = true) }
+            }
+
+            WebhookDelivery.Disabled -> {
+                messages.forEach { process(context, it, triggerWebhooks = false) }
+            }
+        }
 
         logsService.insert(
             LogEntry.Priority.DEBUG,
@@ -88,7 +109,25 @@ class ReceiverService : KoinComponent {
             )
         )
 
-        // Dedup safety net: skip if this exact message was already processed
+        val payload = saveAndBuildPayload(context, message)
+
+        if (payload != null && triggerWebhooks) {
+            webHooksService.emit(context, payload.first, payload.second)
+        }
+
+        if (payload != null) {
+            logsService.insert(
+                LogEntry.Priority.DEBUG,
+                MODULE_NAME,
+                "ReceiverService::process - message processed",
+            )
+        }
+    }
+
+    private fun saveAndBuildPayload(
+        context: Context,
+        message: InboxMessage
+    ): Pair<WebHookEvent, Any>? {
         if (incomingMessagesService.isMessageProcessed(message)) {
             logsService.insert(
                 LogEntry.Priority.DEBUG,
@@ -100,7 +139,7 @@ class ReceiverService : KoinComponent {
                     "subscriptionId" to message.subscriptionId,
                 )
             )
-            return
+            return null
         }
 
         val simSlotIndex = message.subscriptionId?.let {
@@ -113,66 +152,100 @@ class ReceiverService : KoinComponent {
 
         val incoming = incomingMessagesService.save(message)
 
-        if (triggerWebhooks) {
-            val (type, payload) = when (message) {
-                is InboxMessage.Text -> WebHookEvent.SmsReceived to SmsEventPayload.SmsReceived(
-                    messageId = message.hashCode().toUInt().toString(16),
-                    message = message.text,
-                    sender = incoming.sender,
-                    simNumber = simNumber,
-                    receivedAt = message.date,
-                    recipient = recipient,
-                )
+        return when (message) {
+            is InboxMessage.Text -> WebHookEvent.SmsReceived to SmsEventPayload.SmsReceived(
+                messageId = message.hashCode().toUInt().toString(16),
+                message = message.text,
+                sender = incoming.sender,
+                simNumber = simNumber,
+                receivedAt = message.date,
+                recipient = recipient,
+            )
 
-                is InboxMessage.Data -> WebHookEvent.SmsDataReceived to SmsEventPayload.SmsDataReceived(
-                    messageId = message.hashCode().toUInt().toString(16),
-                    data = Base64.encodeToString(message.data, Base64.NO_WRAP),
-                    simNumber = simNumber,
-                    receivedAt = message.date,
-                    sender = incoming.sender,
-                    recipient = recipient,
-                )
+            is InboxMessage.Data -> WebHookEvent.SmsDataReceived to SmsEventPayload.SmsDataReceived(
+                messageId = message.hashCode().toUInt().toString(16),
+                data = Base64.encodeToString(message.data, Base64.NO_WRAP),
+                simNumber = simNumber,
+                receivedAt = message.date,
+                sender = incoming.sender,
+                recipient = recipient,
+            )
 
-                is InboxMessage.MmsHeaders -> WebHookEvent.MmsReceived to MmsReceivedPayload(
-                    messageId = message.messageId ?: message.transactionId,
-                    simNumber = simNumber,
-                    transactionId = message.transactionId,
-                    subject = message.subject,
-                    size = message.size,
-                    contentClass = message.contentClass,
-                    receivedAt = message.date,
-                    sender = incoming.sender,
-                    recipient = recipient,
-                )
+            is InboxMessage.MmsHeaders -> WebHookEvent.MmsReceived to MmsReceivedPayload(
+                messageId = message.messageId ?: message.transactionId,
+                simNumber = simNumber,
+                transactionId = message.transactionId,
+                subject = message.subject,
+                size = message.size,
+                contentClass = message.contentClass,
+                receivedAt = message.date,
+                sender = incoming.sender,
+                recipient = recipient,
+            )
 
-                is InboxMessage.MMS -> WebHookEvent.MmsDownloaded to MmsDownloadedPayload(
-                    messageId = message.messageId,
-                    sender = incoming.sender,
-                    recipient = recipient,
-                    simNumber = simNumber,
-                    body = message.body,
-                    subject = message.subject,
-                    attachments = message.attachments.map {
-                        MmsDownloadedPayload.Attachment(
-                            partId = it.partId,
-                            contentType = it.contentType,
-                            name = it.name,
-                            size = it.size,
-                            data = it.data,
-                        )
-                    },
-                    receivedAt = message.date,
-                )
-            }
-
-            webHooksService.emit(context, type, payload)
+            is InboxMessage.MMS -> WebHookEvent.MmsDownloaded to MmsDownloadedPayload(
+                messageId = message.messageId,
+                sender = incoming.sender,
+                recipient = recipient,
+                simNumber = simNumber,
+                body = message.body,
+                subject = message.subject,
+                attachments = message.attachments.map {
+                    MmsDownloadedPayload.Attachment(
+                        partId = it.partId,
+                        contentType = it.contentType,
+                        name = it.name,
+                        size = it.size,
+                        data = it.data,
+                    )
+                },
+                receivedAt = message.date,
+            )
         }
+    }
 
-        logsService.insert(
-            LogEntry.Priority.DEBUG,
-            MODULE_NAME,
-            "ReceiverService::process - message processed",
-        )
+    private fun emitBatchWebhooks(
+        context: Context,
+        payloads: List<Pair<WebHookEvent, Any>>,
+    ) {
+        val grouped = payloads.groupBy { it.first }
+
+        grouped.forEach { (eventType, items) ->
+            val batchPayloads = items.map { it.second }
+
+            batchPayloads.chunked(BATCH_SIZE).forEach { chunk ->
+                @Suppress("UNCHECKED_CAST")
+                val batchPayload = when (eventType) {
+                    WebHookEvent.SmsReceived -> SmsBatchReceivedPayload(
+                        messages = chunk as List<SmsEventPayload.SmsReceived>,
+                    )
+
+                    WebHookEvent.SmsDataReceived -> SmsDataBatchReceivedPayload(
+                        messages = chunk as List<SmsEventPayload.SmsDataReceived>,
+                    )
+
+                    WebHookEvent.MmsReceived -> MmsBatchReceivedPayload(
+                        messages = chunk as List<MmsReceivedPayload>,
+                    )
+
+                    WebHookEvent.MmsDownloaded -> MmsBatchDownloadedPayload(
+                        messages = chunk as List<MmsDownloadedPayload>,
+                    )
+
+                    else -> {
+                        logsService.insert(
+                            LogEntry.Priority.WARN,
+                            MODULE_NAME,
+                            "ReceiverService::emitBatchWebhooks - unsupported batch event for payload construction",
+                            mapOf("event" to eventType.name)
+                        )
+                        return@forEach
+                    }
+                }
+
+                webHooksService.emit(context, eventType.batchEvent(), batchPayload)
+            }
+        }
     }
 
 
@@ -301,5 +374,9 @@ class ReceiverService : KoinComponent {
         }
 
         return messages
+    }
+
+    companion object {
+        private const val BATCH_SIZE = 100
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/events/MessagesExportRequestedEvent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/events/MessagesExportRequestedEvent.kt
@@ -2,6 +2,7 @@ package me.capcom.smsgateway.modules.receiver.events
 
 import com.google.gson.GsonBuilder
 import com.google.gson.annotations.SerializedName
+import me.capcom.smsgateway.domain.WebhookDelivery
 import me.capcom.smsgateway.extensions.configure
 import me.capcom.smsgateway.modules.events.AppEvent
 import me.capcom.smsgateway.modules.incoming.db.IncomingMessageType
@@ -11,7 +12,7 @@ class MessagesExportRequestedEvent(
     val since: Date,
     val until: Date,
     val messageTypes: Set<IncomingMessageType>,
-    val triggerWebhooks: Boolean,
+    val webhookDelivery: WebhookDelivery,
 ) : AppEvent(NAME) {
     data class Payload(
         @SerializedName("since")
@@ -21,7 +22,10 @@ class MessagesExportRequestedEvent(
         @SerializedName("messageTypes")
         val messageTypes: String? = null,
         @SerializedName("triggerWebhooks")
+        @Deprecated("Replaced with webhookDelivery")
         val triggerWebhooks: Boolean? = null,
+        @SerializedName("webhookDelivery")
+        val webhookDelivery: WebhookDelivery? = null,
     )
 
     companion object {
@@ -42,7 +46,9 @@ class MessagesExportRequestedEvent(
                 since = obj.since,
                 until = obj.until,
                 messageTypes = messageTypes ?: setOf(IncomingMessageType.SMS),
-                triggerWebhooks = obj.triggerWebhooks ?: true,
+                webhookDelivery = obj.webhookDelivery
+                    ?: (if (obj.triggerWebhooks == false) WebhookDelivery.Disabled else null)
+                    ?: WebhookDelivery.Individual,
             )
         }
     }

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
@@ -6,6 +6,9 @@ enum class WebHookEvent(val value: String) {
     @SerializedName("sms:received")
     SmsReceived("sms:received"),
 
+    @SerializedName("sms:batch:received")
+    SmsBatchReceived("sms:batch:received"),
+
     @SerializedName("sms:sent")
     SmsSent("sms:sent"),
 
@@ -21,15 +24,32 @@ enum class WebHookEvent(val value: String) {
     @SerializedName("sms:data-received")
     SmsDataReceived("sms:data-received"),
 
+    @SerializedName("sms:batch:data-received")
+    SmsBatchDataReceived("sms:batch:data-received"),
+
     @SerializedName("mms:received")
     MmsReceived("mms:received"),
 
+    @SerializedName("mms:batch:received")
+    MmsBatchReceived("mms:batch:received"),
+
     @SerializedName("mms:downloaded")
     MmsDownloaded("mms:downloaded"),
+
+    @SerializedName("mms:batch:downloaded")
+    MmsBatchDownloaded("mms:batch:downloaded"),
 
     @SerializedName("app:started")
     AppStarted("app:started"),
 
     @SerializedName("sms:cancelled")
-    SmsCancelled("sms:cancelled"),
+    SmsCancelled("sms:cancelled");
+
+    fun batchEvent(): WebHookEvent = when (this) {
+        SmsReceived -> SmsBatchReceived
+        SmsDataReceived -> SmsBatchDataReceived
+        MmsReceived -> MmsBatchReceived
+        MmsDownloaded -> MmsBatchDownloaded
+        else -> throw NotImplementedError(this.name + " doesn't support batching")
+    }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/BatchEventPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/BatchEventPayload.kt
@@ -1,0 +1,5 @@
+package me.capcom.smsgateway.modules.webhooks.payload
+
+abstract class BatchEventPayload<T : MessageEventPayload>(
+    val messages: List<T>,
+)

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/MmsBatchDownloadedPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/MmsBatchDownloadedPayload.kt
@@ -1,0 +1,5 @@
+package me.capcom.smsgateway.modules.webhooks.payload
+
+class MmsBatchDownloadedPayload(
+    messages: List<MmsDownloadedPayload>
+) : BatchEventPayload<MmsDownloadedPayload>(messages)

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/MmsBatchReceivedPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/MmsBatchReceivedPayload.kt
@@ -1,0 +1,5 @@
+package me.capcom.smsgateway.modules.webhooks.payload
+
+class MmsBatchReceivedPayload(
+    messages: List<MmsReceivedPayload>
+) : BatchEventPayload<MmsReceivedPayload>(messages)

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsBatchReceivedPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsBatchReceivedPayload.kt
@@ -1,0 +1,5 @@
+package me.capcom.smsgateway.modules.webhooks.payload
+
+class SmsBatchReceivedPayload(
+    messages: List<SmsEventPayload.SmsReceived>
+) : BatchEventPayload<SmsEventPayload.SmsReceived>(messages)

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsDataBatchReceivedPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsDataBatchReceivedPayload.kt
@@ -1,0 +1,5 @@
+package me.capcom.smsgateway.modules.webhooks.payload
+
+class SmsDataBatchReceivedPayload(
+    messages: List<SmsEventPayload.SmsDataReceived>
+) : BatchEventPayload<SmsEventPayload.SmsDataReceived>(messages)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webhook delivery modes: **Disabled**, **Individual**, and **Batch**, with **webhookDelivery** configuration replacing legacy **triggerWebhooks** (deprecated).
  * Enhanced webhook export to support **batch delivery** and added new batch webhook event types and payloads for SMS and MMS (including received/data-received/downloaded).
* **Bug Fixes**
  * Webhook payloads are no longer emitted for messages that were already processed, and emission now follows the updated delivery-mode precedence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces ordered batch webhook delivery for inbox messages, replacing the boolean `triggerWebhooks` flag with a three-value `WebhookDelivery` enum (`Disabled`, `Individual`, `Batch`). The refactor is well-structured and backward-compatible: both API endpoints preserve their previous default behaviour, and the legacy `triggerWebhooks` field is mapped gracefully to the new enum via a clear precedence chain.

- `ReceiverService.export()` is split into `saveAndBuildPayload()` and `emitBatchWebhooks()`, grouping messages by type and chunking into batches of up to 100 before emitting a single `sms:batch:received` / `mms:batch:downloaded` webhook per chunk.
- Four new batch `WebHookEvent` variants are added, each backed by a typed `BatchEventPayload<T>` subclass, keeping the type hierarchy clean.
- The cloud server path (`android-sms-gateway/server`) still only sends `triggerWebhooks` in push events, so `Batch` delivery mode is currently only reachable via direct local-server API calls, not via cloud-triggered inbox refresh.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — backward compatibility is preserved on both API endpoints and the new batch path correctly saves messages before any webhook emission.
- The refactor is clean and the backward-compatibility chains for both `InboxRoutes` and `MessagesRoutes` correctly reproduce previous default behaviour. The two observations (MMS batch payload size and cloud-mode limitation) are non-blocking: the MMS concern is a future hardening item and the cloud limitation is a known phased rollout rather than a regression. No existing behaviour is broken.
- `ReceiverService.kt` — worth a second look if MMS attachments are expected to be large in typical deployments, given the fixed BATCH_SIZE of 100 applies uniformly to all message types including downloaded MMS with binary attachment data.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverService.kt | Core refactor splitting `process()` into `saveAndBuildPayload()` + `emitBatchWebhooks()` to support three delivery modes. The `else` branch in `emitBatchWebhooks` is unreachable (covered in previous thread) and the BATCH_SIZE of 100 could produce very large payloads for MMS batches with attachments, but the logic is otherwise sound. |
| app/src/main/java/me/capcom/smsgateway/modules/receiver/events/MessagesExportRequestedEvent.kt | Replaces `triggerWebhooks: Boolean` with `webhookDelivery: WebhookDelivery` in the event class, with a backward-compatible fallback in `withPayload()`. The cloud-server push path still only emits `triggerWebhooks`, which the fallback handles correctly (defaults to `Individual`). |
| app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/InboxRoutes.kt | Backward-compatible precedence chain (`webhookDelivery` → `triggerWebhooks` → `Disabled`) correctly preserves old default behaviour for the `/inbox/refresh` endpoint. |
| app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt | Analogous precedence chain for `POST /messages/inbox/export`; defaults to `Individual` (same as old `triggerWebhooks ?: true`), backward-compatible. |
| app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt | Adds four batch event enum values and a `batchEvent()` helper. Throws `NotImplementedError` for non-batchable events, which is safe because callers only invoke it on the four supported types. |
| app/src/main/java/me/capcom/smsgateway/domain/WebhookDelivery.kt | New enum for the three delivery modes; straightforward. |
| app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/BatchEventPayload.kt | Thin abstract base class for batch payloads. The `MessageEventPayload` bound is satisfied by all four concrete payload subclasses. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /inbox/refresh\nor /messages/inbox/export] --> B{Resolve webhookDelivery}
    B --> |webhookDelivery set| C[Use webhookDelivery]
    B --> |triggerWebhooks legacy| D[Map bool → Disabled / Individual]
    B --> |neither set| E[Default: Disabled / Individual\nper endpoint]
    C --> F[ReceiverService.export]
    D --> F
    E --> F
    F --> G[select messages\nsorted by date]
    G --> H{webhookDelivery}
    H --> |Disabled| I[saveAndBuildPayload for each\nno webhook emission]
    H --> |Individual| J[process each message\nemit individual webhook]
    H --> |Batch| K[saveAndBuildPayload for each\ncollect non-null payloads]
    K --> L[groupBy event type\npreserves per-type order]
    L --> M[chunked by BATCH_SIZE=100]
    M --> N{match event type}
    N --> |SmsReceived| O[SmsBatchReceivedPayload\n→ sms:batch:received]
    N --> |SmsDataReceived| P[SmsDataBatchReceivedPayload\n→ sms:batch:data-received]
    N --> |MmsReceived| Q[MmsBatchReceivedPayload\n→ mms:batch:received]
    N --> |MmsDownloaded| R[MmsBatchDownloadedPayload\n→ mms:batch:downloaded]
    O --> S[webHooksService.emit]
    P --> S
    Q --> S
    R --> S
```
</details>

<sub>Reviews (10): Last reviewed commit: ["\[docs\] update swagger, readme, and chang..."](https://github.com/capcom6/android-sms-gateway/commit/e5010519a82391186ad36d4f6885fe430b6af7c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46602662)</sub>

<!-- /greptile_comment -->