### PR TITLE
[messages] fix ACTION_SENT broadcast

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -219,7 +219,7 @@ class MessagesService(
                     resultCode
                 )
 
-                intent.hasExtra("uri") -> ProcessingState.Sent to null
+                intent.data != null -> ProcessingState.Sent to null
                 else -> return
             }
 
@@ -484,13 +484,12 @@ class MessagesService(
                 }
             }
 
-
-
         request.message.phoneNumbers
             .forEach { sourcePhoneNumber ->
+                val requestCode = id.hashCode()
                 val sentIntent = PendingIntent.getBroadcast(
                     context,
-                    0,
+                    requestCode,
                     Intent(
                         EventsReceiver.ACTION_SENT,
                         Uri.parse("$id|$sourcePhoneNumber"),
@@ -503,7 +502,7 @@ class MessagesService(
                     false -> null
                     true -> PendingIntent.getBroadcast(
                         context,
-                        0,
+                        requestCode,
                         Intent(
                             EventsReceiver.ACTION_DELIVERED,
                             Uri.parse("$id|$sourcePhoneNumber"),


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMS status detection so sent messages are recognized reliably.
  * Prevented sent and delivered notifications from sharing the same pending request identifier, improving tracking for individual messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two bugs in `MessagesService.kt` related to SMS send-status tracking via `PendingIntent` broadcasts.

- **`intent.hasExtra(\"uri\")` → `intent.data != null`**: The ACTION_SENT intent is constructed with a URI set as `intent.data` (not as an extra), so `hasExtra(\"uri\")` was always `false`, silently swallowing every successful-send callback. The fix correctly inspects `intent.data`.
- **requestCode 0 → `id.hashCode()`**: All outbound `PendingIntent`s previously shared `requestCode = 0`. Switching to the message ID's hashcode ensures separate messages have independent request codes, preventing any potential collisions when multiple messages are in-flight simultaneously.

<h3>Confidence Score: 5/5</h3>

Both changes are well-scoped corrections with no regressions introduced.

The `intent.data != null` fix is a straightforward correction for a condition that was always false, and the `id.hashCode()` request-code change narrows PendingIntent scoping without breaking any other path. No edge cases were introduced.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt | Two targeted bug fixes: replaces incorrect `hasExtra("uri")` check with `intent.data != null` for sent-status detection, and uses `id.hashCode()` instead of literal `0` as the PendingIntent request code. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant MS as MessagesService
    participant SM as SmsManager
    participant ER as EventsReceiver

    MS->>SM: sendTextMessage(phone, sentIntent, deliveredIntent)
    Note over MS: sentIntent = PendingIntent(requestCode=id.hashCode(),<br/>action=ACTION_SENT, data="id|phone")
    Note over MS: deliveredIntent = PendingIntent(requestCode=id.hashCode(),<br/>action=ACTION_DELIVERED, data="id|phone")

    SM-->>ER: broadcast ACTION_SENT (resultCode, intent.data)
    ER->>MS: processStateIntent(intent, resultCode)
    alt "resultCode != RESULT_OK"
        MS->>MS: "state = Failed"
    else "intent.data != null"
        MS->>MS: "state = Sent"
    else
        MS->>MS: return (ignore)
    end

    SM-->>ER: broadcast ACTION_DELIVERED (resultCode, pdu)
    ER->>MS: processStateIntent(intent, resultCode)
    MS->>MS: "state = Delivered / Failed"
```
</details>

<sub>Reviews (5): Last reviewed commit: ["\[messages\] fix ACTION\_SENT broadcast dro..."](https://github.com/capcom6/android-sms-gateway/commit/f478e5e772d366977c2ca3a8c5d3a98eeeba3462) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46602658)</sub>

<!-- /greptile_comment -->