### PR TITLE
Fix ACTION_SENT broadcast handling when uri extra is missing

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -209,7 +209,7 @@ class MessagesService(
                     resultCode
                 )
 
-                intent.hasExtra("uri") -> ProcessingState.Sent to null
+                intent.data != null || intent.hasExtra("uri") -> ProcessingState.Sent to null
                 else -> return
             }
 


### PR DESCRIPTION
# Fix ACTION_SENT broadcast handling when uri extra is missing

## Summary

The ACTION_SENT broadcast was being dropped when the intent lacked a "uri" extra, even though the intent's data field contained the URI. This change modifies the condition to also check for a non-null intent.data.

Fixes #403

## Changes

- Modified MessagesService.kt to check `intent.data != null || intent.hasExtra("uri")` when determining if the SMS was sent successfully.

## Testing

Attempted to run unit tests via `sandbox-run "./gradlew test"` but encountered issues with the Java environment in the sandbox. However, the change is minimal and only affects the condition for determining send success. The intent.data is set when the pending intent is created (see line where intent.dataString is split), so this change should not break existing functionality where the uri extra is present. Manual inspection of the code confirms the change is safe.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message delivery status handling when a sent-message intent includes data.
  * Preserved existing failure handling for unsuccessful sends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->