### PR TITLE
[webhooks] use scheduling instead of polling

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueDao.kt
@@ -21,10 +21,16 @@ interface WebhookQueueDao {
     suspend fun getById(id: String): WebhookQueueEntity
 
     /**
-     * Check if there are any scheduled webhook events.
+     * Check if there are any due webhook events (where next_attempt has passed).
      */
-    @Query("SELECT COUNT(*) FROM webhook_queue WHERE status IN ('pending', 'failed')")
-    suspend fun scheduledWebhooksCount(): Long
+    @Query("SELECT COUNT(*) FROM webhook_queue WHERE status IN ('pending', 'failed') AND next_attempt <= :currentTime")
+    suspend fun dueWebhooksCount(currentTime: Long = System.currentTimeMillis()): Long
+
+    /**
+     * Get the minimum next_attempt time for all pending/failed webhooks.
+     */
+    @Query("SELECT MIN(next_attempt) FROM webhook_queue WHERE status IN ('pending', 'failed')")
+    suspend fun getNextAttemptTime(): Long?
 
     /**
      * Get all pending webhook events ordered by next attempt time.

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueRepository.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueRepository.kt
@@ -34,7 +34,7 @@ class WebhookQueueRepository(
                     createdAt = System.currentTimeMillis(),
                     nextAttempt = System.currentTimeMillis()
                 )
-             )
+            )
         } catch (e: Exception) {
             payloadStorage.delete(id)
             throw e
@@ -44,10 +44,17 @@ class WebhookQueueRepository(
     }
 
     /**
-     * Check if there are any scheduled webhook events.
+     * Check if there are any webhook events due now.
      */
-    suspend fun hasScheduledWebhooks(): Boolean {
-        return dao.scheduledWebhooksCount() > 0
+    suspend fun hasDueWebhooks(): Boolean {
+        return dao.dueWebhooksCount(System.currentTimeMillis()) > 0
+    }
+
+    /**
+     * Get the minimum next_attempt time for all pending/failed webhooks.
+     */
+    suspend fun getNextAttemptTime(): Long? {
+        return dao.getNextAttemptTime()
     }
 
     /**

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/workers/WebhookQueueProcessorWorker.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/workers/WebhookQueueProcessorWorker.kt
@@ -44,6 +44,7 @@ import org.json.JSONException
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Worker that processes webhook events from a persistent queue.
@@ -71,11 +72,13 @@ class WebhookQueueProcessorWorker(
 
         /**
          * Start the queue processor worker.
-         * This will schedule the worker to run periodically.
+         * @param initialDelayMs delay before the worker runs (0 for immediate).
          */
         fun start(
             context: Context,
-            internetRequired: Boolean = false
+            internetRequired: Boolean = false,
+            initialDelayMs: Long = 0,
+            policy: ExistingWorkPolicy = ExistingWorkPolicy.REPLACE,
         ) {
             val workRequest = OneTimeWorkRequestBuilder<WebhookQueueProcessorWorker>()
                 .setBackoffCriteria(
@@ -91,12 +94,15 @@ class WebhookQueueProcessorWorker(
                                 .build()
                         )
                     }
+                    if (initialDelayMs > 0) {
+                        setInitialDelay(initialDelayMs, TimeUnit.MILLISECONDS)
+                    }
                 }
                 .build()
 
             WorkManager.getInstance(context).enqueueUniqueWork(
                 WORK_NAME,
-                ExistingWorkPolicy.KEEP,
+                policy,
                 workRequest
             )
         }
@@ -133,7 +139,6 @@ class WebhookQueueProcessorWorker(
             }
 
             do {
-                // Process the queue with priority handling
                 val processedCount = withContext(NonCancellable) {
                     processWebhookQueue()
                 }
@@ -150,10 +155,31 @@ class WebhookQueueProcessorWorker(
                 if (processedCount == 0) {
                     delay(MIN_BACKOFF_DELAY_MS)
                 }
-            } while (webhookRepository.hasScheduledWebhooks() && isActive)
+            } while (webhookRepository.hasDueWebhooks() && isActive)
 
             if (isActive) {
                 webhookRepository.cleanupOldEntries()
+
+                val nextAttempt = webhookRepository.getNextAttemptTime()
+                if (nextAttempt != null) {
+                    val delayMs = nextAttempt - System.currentTimeMillis()
+                    logsSvc.insert(
+                        priority = LogEntry.Priority.DEBUG,
+                        module = NAME,
+                        message = "Scheduling next webhook queue processing",
+                        context = mapOf(
+                            "delayMs" to delayMs,
+                            "nextAttempt" to nextAttempt
+                        )
+                    )
+
+                    start(
+                        context = applicationContext,
+                        internetRequired = settings.internetRequired,
+                        initialDelayMs = delayMs,
+                        policy = ExistingWorkPolicy.APPEND_OR_REPLACE,
+                    )
+                }
             }
 
             logsSvc.insert(
@@ -166,6 +192,8 @@ class WebhookQueueProcessorWorker(
             )
 
             return@withContext Result.success()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             logsSvc.insert(
                 priority = LogEntry.Priority.ERROR,
@@ -179,6 +207,8 @@ class WebhookQueueProcessorWorker(
 
             // Use linear backoff for retries
             return@withContext Result.retry()
+        } finally {
+            client.close()
         }
     }
 
@@ -236,34 +266,36 @@ class WebhookQueueProcessorWorker(
                 var failedCount = 0
 
                 for (webhook in webhooks) {
-                    try {
-                        // Start processing this webhook
-                        webhookRepository.startProcessing(webhook.id)
+                    withContext(NonCancellable) {
+                        try {
+                            // Start processing this webhook
+                            webhookRepository.startProcessing(webhook.id)
 
-                        // Send the webhook
-                        val success = sendWebhook(webhook)
+                            // Send the webhook
+                            val success = sendWebhook(webhook)
 
-                        if (success) {
-                            // Mark as completed
-                            webhookRepository.completeWebhook(webhook.id)
-                            processedCount++
-                        } else {
-                            // Schedule retry
-                            handleWebhookFailure(webhook.id, "Processing failed")
+                            if (success) {
+                                // Mark as completed
+                                webhookRepository.completeWebhook(webhook.id)
+                                processedCount++
+                            } else {
+                                // Schedule retry
+                                handleWebhookFailure(webhook.id, "Processing failed")
+                                failedCount++
+                            }
+                        } catch (e: Exception) {
+                            logsSvc.insert(
+                                priority = LogEntry.Priority.ERROR,
+                                module = NAME,
+                                message = "Error processing webhook ${webhook.id}: ${e.message}",
+                                context = mapOf(
+                                    "webhookId" to webhook.id,
+                                    "error" to e.toString()
+                                )
+                            )
+                            handleWebhookFailure(webhook.id, e.message)
                             failedCount++
                         }
-                    } catch (e: Exception) {
-                        logsSvc.insert(
-                            priority = LogEntry.Priority.ERROR,
-                            module = NAME,
-                            message = "Error processing webhook ${webhook.id}: ${e.message}",
-                            context = mapOf(
-                                "webhookId" to webhook.id,
-                                "error" to e.toString()
-                            )
-                        )
-                        handleWebhookFailure(webhook.id, e.message)
-                        failedCount++
                     }
                 }
 
@@ -368,8 +400,6 @@ class WebhookQueueProcessorWorker(
                     )
                 )
                 false // Network errors should trigger retry
-            } finally {
-                client.close()
             }
         }
 
@@ -414,8 +444,8 @@ class WebhookQueueProcessorWorker(
     /**
      * HTTP client with the same configuration as the original SendWebhookWorker.
      */
-    private val client
-        get() = HttpClient(OkHttp) {
+    private val client by lazy {
+        HttpClient(OkHttp) {
             install(HttpTimeout) {
                 requestTimeoutMillis = PROCESSING_TIMEOUT_MS
                 connectTimeoutMillis = 5000
@@ -433,6 +463,7 @@ class WebhookQueueProcessorWorker(
                 secretKeyProvider = { settings.signingKey }
             }
         }
+    }
 
     private val gson = GsonBuilder().configure().create()
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook retries now run based on due retry times, using the next available attempt time to automatically reschedule processing.
  * Job startup now supports an optional initial delay for improved timing control.
* **Bug Fixes**
  * Rescheduling now replaces any existing queued run to prevent stale or duplicate execution timing.
  * Batch processing is more resilient by isolating cancellation and failure handling per webhook item to reduce cross-impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the previous polling loop (`hasScheduledWebhooks` checked unconditionally) with a scheduling-based approach: the processor now only processes webhooks whose `next_attempt` has passed and, when the queue is drained, self-schedules a delayed run timed to the earliest future retry via `APPEND_OR_REPLACE`.

- `WebhookQueueDao` gains `dueWebhooksCount(currentTime)` and `getNextAttemptTime()`, replacing the now-removed `scheduledWebhooksCount()`.
- `WebhookQueueProcessorWorker.start()` gains `initialDelayMs` and `policy` parameters; the self-reschedule uses `ExistingWorkPolicy.APPEND_OR_REPLACE` so an urgent immediate enqueue from `SendWebhookWorker` (which uses `REPLACE`) correctly clobbers the delayed one rather than the reverse.
- `CancellationException` is now re-thrown explicitly, the `HttpClient` was converted from a computed property (each access created a new instance) to a `lazy` val closed once in `doWork`'s `finally`, and per-webhook processing is isolated inside `withContext(NonCancellable)` to prevent one failure from interrupting the rest of the batch.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; the scheduling refactor is well-structured with one minor resource-waste edge case in the finally block.
- The three previously flagged regressions (CancellationException swallowing, HttpClient leak from the computed property, and dead `scheduledWebhooksCount` DAO method) are all resolved. The lazy-client close in the `finally` block will unconditionally initialize the OkHttp engine even on code paths where no webhook was ever sent, wasting a brief spin-up/teardown cycle. This is the one remaining imperfection keeping the score below 5.
- app/src/main/java/me/capcom/smsgateway/modules/webhooks/workers/WebhookQueueProcessorWorker.kt — the lazy-client close in the finally block.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueDao.kt | Replaces scheduledWebhooksCount() with dueWebhooksCount(currentTime) (filters on next_attempt <= currentTime) and adds getNextAttemptTime() to find the earliest future retry. Clean change; no issues. |
| app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueRepository.kt | Replaces hasScheduledWebhooks() with hasDueWebhooks() (passes current time explicitly) and delegates getNextAttemptTime() to the DAO. Straightforward and correct. |
| app/src/main/java/me/capcom/smsgateway/modules/webhooks/workers/WebhookQueueProcessorWorker.kt | Core scheduling refactor: adds initialDelayMs/policy params to start(), fixes CancellationException re-throw, converts client to lazy val with a single close() in finally, wraps per-webhook processing in NonCancellable, and self-schedules the next run via APPEND_OR_REPLACE. Minor: finally block always triggers lazy-client initialization even when no webhooks were processed. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Worker starts]) --> B[setForeground]
    B --> C{hasDueWebhooks?}
    C -- yes --> D[processWebhookQueue\nNonCancellable]
    D --> E{processedCount == 0?}
    E -- yes --> F[delay 5s]
    E -- no --> C
    F --> C
    C -- no --> G[cleanupOldEntries]
    G --> H[getNextAttemptTime]
    H --> I{nextAttempt != null?}
    I -- yes --> J["start(delayMs,\nAPPEND_OR_REPLACE)"]
    I -- no --> K([Result.success])
    J --> K
    D2[SendWebhookWorker\nenqueues webhook] -->|start 0ms, REPLACE| L[Replaces any\npending delayed run]
    L --> A

    subgraph "Per-webhook in NonCancellable"
    D --> D1[startProcessing]
    D1 --> D3[sendWebhook]
    D3 -- success --> D4[completeWebhook]
    D3 -- failure --> D5[handleWebhookFailure\nschedule retry]
    D3 -- exception --> D5
    end
```
</details>

<sub>Reviews (16): Last reviewed commit: ["\[webhooks\] use scheduling instead of pol..."](https://github.com/capcom6/android-sms-gateway/commit/f9db62bb7dcd9319b324ed31481e040074c4b724) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46602661)</sub>

<!-- /greptile_comment -->