### PR TITLE
[receiver] delay mms parsing on download

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsContentObserver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsContentObserver.kt
@@ -147,28 +147,48 @@ class MmsContentObserver : KoinComponent {
     }
 
     private fun processMmsDownloaded(mmsId: Long) {
-        val message = MmsContentReader.read(context, mmsId) ?: return
-        receiverSvc.process(
-            context,
-            InboxMessage.MMS(
-                mmsId.toString(),
-                message.body,
-                message.subject,
-                message.attachments.map {
-                    InboxMessage.MMS.Attachment(
-                        it.partId,
-                        it.contentType,
-                        it.name,
-                        it.size,
-                        it.data
-                    )
-                },
-                message.sender,
-                message.date,
-                message.subscriptionId
-            ),
-            true,
-        )
+        // The content observer fires when the parent MMS row is inserted, but the
+        // child addr/part sub-tables may not be populated yet by the telephony
+        // framework. Retry a few times with a short delay to wait for them.
+        var message: MmsContentReader.MmsMessage? = null
+        for (attempt in 1..MMS_DOWNLOAD_MAX_RETRIES) {
+            message = MmsContentReader.read(context, mmsId) ?: return
+            val needsRetry = message.sender == "unknown" || (message.body.isNullOrBlank() && message.attachments.isEmpty())
+            if (!needsRetry) break
+            if (attempt < MMS_DOWNLOAD_MAX_RETRIES) {
+                logsService.insert(
+                    LogEntry.Priority.DEBUG,
+                    MODULE_NAME,
+                    "MMS content incomplete (id=$mmsId, sender=${message.sender}, attachments=${message.attachments.size}), " +
+                            "retrying in ${MMS_DOWNLOAD_RETRY_DELAY_MS}ms (attempt $attempt/$MMS_DOWNLOAD_MAX_RETRIES)",
+                )
+                Thread.sleep(MMS_DOWNLOAD_RETRY_DELAY_MS)
+            }
+        }
+
+        message?.let { msg ->
+            receiverSvc.process(
+                context,
+                InboxMessage.MMS(
+                    mmsId.toString(),
+                    msg.body,
+                    msg.subject,
+                    msg.attachments.map {
+                        InboxMessage.MMS.Attachment(
+                            it.partId,
+                            it.contentType,
+                            it.name,
+                            it.size,
+                            it.data
+                        )
+                    },
+                    msg.sender,
+                    msg.date,
+                    msg.subscriptionId
+                ),
+                true,
+            )
+        }
     }
 
     private fun canReadSms(): Boolean = ContextCompat.checkSelfPermission(
@@ -178,5 +198,7 @@ class MmsContentObserver : KoinComponent {
 
     companion object {
         private const val TAG = "MmsContentObserver"
+        private const val MMS_DOWNLOAD_MAX_RETRIES = 3
+        private const val MMS_DOWNLOAD_RETRY_DELAY_MS = 1500L
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsContentReader.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsContentReader.kt
@@ -50,7 +50,7 @@ object MmsContentReader {
         val subscriptionId: Int?
         mmsCursor.use { c ->
             if (!c.moveToFirst()) return null
-            subject = c.getString(0)
+            subject = recoverSubjectEncoding(c.getString(0))
             // MMS dates are in seconds, not milliseconds
             date = Date(c.getLong(1) * 1000)
             subscriptionId = when {
@@ -199,5 +199,52 @@ object MmsContentReader {
             }
         }
         return Charsets.UTF_8
+    }
+
+    /**
+     * Attempts to recover from common content provider charset mis-decoding.
+     *
+     * The MMS `sub` column is decoded by the Android telephony framework. On some
+     * devices/carriers, non-ASCII subjects (e.g., Korean, Japanese, Chinese) are
+     * decoded with the wrong charset (typically ISO-8859-1 instead of UTF-8),
+     * producing garbled text instead of the correct subject.
+     *
+     * This heuristic detects such mis-decoding and attempts recovery by re-encoding
+     * the garbled string as ISO-8859-1 bytes, then decoding those bytes as UTF-8.
+     */
+    private fun recoverSubjectEncoding(subject: String?): String? {
+        if (subject == null || subject.isEmpty()) return subject
+
+        if (isLikelyMisEncoded(subject)) {
+            return try {
+                val recovered = String(subject.toByteArray(Charsets.ISO_8859_1), Charsets.UTF_8)
+                // Only use the recovered version if it looks like valid text
+                // (no replacement chars and has at least some non-ASCII content)
+                if (!recovered.contains('\uFFFD') && recovered != subject) recovered else subject
+            } catch (_: Exception) {
+                subject
+            }
+        }
+
+        return subject
+    }
+
+    /**
+     * Heuristic to detect text that was decoded with the wrong charset (typically
+     * ISO-8859-1 instead of UTF-8). Counts UTF-8 lead bytes and continuation bytes.
+     *
+     * Note: this can false-positive on valid ISO-8859-1 subjects containing multi-byte
+     * Latin-1 characters (e.g., U+00C2–U+00EF) paired with continuation-range characters
+     * (U+0080–U+00BF). The risk is low because such byte patterns are uncommon in
+     * real-world subjects, and the recovery is guarded against replacement characters.
+     */
+    private fun isLikelyMisEncoded(text: String): Boolean {
+        var leadByteCount = 0
+        var highByteCount = 0
+        for (ch in text) {
+            if (ch.code in 0xC2..0xEF) leadByteCount++
+            if (ch.code in 0x80..0xBF) highByteCount++
+        }
+        return leadByteCount >= 2 && highByteCount >= leadByteCount
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParser.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParser.kt
@@ -1,7 +1,9 @@
 package me.capcom.smsgateway.modules.receiver.parsers
 
+import me.capcom.smsgateway.modules.mms.pdu.aosp.CharacterSets
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.nio.charset.Charset
 import java.util.Date
 
 
@@ -161,13 +163,46 @@ object MMSParser {
     private fun parseEncodedString(buffer: ByteBuffer): String {
         if (!buffer.hasRemaining()) return ""
         val mark = buffer.position()
-        val lenOrToken = buffer.get().toInt() and 0xFF
+        val firstByte = buffer.get().toInt() and 0xFF
 
         buffer.position(mark)
 
-        if (lenOrToken < 32) {
-            parseValueLength(buffer)
-            parseShortInteger(buffer)
+        if (firstByte < 32) {
+            // Value-length Char-set Text-string
+            val valueLength = parseValueLength(buffer)
+
+            // Character-set is a Constrained-encoding (Short-integer or Longer-integer).
+            // Short-integer: bit 7 set (>= 128), value = byte & 0x7F
+            // Longer-integer: bit 7 clear (< 128), length-prefixed big-endian bytes follow
+            val charsetByte = buffer.get().toInt() and 0xFF
+            val charset = if (charsetByte and 0x80 != 0) {
+                // Short-integer: 7-bit value (e.g., 0xEA = UTF-8 → 0x6A = 106)
+                charsetByte and 0x7F
+            } else {
+                // Longer-integer: first byte is length, followed by that many big-endian bytes
+                val length = charsetByte
+                var value = 0
+                repeat(length.coerceAtMost(buffer.remaining())) {
+                    value = (value shl 8) or (buffer.get().toInt() and 0xFF)
+                }
+                value
+            }
+
+            // Read the text bytes using the resolved charset, bounded by value-length
+            val charsetObj = try {
+                Charset.forName(CharacterSets.getMimeName(charset))
+            } catch (_: Exception) {
+                Charsets.UTF_8
+            }
+            val charsetByteSize = if (charsetByte and 0x80 != 0) 1 else 1 + charsetByte
+            val textBytes = mutableListOf<Byte>()
+            var remaining = valueLength - charsetByteSize
+            while (remaining-- > 0 && buffer.hasRemaining()) {
+                val b = buffer.get()
+                if (b == 0x00.toByte()) break
+                textBytes.add(b)
+            }
+            return String(textBytes.toByteArray(), charsetObj)
         }
 
         return parseTextString(buffer)

--- a/app/src/test/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParserTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParserTest.kt
@@ -234,4 +234,52 @@ internal class MMSParserTest {
         val notification = MMSParser.parseMNotificationInd(data)
         assert(notification.from == "+19162255887/TYPE=PLMN")
     }
+
+    @Test
+    fun parseSubjectUtf8() {
+        // Minimal MMS notification-ind PDU with UTF-8 subject "테스트" (Korean for "test")
+        // FROM uses Text-string format (no charset prefix) — first byte of address >= 0x20
+        // Subject header: 0x96 (HEADER_SUBJECT) + Value-length(0x0B=11) + Char-set(0xEA=UTF-8 Short-int) + text + 0x00
+        // Value-length = 1 (charset) + 9 (text bytes) + 1 (null terminator) = 11
+        val pdu = hexToBytes(
+            """
+                8C 82
+                98 74 65 73 74 2D 74 78 6E 2D 30 30 31 00
+                8D 92
+                89 0C 80 31 32 33 34 35 36 37 38 39 30 00
+                96 0B EA ED 85 8C EC 8A A4 ED 8A B8 00
+                8E 02 03 E8
+                85 04 63 B7 9F 80
+            """.trimIndent()
+        )
+
+        val notification = MMSParser.parseMNotificationInd(pdu)
+        assert(notification.from == "1234567890")
+        assert(notification.subject == "테스트") { "Expected '테스트' but got '${notification.subject}'" }
+        assert(notification.transactionId == "test-txn-001")
+        assert(notification.messageSize == 1000L)
+    }
+
+    @Test
+    fun parseSubjectAscii() {
+        // Minimal MMS notification-ind PDU with ASCII subject "Hello"
+        // FROM uses Text-string format (no charset prefix)
+        // Subject header: 0x96 + Value-length(0x07=7) + Char-set(0xEA=UTF-8 Short-int) + text + 0x00
+        // Value-length = 1 (charset) + 5 (text bytes) + 1 (null terminator) = 7
+        val pdu = hexToBytes(
+            """
+                8C 82
+                98 04 61 62 63 00
+                8D 92
+                89 0C 80 31 32 33 34 35 36 37 38 39 30 00
+                96 07 EA 48 65 6C 6C 6F 00
+                8E 02 03 E8
+                85 04 63 B7 9F 80
+            """.trimIndent()
+        )
+
+        val notification = MMSParser.parseMNotificationInd(pdu)
+        assert(notification.from == "1234567890")
+        assert(notification.subject == "Hello") { "Expected 'Hello' but got '${notification.subject}'" }
+    }
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MMS processing reliability by retrying briefly until MMS content and attachments are available before handling the message.
  - Fixed MMS subject decoding to better recover from common charset mis-decoding, improving multilingual subject text.
  - Enhanced decoding of character-encoded MMS headers to provide more accurate message details.
- **Tests**
  - Added unit tests for MMS subject decoding across UTF-8 (multilingual) and ASCII cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves MMS receive reliability in three ways: it adds a short retry loop in `MmsContentObserver` to tolerate the telephony framework populating addr/part sub-tables after the parent row triggers the `ContentObserver`; it adds a heuristic in `MmsContentReader` to recover subjects that were mis-decoded as ISO-8859-1 instead of UTF-8; and it rewrites `parseEncodedString` in `MMSParser` to correctly decode the WSP Constrained-encoding charset field and bound text reads by the declared value-length.

- **MmsContentObserver**: retry loop with `Thread.sleep(1500 ms)` blocks the shared `HandlerThread` and the watermark (`mmsLastProcessedID`) is advanced to `mmsId` before retries resolve, so a process restart during a pending retry will permanently skip that message.
- **MmsContentReader**: `recoverSubjectEncoding` re-encodes the garbled string as ISO-8859-1 bytes and decodes as UTF-8, guarded against replacement characters; the known false-positive risk is documented in code.
- **MMSParser**: `parseEncodedString` now reads the charset as either a Short-integer or Longer-integer per the WSP spec, computes `charsetByteSize` correctly for both forms, and uses `valueLength - charsetByteSize` as an upper bound on the text read loop.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the charset and subject-encoding fixes; the retry loop in MmsContentObserver carries known trade-offs around the HandlerThread and watermark that are worth tracking.

The processMmsDownloaded retry loop calls Thread.sleep on the HandlerThread that services all ContentObserver callbacks — up to 4.5 s per message — and the watermark is advanced to mmsId before any retry resolves, so a process death during a retry permanently loses that MMS. Both issues were flagged in prior review rounds and remain unaddressed in this revision. The charset parsing and subject-recovery changes are sound and well-tested.

**Files Needing Attention:** app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsContentObserver.kt — retry timing and watermark ordering

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsContentObserver.kt | Adds retry loop with Thread.sleep to wait for MMS sub-tables; the blocking sleep on the HandlerThread and advancing the watermark before retries resolve are real reliability concerns |
| app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsContentReader.kt | Adds recoverSubjectEncoding heuristic to fix ISO-8859-1/UTF-8 mis-decoding on certain devices; heuristic is documented and guarded against replacement characters |
| app/src/main/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParser.kt | parseEncodedString now correctly decodes charset from Constrained-encoding and bounds text read by value-length; charsetByteSize calculation is accurate for both Short-integer and Longer-integer forms |
| app/src/test/java/me/capcom/smsgateway/modules/receiver/parsers/MMSParserTest.kt | Adds two unit tests for UTF-8 Korean and ASCII subjects in MMS notification PDUs; test data byte sequences are consistent with the accompanying comments |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant HT as HandlerThread
    participant MCO as MmsContentObserver
    participant MCR as MmsContentReader
    participant RS as ReceiverService

    HT->>MCO: processNewMessages()
    MCO->>MCO: query new MMS IDs (cursor stays open)
    loop for each mmsId
        MCO->>MCO: processMmsDownloaded(mmsId)
        loop attempt 1..MAX_RETRIES (3)
            MCO->>MCR: read(context, mmsId)
            MCR-->>MCO: MmsMessage (or null)
            alt "incomplete (sender==unknown OR no body/attachments)"
                MCO->>HT: Thread.sleep(1500ms) blocks HandlerThread
            else complete
                MCO->>MCO: break
            end
        end
        MCO->>RS: process(InboxMessage.MMS)
        MCO->>MCO: "advance watermark (mmsLastProcessedID = mmsId)"
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["\[receiver\] delay mms parsing on download"](https://github.com/capcom6/android-sms-gateway/commit/bc2a1a809de74c44de318397d0ac3775d8459eb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46602659)</sub>

<!-- /greptile_comment -->