### PR TITLE
[helpers] new API for resolve phone number

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.MANAGE_SUBSCRIPTION_USER_ASSOCIATION" />
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/app/src/main/java/me/capcom/smsgateway/helpers/SubscriptionsHelper.kt
+++ b/app/src/main/java/me/capcom/smsgateway/helpers/SubscriptionsHelper.kt
@@ -28,6 +28,7 @@ object SubscriptionsHelper {
         return when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1 -> subscriptionManager.activeSubscriptionInfoList.map { it.simSlotIndex }
                 .toSet()
+
             else -> null
         }
     }
@@ -64,7 +65,7 @@ object SubscriptionsHelper {
         }
     }
 
-    fun hasPhoneStatePermission(context: Context): Boolean {
+    private fun hasPhoneStatePermission(context: Context): Boolean {
         return ActivityCompat.checkSelfPermission(
             context,
             Manifest.permission.READ_PHONE_STATE
@@ -98,7 +99,7 @@ object SubscriptionsHelper {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
             subscriptionManager.activeSubscriptionInfoList?.find {
                 it.simSlotIndex == simSlotIndex
-            }?.number?.takeIf { it.isNotBlank() }
+            }?.let { resolvePhoneNumber(subscriptionManager, it) }
         } else {
             null
         }
@@ -108,7 +109,8 @@ object SubscriptionsHelper {
      * Retrieves information about all active SIM cards in the device.
      *
      * Returns a list of SimCard objects for each active subscription.
-     * Phone numbers will be null if READ_PHONE_STATE permission is not granted.
+     * Phone numbers will be null if READ_PHONE_STATE permission is not granted, or unavailable
+     * on Android 13+ without READ_PHONE_NUMBERS permission.
      * Returns empty list on API levels below LOLLIPOP_MR1 (22).
      *
      * @param context Android context for accessing system services
@@ -135,7 +137,7 @@ object SubscriptionsHelper {
                 slotIndex = info.simSlotIndex,
                 simNumber = info.simSlotIndex + 1,
                 phoneNumber = if (hasPermission) {
-                    info.number?.takeIf { it.isNotBlank() }
+                    resolvePhoneNumber(subscriptionManager, info)
                 } else {
                     null
                 },
@@ -143,5 +145,26 @@ object SubscriptionsHelper {
                 iccid = info.iccId?.takeIf { it.isNotBlank() },
             )
         }
+    }
+
+    /**
+     * Resolves the phone number for a subscription, preferring the modern
+     * SubscriptionManager.getPhoneNumber() on Android 13+ (which can source the
+     * number from the carrier/IMS, not just the SIM) and falling back to the
+     * deprecated SubscriptionInfo.number on older devices. May still be null if
+     * the carrier never provisioned the number.
+     */
+    @SuppressLint("MissingPermission")
+    private fun resolvePhoneNumber(
+        subscriptionManager: SubscriptionManager,
+        info: android.telephony.SubscriptionInfo,
+    ): String? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            runCatching { subscriptionManager.getPhoneNumber(info.subscriptionId) }
+                .getOrNull()
+                ?.takeIf { it.isNotBlank() }
+        } else {
+            null
+        } ?: info.number?.takeIf { it.isNotBlank() }
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt
@@ -380,7 +380,9 @@ class HomeFragment : Fragment() {
                 Manifest.permission.RECEIVE_SMS,
                 Manifest.permission.SEND_SMS,
                 Manifest.permission.RECEIVE_MMS,
+                Manifest.permission.READ_PHONE_NUMBERS.takeIf { Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU },
             )
+                .filterNotNull()
                 .filter {
                     ContextCompat.checkSelfPermission(
                         requireContext(),


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SIM card phone number retrieval across Android versions, resulting in more reliable phone numbers in the app.
  * Added safer handling when phone numbers cannot be read, reducing missing or incorrect values.
* **Permissions**
  * Added the required permission to read SIM phone numbers so the app can display accurate phone numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves SIM phone number retrieval by introducing `resolvePhoneNumber()` in `SubscriptionsHelper`, which prefers the modern `SubscriptionManager.getPhoneNumber()` API on Android 13+ (sourcing from carrier/IMS) and gracefully falls back to the deprecated `SubscriptionInfo.number` on older devices via `runCatching`.

- **`SubscriptionsHelper.kt`**: New private `resolvePhoneNumber()` function handles the API split between Android 13+ and older devices; `hasPhoneStatePermission` is correctly narrowed to `private`; KDoc updated to document the new `READ_PHONE_NUMBERS` dependency.
- **`HomeFragment.kt`**: `READ_PHONE_NUMBERS` is added to the runtime permission request, correctly gated behind `>= TIRAMISU` and null-filtered via `filterNotNull()`.
- **`AndroidManifest.xml`**: `READ_PHONE_NUMBERS` permission added as required by the Android 13+ `getPhoneNumber()` API.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — all three changed files are self-consistent, the new phone-number resolution logic degrades gracefully when the permission is absent, and no existing behaviour is broken.
- The change is narrowly scoped: a new private helper method with well-understood fallback logic, a runtime permission request correctly conditioned on API level, and a manifest addition. SecurityException from the unpermissioned API call is caught by runCatching, the deprecated SubscriptionInfo.number fallback is preserved for older devices, and the UI permission flow handles null entries cleanly with filterNotNull().
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/AndroidManifest.xml | Adds READ_PHONE_NUMBERS permission declaration without maxSdkVersion restriction; permission is correctly placed alongside READ_PHONE_STATE. |
| app/src/main/java/me/capcom/smsgateway/helpers/SubscriptionsHelper.kt | Adds resolvePhoneNumber() to use the modern SubscriptionManager.getPhoneNumber() API on Android 13+, gracefully falling back to the deprecated SubscriptionInfo.number via runCatching. Makes hasPhoneStatePermission private (no external callers). KDoc updated to reflect new READ_PHONE_NUMBERS requirement. |
| app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt | Adds READ_PHONE_NUMBERS to the runtime permission request list, correctly gated on Build.VERSION.SDK_INT >= TIRAMISU (API 33) and filtered for null before use. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolvePhoneNumber called] --> B{Android 13+?}
    B -- Yes --> C[subscriptionManager.getPhoneNumber]
    C --> D{SecurityException?}
    D -- Yes, caught by runCatching --> E[getOrNull = null]
    D -- No --> F[result string]
    F --> G{isNotBlank?}
    G -- Yes --> H[Return phone number ✓]
    G -- No --> E
    E --> I[Fallback: info.number]
    B -- No --> I
    I --> J{isNotBlank?}
    J -- Yes --> K[Return deprecated number ✓]
    J -- No --> L[Return null]
```
</details>

<sub>Reviews (14): Last reviewed commit: ["\[helpers\] new API for resolve phone numb..."](https://github.com/capcom6/android-sms-gateway/commit/7da18445e9bd9ecc7c24b0f22defc907f5c4ecae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46602660)</sub>

<!-- /greptile_comment -->