### PR TITLE
[devices] improved end to end encryption

### DIFF
--- a/app/schemas/me.capcom.smsgateway.data.AppDatabase/24.json
+++ b/app/schemas/me.capcom.smsgateway.data.AppDatabase/24.json
@@ -1,0 +1,721 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "481a0f54fb3737280ebff0d95187528d",
+    "entities": [
+      {
+        "tableName": "Message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `withDeliveryReport` INTEGER NOT NULL DEFAULT 1, `simNumber` INTEGER, `validUntil` TEXT, `scheduleAt` TEXT, `isEncrypted` INTEGER NOT NULL DEFAULT 0, `skipPhoneValidation` INTEGER NOT NULL DEFAULT 0, `priority` INTEGER NOT NULL DEFAULT 0, `source` TEXT NOT NULL DEFAULT 'Local', `type` TEXT NOT NULL DEFAULT 'Text', `content` TEXT NOT NULL, `state` TEXT NOT NULL, `partsCount` INTEGER, `createdAt` INTEGER NOT NULL DEFAULT 0, `processedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "withDeliveryReport",
+            "columnName": "withDeliveryReport",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "simNumber",
+            "columnName": "simNumber",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "validUntil",
+            "columnName": "validUntil",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "scheduleAt",
+            "columnName": "scheduleAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEncrypted",
+            "columnName": "isEncrypted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "skipPhoneValidation",
+            "columnName": "skipPhoneValidation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Local'"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Text'"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partsCount",
+            "columnName": "partsCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "processedAt",
+            "columnName": "processedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Message_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Message_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_Message_state_processedAt",
+            "unique": false,
+            "columnNames": [
+              "state",
+              "processedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Message_state_processedAt` ON `${TABLE_NAME}` (`state`, `processedAt`)"
+          },
+          {
+            "name": "index_Message_state_createdAt",
+            "unique": false,
+            "columnNames": [
+              "state",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Message_state_createdAt` ON `${TABLE_NAME}` (`state`, `createdAt`)"
+          },
+          {
+            "name": "index_Message_state_scheduleAt",
+            "unique": false,
+            "columnNames": [
+              "state",
+              "scheduleAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Message_state_scheduleAt` ON `${TABLE_NAME}` (`state`, `scheduleAt`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "MessageRecipient",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, `state` TEXT NOT NULL, `error` TEXT, PRIMARY KEY(`messageId`, `phoneNumber`), FOREIGN KEY(`messageId`) REFERENCES `Message`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "phoneNumber"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Message",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "RecipientState",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, `state` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`messageId`, `phoneNumber`, `state`), FOREIGN KEY(`messageId`, `phoneNumber`) REFERENCES `MessageRecipient`(`messageId`, `phoneNumber`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "phoneNumber",
+            "state"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "MessageRecipient",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId",
+              "phoneNumber"
+            ],
+            "referencedColumns": [
+              "messageId",
+              "phoneNumber"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "MessageState",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `state` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`messageId`, `state`), FOREIGN KEY(`messageId`) REFERENCES `Message`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "messageId",
+            "state"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Message",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "WebHook",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `event` TEXT NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "event",
+            "columnName": "event",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "webhook_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `payload` TEXT NOT NULL, `retry_count` INTEGER NOT NULL DEFAULT 0, `status` TEXT NOT NULL DEFAULT 'pending', `created_at` INTEGER NOT NULL, `next_attempt` INTEGER NOT NULL, `last_error` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retry_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'pending'"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextAttempt",
+            "columnName": "next_attempt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "last_error",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_webhook_queue_status_next_attempt",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "next_attempt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_webhook_queue_status_next_attempt` ON `${TABLE_NAME}` (`status`, `next_attempt`)"
+          },
+          {
+            "name": "index_webhook_queue_status_created_at",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_webhook_queue_status_created_at` ON `${TABLE_NAME}` (`status`, `created_at`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "logs_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`priority` TEXT NOT NULL, `module` TEXT NOT NULL, `message` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `context` TEXT, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "module",
+            "columnName": "module",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "context",
+            "columnName": "context",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_logs_entries_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_logs_entries_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tokens",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `expiresAt` INTEGER NOT NULL, `revokedAt` INTEGER, `tokenUse` TEXT NOT NULL DEFAULT 'access', `parentJti` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revokedAt",
+            "columnName": "revokedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tokenUse",
+            "columnName": "tokenUse",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'access'"
+          },
+          {
+            "fieldPath": "parentJti",
+            "columnName": "parentJti",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_tokens_expiresAt",
+            "unique": false,
+            "columnNames": [
+              "expiresAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tokens_expiresAt` ON `${TABLE_NAME}` (`expiresAt`)"
+          },
+          {
+            "name": "index_tokens_tokenUse",
+            "unique": false,
+            "columnNames": [
+              "tokenUse"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tokens_tokenUse` ON `${TABLE_NAME}` (`tokenUse`)"
+          },
+          {
+            "name": "index_tokens_parentJti",
+            "unique": false,
+            "columnNames": [
+              "parentJti"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tokens_parentJti` ON `${TABLE_NAME}` (`parentJti`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "incoming_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `type` TEXT NOT NULL, `sender` TEXT NOT NULL, `recipient` TEXT, `simNumber` INTEGER, `subscriptionId` INTEGER, `contentPreview` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipient",
+            "columnName": "recipient",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "simNumber",
+            "columnName": "simNumber",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "subscriptionId",
+            "columnName": "subscriptionId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentPreview",
+            "columnName": "contentPreview",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_incoming_messages_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_incoming_messages_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_incoming_messages_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_incoming_messages_type` ON `${TABLE_NAME}` (`type`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "encryption_keys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `key_version` INTEGER NOT NULL, `private_key_blob` BLOB NOT NULL, `public_key_base64` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `retired_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyVersion",
+            "columnName": "key_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privateKeyBlob",
+            "columnName": "private_key_blob",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicKeyBase64",
+            "columnName": "public_key_base64",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retiredAt",
+            "columnName": "retired_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_encryption_keys_retired_at",
+            "unique": false,
+            "columnNames": [
+              "retired_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_encryption_keys_retired_at` ON `${TABLE_NAME}` (`retired_at`)"
+          },
+          {
+            "name": "index_encryption_keys_key_version",
+            "unique": true,
+            "columnNames": [
+              "key_version"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_encryption_keys_key_version` ON `${TABLE_NAME}` (`key_version`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '481a0f54fb3737280ebff0d95187528d')"
+    ]
+  }
+}

--- a/app/src/androidTest/assets/e2e-vector-v1.json
+++ b/app/src/androidTest/assets/e2e-vector-v1.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "format": "rsa-oaep-aes-256-gcm",
+  "version": "1",
+  "keyVersion": 1,
+  "algorithms": {
+    "rsaOaep": "RSA/ECB/OAEPWithSHA-256AndMGF1Padding",
+    "hash": "SHA-256",
+    "mgf1": "MGF1-SHA-256",
+    "aesGcm": "AES/GCM/NoPadding",
+    "tagBits": 128,
+    "ivLen": 12
+  },
+  "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDxn2NKvx1gOlk6\ned6kEJJQGOL/c0LaT6x2NYrem6m5clY3hhlQoMaq3uaTsbHqSWVni02XABJFjuaR\nNtsVYiFmvY4mc5Rlz/2XLBNwHcGh/aFoSZGFF8QSW+VAZ0Rmh/n5G55xnZznMhjp\nWWfwlxh7Qoogtyn2G4C/doIT7W5SyIKZO2TsAE8j4cXugfCxIk8J/R9D+8JRgFK2\nHRBIxyT2OotoCjVLUjnM3cIB5NJ+f8eTlT6OMq8l/VJNahHvwC1GEG+4ASex8UBt\nwkdpDvs3u11SiM/osUypYFckV9mY58oIo2jC5iClkULKqLyLtPET4RV1cU4TWxkX\nEJLqf0cDAgMBAAECggEAAbUl1KmSHGkn0p0kNiufJRgamUHoHIvd76iZi9Dfe7Mz\nqckgVQILNWTwOJCpGGX0D1hxhW+CMYynfio8P86a5tN7IDQb6Iug7Vhp5hZyamHU\n/1wvE5jjPAVQkvUdNiOgNXhSVSzkfCZ4p5mH/bAhA6n+OOn3zsigpHnCxJTz0nub\nG1tyngp9FnJgRg8J/vuk3Tv/n+6SxnIm/rcQWIelv5SXXcto4e4/aDElBrLs8+UM\npEGD2xLM0CbGrobwEuEIX6NwaEDxVeKRgnAV7RJcmM/2VdC39NR7Mx7BaeX7nWWc\nZkXCj9gjXzQQXl4P02qVEIlJVQolTHXwBEAPVAbrQQKBgQD7JxOtxUIQ7omGtoW9\nTmT95ek/oi9u/Pb8Eh7zBGBblNfPfEi9lq30k3Njpr5386ZpeoM55ISFtjwru46X\nlbc7GRtvjRHLlXyBWtqznDU8Lr1TN6ypdhplbfxcB15qXH0/LQe9JbaO8P7+R88p\np6XUy4rlwRpiQc8vwwJfosSbQwKBgQD2STlTBhMDkGD39EnrVgqwjUMGRL14z+yt\nB6IlOtMmS4zFGpWFVd7yt/WIW1xYD/XnjkB6EPPGV8EPAPq+KScdGc6+7sWUlV6y\nLHYRu46q8vFt/kXv+mh1aI3I0rDt3+VEFRg3Hgrg1NlAfu1dYasr4JmwxJCVz/Ep\nzN+6jj+JQQKBgQCjzvv11ffeRUbr13ZpX41dUKyOdYEMme+Zv1PyW0Nh2DXePYjQ\nJ0w0fku/jk0ivYcnuuGGS/bno1GhkIZTdjH5WMndOxyFNW3sjM6iYVsTcsTHV0PF\nj6NtzovPlnrNUp/aKcunYcateqBGR53l5FOz9EIW0pkbxyKUW1Pb/rTPMwKBgQCZ\n8QMHxhA0dhZmZieeFdXwrRtr26Oi1DRXoyHSq4Y3tZlzyj4Tba1BgYLTjGeYE8Hc\nzqm2osn8+/UMb8xK+GYeZnc4GP8e9I6QSAI060stx1TpL7p/WcHZQVT+ZdN5nC0t\n9RGBwiGCjwiMq8mqSNY5QtZOC09klOlk+04MycUlAQKBgQCD+aBa7P+hnZfNEcdM\n8sNq0fX/m/5RYiDoe5VSIfQCAs4yp3yxpzig0CMOooboW0AI9SuLAAhWP+SVK9lh\n9x4YRBp4O/HMGWQ4r/hmP0hFtZb7uaX2pJcmNK2SMx6cDfscsJwxypLdFtwSQkjq\nr8Je0Wxy/Lku5NQyxEULzKuUOA==\n-----END PRIVATE KEY-----",
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8Z9jSr8dYDpZOnnepBCS\nUBji/3NC2k+sdjWK3pupuXJWN4YZUKDGqt7mk7Gx6kllZ4tNlwASRY7mkTbbFWIh\nZr2OJnOUZc/9lywTcB3Bof2haEmRhRfEElvlQGdEZof5+RuecZ2c5zIY6Vln8JcY\ne0KKILcp9huAv3aCE+1uUsiCmTtk7ABPI+HF7oHwsSJPCf0fQ/vCUYBSth0QSMck\n9jqLaAo1S1I5zN3CAeTSfn/Hk5U+jjKvJf1STWoR78AtRhBvuAEnsfFAbcJHaQ77\nN7tdUojP6LFMqWBXJFfZmOfKCKNowuYgpZFCyqi8i7TxE+EVdXFOE1sZFxCS6n9H\nAwIDAQAB\n-----END PUBLIC KEY-----\n",
+  "publicKeySpkiBase64": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8Z9jSr8dYDpZOnnepBCSUBji/3NC2k+sdjWK3pupuXJWN4YZUKDGqt7mk7Gx6kllZ4tNlwASRY7mkTbbFWIhZr2OJnOUZc/9lywTcB3Bof2haEmRhRfEElvlQGdEZof5+RuecZ2c5zIY6Vln8JcYe0KKILcp9huAv3aCE+1uUsiCmTtk7ABPI+HF7oHwsSJPCf0fQ/vCUYBSth0QSMck9jqLaAo1S1I5zN3CAeTSfn/Hk5U+jjKvJf1STWoR78AtRhBvuAEnsfFAbcJHaQ77N7tdUojP6LFMqWBXJFfZmOfKCKNowuYgpZFCyqi8i7TxE+EVdXFOE1sZFxCS6n9HAwIDAQAB",
+  "aesKeyHex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+  "ivHex": "000102030405060708090a0b",
+  "plaintext": "The quick brown fox jumps over the lazy dog 0123456789",
+  "chunk4EncryptedAesKeyB64": "we9jv63Er6bukIsgCkorCXDtEx5elni/OeguUvX0shoIQIQxnbr65asrFDRoJJztnEjagR45Oc1zVOwkIpnPXA9cploe7F12IVSc3oeXGWhGMtsbk3rL3PLT2qxgX390+QES4zgaKXULQ5fmmqZPFyEr/5/wQ04Z4i3PsRML5EBzMuD6rLrzrc195KIMiFYJ88AvnQN7Cju3ELvbiiNn7m20zftgcWHmo3VtzC7s1Gs8agPmjepe9GbeTaM3a9vF3qTX0hG6yjaV/tR17opQ16H9KpPGXo9rIrJJ++1olCdYDs/uw1F2iYDULncNs80zj6myn7QM1dvsd3IvBgykiQ==",
+  "ctTagChunkB64": "E2qzO7SQq3jmYfX53p4WTeW5/xSaDjIMS0eK83gbIMZpdY6QzrtruBDLGM24thoL2mxWumLvk9LtQZ0tPm1tWWUipJ5q7Q==",
+  "fullFormatSample": "$rsa-oaep-aes-256-gcm$v=1$k=1$we9jv63Er6bukIsgCkorCXDtEx5elni/OeguUvX0shoIQIQxnbr65asrFDRoJJztnEjagR45Oc1zVOwkIpnPXA9cploe7F12IVSc3oeXGWhGMtsbk3rL3PLT2qxgX390+QES4zgaKXULQ5fmmqZPFyEr/5/wQ04Z4i3PsRML5EBzMuD6rLrzrc195KIMiFYJ88AvnQN7Cju3ELvbiiNn7m20zftgcWHmo3VtzC7s1Gs8agPmjepe9GbeTaM3a9vF3qTX0hG6yjaV/tR17opQ16H9KpPGXo9rIrJJ++1olCdYDs/uw1F2iYDULncNs80zj6myn7QM1dvsd3IvBgykiQ==$AAECAwQFBgcICQoL$E2qzO7SQq3jmYfX53p4WTeW5/xSaDjIMS0eK83gbIMZpdY6QzrtruBDLGM24thoL2mxWumLvk9LtQZ0tPm1tWWUipJ5q7Q==",
+  "notes": [
+    "RSA-OAEP is randomized per RFC 8017 7.1.2: chunk4 and fullFormatSample are ONE valid sample (generated with a fixed seed for reproducibility); any rand source yields a valid chunk4.",
+    "Only ctTagChunkB64 (and chunk6 of fullFormatSample, given the same fixed key+IV+plaintext) is byte-comparable across languages.",
+    "Verify chunk4 by RSA-decrypting with privateKeyPem: the result must equal the 32 bytes of aesKeyHex.",
+    "The AES key is 32 bytes; the IV is 12 bytes. A 12-byte AES key throws InvalidKeyException on Android.",
+    "Production code MUST generate a fresh 12-byte CSPRNG IV per value (body + each phone number) and never reuse ivHex."
+  ]
+}

--- a/app/src/androidTest/java/me/capcom/smsgateway/encryption/E2EEncryptionBenchmarkTest.kt
+++ b/app/src/androidTest/java/me/capcom/smsgateway/encryption/E2EEncryptionBenchmarkTest.kt
@@ -1,0 +1,238 @@
+package me.capcom.smsgateway.encryption
+
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import android.util.Log
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.spec.MGF1ParameterSpec
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.OAEPParameterSpec
+import javax.crypto.spec.PSource
+import javax.crypto.spec.SecretKeySpec
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Performance benchmarks + cross-language format verification for the E2E
+ * hybrid scheme (RSA-2048 OAEP-SHA256 + AES-256-GCM), plan
+ * `e2e-encryption-device-paired`.
+ *
+ * Acceptance thresholds (docs/plan/e2e-encryption/benchmarks.md):
+ *  - API 21-22 (software keygen path): keygen < 5 s, per-message decrypt < 200 ms,
+ *    100 messages < 15 s
+ *  - API 28+ (AndroidKeyStore path): keygen < 1 s, per-message decrypt < 50 ms
+ *  - API 23-27 runs the API 28+ thresholds (Keystore is available from API 23)
+ *
+ * Manual run:
+ *  ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=me.capcom.smsgateway.encryption.E2EEncryptionBenchmarkTest
+ * on an API 21/22 and an API 28+ emulator.
+ */
+@RunWith(AndroidJUnit4::class)
+class E2EEncryptionBenchmarkTest {
+
+    private val tag = "E2EBenchmark"
+
+    // ---------------------------------------------------------------------
+    // Cross-language format check: decrypt the shared vector sample with the
+    // exact JCA path used by EncryptionService.decryptE2E.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun vectorSampleDecryptsWithAndroidJcaPath() {
+        val vector = loadVector()
+        val privateKey = parseVectorPrivateKey(vector)
+        val plaintext = decryptE2EValue(vector.optString("fullFormatSample"), privateKey)
+
+        assertEquals(vector.optString("plaintext"), plaintext)
+        Log.i(tag, "vector fullFormatSample decrypted via Android JCA path OK")
+    }
+
+    // ---------------------------------------------------------------------
+    // Key generation
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun keygenWithinThreshold() {
+        val sdk = Build.VERSION.SDK_INT
+        val limitMs = if (sdk < Build.VERSION_CODES.M) 5000L else 1000L
+
+        val started = System.nanoTime()
+        val keyPair = generateKeyPair(sdk)
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+
+        assertTrue(
+            "keygen took ${elapsedMs}ms, limit ${limitMs}ms (API $sdk)",
+            elapsedMs < limitMs,
+        )
+        Log.i(tag, "keygen API=$sdk elapsed=${elapsedMs}ms")
+    }
+
+    // ---------------------------------------------------------------------
+    // Per-message decryption
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun decryptWithinThreshold() {
+        val sdk = Build.VERSION.SDK_INT
+        val limitMs = if (sdk < Build.VERSION_CODES.M) 200L else 50L
+
+        val keyPair = generateKeyPair(sdk)
+        val value = encryptE2EValue(keyPair.public, "per-message benchmark payload")
+
+        val started = System.nanoTime()
+        val plaintext = decryptE2EValue(value, keyPair.private)
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+
+        assertEquals("per-message benchmark payload", plaintext)
+        assertTrue(
+            "decrypt took ${elapsedMs}ms, limit ${limitMs}ms (API $sdk)",
+            elapsedMs < limitMs,
+        )
+        Log.i(tag, "decrypt API=$sdk elapsed=${elapsedMs}ms")
+    }
+
+    // ---------------------------------------------------------------------
+    // Batch: 100 messages
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun batch100DecryptsWithin15s() {
+        val sdk = Build.VERSION.SDK_INT
+        val keyPair = generateKeyPair(sdk)
+        val values = (0 until 100).map {
+            encryptE2EValue(keyPair.public, "batch message number $it")
+        }
+
+        val started = System.nanoTime()
+        for (value in values) {
+            decryptE2EValue(value, keyPair.private)
+        }
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+
+        assertTrue(
+            "100 decryptions took ${elapsedMs}ms, limit 15000ms (API $sdk)",
+            elapsedMs < 15_000L,
+        )
+        Log.i(tag, "batch100 API=$sdk elapsed=${elapsedMs}ms per-msg=${elapsedMs / 100.0}ms")
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers (mirror E2EKeyService / EncryptionService)
+    // ---------------------------------------------------------------------
+
+    private fun generateKeyPair(sdk: Int): KeyPair {
+        return if (sdk >= Build.VERSION_CODES.M) {
+            val alias = "e2e_benchmark_${System.nanoTime()}"
+            val generator = KeyPairGenerator.getInstance(
+                KeyProperties.KEY_ALGORITHM_RSA,
+                "AndroidKeyStore",
+            )
+            val spec = KeyGenParameterSpec.Builder(
+                alias,
+                KeyProperties.PURPOSE_DECRYPT or KeyProperties.PURPOSE_ENCRYPT,
+            )
+                .setKeySize(2048)
+                .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_OAEP)
+                .setDigests(KeyProperties.DIGEST_SHA256)
+                .build()
+            generator.initialize(spec)
+            generator.generateKeyPair()
+        } else {
+            val generator = KeyPairGenerator.getInstance("RSA")
+            generator.initialize(2048)
+            generator.generateKeyPair()
+        }
+    }
+
+    private fun encryptE2EValue(publicKey: PublicKey, plaintext: String): String {
+        val aesKey = ByteArray(32).also { java.security.SecureRandom().nextBytes(it) }
+        val iv = ByteArray(12).also { java.security.SecureRandom().nextBytes(it) }
+
+        val rsaCipher = Cipher.getInstance(RSA_OAEP_ALGORITHM)
+        rsaCipher.init(Cipher.ENCRYPT_MODE, publicKey, oaepSpec())
+        val encryptedAesKey = rsaCipher.doFinal(aesKey)
+
+        val aesCipher = Cipher.getInstance(AES_GCM_ALGORITHM)
+        aesCipher.init(
+            Cipher.ENCRYPT_MODE,
+            SecretKeySpec(aesKey, "AES"),
+            GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv),
+        )
+        val ciphertext = aesCipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+
+        return "$E2E_FORMAT\$v=1\$k=1\$" +
+            Base64.encodeToString(encryptedAesKey, Base64.NO_WRAP) + "$" +
+            Base64.encodeToString(iv, Base64.NO_WRAP) + "$" +
+            Base64.encodeToString(ciphertext, Base64.NO_WRAP)
+    }
+
+    private fun decryptE2EValue(value: String, privateKey: PrivateKey): String {
+        val chunks = value.split("$")
+        check(chunks.size >= 7) { "Invalid E2E encrypted data format: expected at least 7 chunks" }
+        check(chunks[2].removePrefix("v=") == "1") { "Unsupported E2E version: ${chunks[2]}" }
+        chunks[3].removePrefix("k=").toIntOrNull()
+            ?: error("Invalid E2E key version: ${chunks[3]}")
+
+        val encryptedAesKey = Base64.decode(chunks[4], Base64.DEFAULT)
+        val iv = Base64.decode(chunks[5], Base64.DEFAULT)
+        val ciphertext = Base64.decode(chunks[6], Base64.DEFAULT)
+
+        val rsaCipher = Cipher.getInstance(RSA_OAEP_ALGORITHM)
+        rsaCipher.init(Cipher.DECRYPT_MODE, privateKey, oaepSpec())
+        val aesKey = rsaCipher.doFinal(encryptedAesKey)
+
+        val aesCipher = Cipher.getInstance(AES_GCM_ALGORITHM)
+        aesCipher.init(
+            Cipher.DECRYPT_MODE,
+            SecretKeySpec(aesKey, "AES"),
+            GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv),
+        )
+        return String(aesCipher.doFinal(ciphertext), Charsets.UTF_8)
+    }
+
+    private fun oaepSpec(): OAEPParameterSpec {
+        return OAEPParameterSpec(
+            "SHA-256",
+            "MGF1",
+            MGF1ParameterSpec.SHA256,
+            PSource.PSpecified.DEFAULT,
+        )
+    }
+
+    private fun loadVector(): JSONObject {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val json = context.assets.open("e2e-vector-v1.json").bufferedReader().use { it.readText() }
+        return JSONObject(json)
+    }
+
+    private fun parseVectorPrivateKey(vector: JSONObject): PrivateKey {
+        val pem = vector.optString("privateKeyPem")
+        val base64Body = pem
+            .removePrefix("-----BEGIN PRIVATE KEY-----")
+            .removeSuffix("-----END PRIVATE KEY-----")
+            .replace("\n", "")
+        val keyBytes = Base64.decode(base64Body, Base64.DEFAULT)
+        val spec = java.security.spec.PKCS8EncodedKeySpec(keyBytes)
+        return java.security.KeyFactory.getInstance("RSA").generatePrivate(spec)
+    }
+
+    companion object {
+        private const val E2E_FORMAT = "\$rsa-oaep-aes-256-gcm"
+        private const val GCM_TAG_LENGTH_BITS = 128
+        private const val RSA_OAEP_ALGORITHM = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"
+        private const val AES_GCM_ALGORITHM = "AES/GCM/NoPadding"
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,12 +23,15 @@
     <application
         android:name=".App"
         android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="${networkSecurityConfig}"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.SmsGateway">
+        android:theme="@style/Theme.SmsGateway"
+        tools:targetApi="s">
         <service
             android:name=".modules.gateway.services.SSEForegroundService"
             android:enabled="true"

--- a/app/src/main/java/me/capcom/smsgateway/App.kt
+++ b/app/src/main/java/me/capcom/smsgateway/App.kt
@@ -2,13 +2,14 @@ package me.capcom.smsgateway
 
 import android.app.Application
 import android.content.Context
-import healthModule
 import me.capcom.smsgateway.data.dbModule
 import me.capcom.smsgateway.helpers.LocaleHelper
 import me.capcom.smsgateway.modules.connection.connectionModule
 import me.capcom.smsgateway.modules.encryption.encryptionModule
 import me.capcom.smsgateway.modules.events.eventBusModule
 import me.capcom.smsgateway.modules.gateway.GatewayService
+import me.capcom.smsgateway.modules.gateway.gatewayModule
+import me.capcom.smsgateway.modules.health.healthModule
 import me.capcom.smsgateway.modules.incoming.incomingModule
 import me.capcom.smsgateway.modules.localserver.localserverModule
 import me.capcom.smsgateway.modules.logs.logsModule
@@ -28,7 +29,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 
-class App: Application() {
+class App : Application() {
     override fun attachBaseContext(base: Context?) {
         super.attachBaseContext(base?.let { LocaleHelper.onAttach(it) })
     }
@@ -50,7 +51,7 @@ class App: Application() {
                 incomingModule,
                 receiverModule,
                 encryptionModule,
-                me.capcom.smsgateway.modules.gateway.gatewayModule,
+                gatewayModule,
                 healthModule,
                 webhooksModule,
                 localserverModule,

--- a/app/src/main/java/me/capcom/smsgateway/data/AppDatabase.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/AppDatabase.kt
@@ -12,6 +12,8 @@ import me.capcom.smsgateway.data.entities.MessageRecipient
 import me.capcom.smsgateway.data.entities.MessageState
 import me.capcom.smsgateway.data.entities.RecipientState
 import me.capcom.smsgateway.data.entities.Token
+import me.capcom.smsgateway.modules.encryption.db.EncryptionKey
+import me.capcom.smsgateway.modules.encryption.db.EncryptionKeysDao
 import me.capcom.smsgateway.modules.incoming.db.IncomingMessage
 import me.capcom.smsgateway.modules.incoming.db.IncomingMessagesDao
 import me.capcom.smsgateway.modules.logs.db.LogEntriesDao
@@ -32,8 +34,9 @@ import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueEntity
         LogEntry::class,
         Token::class,
         IncomingMessage::class,
+        EncryptionKey::class,
     ],
-    version = 23,
+    version = 24,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -57,6 +60,7 @@ import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueEntity
         AutoMigration(from = 20, to = 21),
 //        AutoMigration(from = 21, to = 22), // manual migration
         AutoMigration(from = 22, to = 23),
+        AutoMigration(from = 23, to = 24),
     ]
 )
 @TypeConverters(Converters::class)
@@ -67,6 +71,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun logDao(): LogEntriesDao
     abstract fun incomingMessagesDao(): IncomingMessagesDao
     abstract fun tokensDao(): TokensDao
+    abstract fun e2eKeysDao(): EncryptionKeysDao
 
     companion object {
         fun getDatabase(context: android.content.Context): AppDatabase {

--- a/app/src/main/java/me/capcom/smsgateway/data/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/Module.kt
@@ -10,4 +10,5 @@ val dbModule = module {
     single { get<AppDatabase>().webhookQueueDao() }
     single { get<AppDatabase>().logDao() }
     single { get<AppDatabase>().tokensDao() }
+    single { get<AppDatabase>().e2eKeysDao() }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/AndroidEncryptionKeyStore.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/AndroidEncryptionKeyStore.kt
@@ -1,0 +1,173 @@
+package me.capcom.smsgateway.modules.encryption
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import androidx.annotation.RequiresApi
+import java.security.KeyFactory
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.spec.PKCS8EncodedKeySpec
+
+/**
+ * Abstraction over key material storage so the rotation logic in
+ * [E2EKeyService] can be unit-tested on the JVM.
+ *
+ * On API 23+ keys live in the AndroidKeyStore (non-exportable); on API 21-22
+ * a software keypair is stored as an AES-GCM encrypted blob in Room.
+ */
+interface EncryptionKeyStore {
+    /**
+     * Generates a new RSA-2048 keypair under [alias].
+     * [KeyPairResult.persistedBlob] is what gets stored in Room (empty on API 23+).
+     */
+    fun generateKeyPair(alias: String): KeyPairResult
+
+    /**
+     * Loads the private key for [alias], using [persistedBlob] from Room on
+     * API 21-22. Returns null when the key cannot be found.
+     *
+     * [KeyLoadResult.upgradedBlob] is non-null when the stored blob used the
+     * legacy derivation and was re-encrypted to the PBKDF2 format; the
+     * caller must persist it to Room.
+     */
+    fun getPrivateKey(alias: String, persistedBlob: ByteArray): KeyLoadResult?
+
+    /** Permanently removes the key material under [alias]. */
+    fun delete(alias: String)
+}
+
+data class KeyPairResult(
+    val keyPair: KeyPair,
+    val persistedBlob: ByteArray,
+    val publicKeyBase64: String,
+)
+
+data class KeyLoadResult(
+    val privateKey: PrivateKey,
+)
+
+class AndroidEncryptionKeyStore(
+    private val context: Context,
+) : EncryptionKeyStore {
+
+    private val storageCipher: StorageBlobCipher by lazy {
+        StorageBlobCipher(legacyKeyMaterial())
+    }
+
+    override fun generateKeyPair(alias: String): KeyPairResult {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val keyPair = generateKeyPairInKeystore(alias)
+            KeyPairResult(
+                keyPair,
+                ByteArray(0), // private key lives in AndroidKeyStore
+                encodePublicKey(keyPair),
+            )
+        } else {
+            val keyPair = generateKeyPairSoftware()
+            KeyPairResult(
+                keyPair,
+                encryptPrivateKeyForStorage(keyPair.private),
+                encodePublicKey(keyPair),
+            )
+        }
+    }
+
+    override fun getPrivateKey(alias: String, persistedBlob: ByteArray): KeyLoadResult? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            getKeyFromKeystore(alias)?.let { KeyLoadResult(it) }
+        } else {
+            if (persistedBlob.isEmpty()) return null
+            val decrypted = decryptPrivateKeyFromStorage(persistedBlob)
+            val keySpec = PKCS8EncodedKeySpec(decrypted.plaintext)
+            val privateKey = KeyFactory.getInstance(RSA_ALGORITHM).generatePrivate(keySpec)
+            KeyLoadResult(privateKey)
+        }
+    }
+
+    override fun delete(alias: String) {
+        deleteKeyFromKeystore(alias)
+    }
+
+    private fun encodePublicKey(keyPair: KeyPair): String {
+        return Base64.encodeToString(keyPair.public.encoded, Base64.NO_WRAP)
+    }
+
+    // -------------------------------------------------------------------------
+    // API 23+ : AndroidKeyStore
+    // -------------------------------------------------------------------------
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private fun generateKeyPairInKeystore(alias: String): KeyPair {
+        val kpg = KeyPairGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_RSA,
+            ANDROID_KEYSTORE,
+        )
+        val spec = KeyGenParameterSpec.Builder(
+            alias,
+            KeyProperties.PURPOSE_DECRYPT or KeyProperties.PURPOSE_ENCRYPT,
+        )
+            .setKeySize(2048)
+            .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_OAEP)
+            .setDigests(KeyProperties.DIGEST_SHA256)
+            .build()
+        kpg.initialize(spec)
+        return kpg.generateKeyPair()
+    }
+
+    private fun getKeyFromKeystore(alias: String): PrivateKey? {
+        val ks = KeyStore.getInstance(ANDROID_KEYSTORE)
+        ks.load(null)
+        return ks.getKey(alias, null) as? PrivateKey
+    }
+
+    private fun deleteKeyFromKeystore(alias: String) {
+        val ks = KeyStore.getInstance(ANDROID_KEYSTORE)
+        ks.load(null)
+        ks.deleteEntry(alias)
+    }
+
+    // -------------------------------------------------------------------------
+    // API 21-22 : Software keypair, encrypted private key in Room
+    // -------------------------------------------------------------------------
+
+    private fun generateKeyPairSoftware(): KeyPair {
+        val kpg = KeyPairGenerator.getInstance(RSA_ALGORITHM)
+        kpg.initialize(2048)
+        return kpg.generateKeyPair()
+    }
+
+    private fun encryptPrivateKeyForStorage(privateKey: PrivateKey): ByteArray {
+        return storageCipher.encrypt(privateKey.encoded)
+    }
+
+    private fun decryptPrivateKeyFromStorage(encryptedBlob: ByteArray): BlobDecryptResult {
+        return storageCipher.decrypt(encryptedBlob)
+    }
+
+    /**
+     * Per-device secret material for the API 21-22 software-key derivation.
+     * The same ANDROID_ID:packageName string seeds both the legacy SHA-256
+     * derivation (obfuscation only - see [StorageBlobCipher]) and the PBKDF2
+     * KDF used for v1 blobs.
+     */
+    @SuppressLint("HardwareIds")
+    private fun legacyKeyMaterial(): String {
+        val androidId = android.provider.Settings.Secure.getString(
+            context.contentResolver,
+            android.provider.Settings.Secure.ANDROID_ID,
+        ) ?: "fallback"
+        return "$androidId:${context.packageName}"
+    }
+
+    companion object {
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        private const val RSA_ALGORITHM = "RSA"
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/E2EKeyService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/E2EKeyService.kt
@@ -1,12 +1,5 @@
 package me.capcom.smsgateway.modules.encryption
 
-import android.annotation.SuppressLint
-import android.content.Context
-import android.os.Build
-import android.security.keystore.KeyGenParameterSpec
-import android.security.keystore.KeyProperties
-import android.util.Base64
-import androidx.annotation.RequiresApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -15,27 +8,32 @@ import me.capcom.smsgateway.modules.encryption.db.EncryptionKey
 import me.capcom.smsgateway.modules.encryption.db.EncryptionKeysDao
 import me.capcom.smsgateway.modules.logs.LogsService
 import me.capcom.smsgateway.modules.logs.db.LogEntry
-import java.security.KeyFactory
-import java.security.KeyPair
-import java.security.KeyPairGenerator
-import java.security.KeyStore
-import java.security.MessageDigest
 import java.security.PrivateKey
-import java.security.spec.PKCS8EncodedKeySpec
-import javax.crypto.Cipher
-import javax.crypto.spec.GCMParameterSpec
-import javax.crypto.spec.SecretKeySpec
+import java.util.concurrent.ConcurrentHashMap
 
 class E2EKeyService(
-    private val context: Context,
+    private val keyStore: EncryptionKeyStore,
     private val dao: EncryptionKeysDao,
     private val logsSvc: LogsService,
 ) {
     private val rotationMutex = Mutex()
 
     /**
+     * In-memory cache of loaded [PrivateKey]s keyed by keyVersion. A batch of
+     * N values decrypting with the same keyVersion performs exactly 1 Room
+     * lookup and 1 keystore load; the loaded key is reused for the rest.
+     *
+     * ConcurrentHashMap so invalidations from rotate/retire/cleanup (which do
+     * not hold [rotationMutex]) are safe; the load path in [getPrivateKey] is
+     * double-checked under [rotationMutex] so concurrent batches load once.
+     * Entries are removed on rotate/retire/cleanup so no stale private key
+     * material is retained after it is no longer active.
+     */
+    private val privateKeyCache = ConcurrentHashMap<Int, PrivateKey>()
+
+    /**
      * Ensures the device has an E2E keypair. Generates one if missing.
-     * Returns the public key base64 or null if generation failed.
+     * Returns the current [EncryptionKey] or null if generation failed.
      */
     suspend fun ensureKey(): EncryptionKey? {
         return rotationMutex.withLock {
@@ -43,13 +41,13 @@ class E2EKeyService(
             if (existing != null) return@withLock existing
 
             try {
-                rotateKey()
+                rotateKeyLocked()
             } catch (e: Exception) {
                 logsSvc.insert(
                     LogEntry.Priority.WARN,
                     MODULE_NAME,
                     "Failed to rotate device key",
-                    mapOf("exception" to e),
+                    e,
                 )
                 return@withLock null
             }
@@ -57,50 +55,46 @@ class E2EKeyService(
     }
 
     /**
-     * Generates a new RSA-2048 keypair and stores it.
-     * Retires the current active key if one exists.
-     * Returns the newly created [EncryptionKey].
+     * Generates a new RSA-2048 keypair and stores it, then retires the
+     * previously active key. The retired key stays decryptable (its key
+     * material is kept) until [cleanupOldKeys] purges it after the retention
+     * period, so in-flight messages to older versions still decrypt.
+     *
+     * Returns the newly created [EncryptionKey]. Throws on failure.
      */
-    private suspend fun rotateKey(): EncryptionKey = withContext(Dispatchers.IO) {
+    suspend fun rotateKey(): EncryptionKey {
+        return rotationMutex.withLock {
+            rotateKeyLocked()
+        }
+    }
+
+    private suspend fun rotateKeyLocked(): EncryptionKey = withContext(Dispatchers.IO) {
         val nextVersion = (dao.getAll().firstOrNull()?.keyVersion ?: 0) + 1
         val alias = keyAlias(nextVersion)
 
-        val keyPair = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            generateKeyPairInKeystore(alias)
-        } else {
-            generateKeyPairSoftware()
-        }
-
-        // Retire current active key (also deletes its AndroidKeyStore entry)
-        dao.getCurrent()?.let { current ->
-            retireKey(current.keyVersion)
-        }
-
-        val privateKeyBlob = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            ByteArray(0) // stored in AndroidKeyStore
-        } else {
-            encryptPrivateKeyForStorage(keyPair.private)
-        }
-
-        val publicKeyBase64 = Base64.encodeToString(
-            keyPair.public.encoded,
-            Base64.NO_WRAP,
-        )
-
+        val generated = keyStore.generateKeyPair(alias)
         val entity = EncryptionKey(
             keyVersion = nextVersion,
-            privateKeyBlob = privateKeyBlob,
-            publicKeyBase64 = publicKeyBase64,
+            privateKeyBlob = generated.persistedBlob,
+            publicKeyBase64 = generated.publicKeyBase64,
         )
+
+        // Persist the new key first so there is never a window with no
+        // active key, then retire the old one.
+        val current = dao.getCurrent()
         val id = try {
             dao.insert(entity)
         } catch (e: Exception) {
             // Remove the keystore entry so it is not orphaned when persistence fails
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                deleteKeyFromKeystore(alias)
+            try {
+                keyStore.delete(alias)
+            } catch (_: Exception) {
+                // best-effort cleanup; original failure is what matters
             }
             throw e
         }
+
+        current?.let { retireKey(it.keyVersion) }
 
         val saved = entity.copy(id = id)
         try {
@@ -110,9 +104,12 @@ class E2EKeyService(
                 LogEntry.Priority.WARN,
                 MODULE_NAME,
                 "Failed to enforce key limit",
-                mapOf("exception" to e),
+                e,
             )
         }
+        // A new version is active and old ones were retired: never serve stale
+        // private key material from before the rotation.
+        privateKeyCache.clear()
         saved
     }
 
@@ -128,102 +125,25 @@ class E2EKeyService(
      * active key when null. Returns null if the key cannot be found or loaded.
      */
     suspend fun getPrivateKey(keyVersion: Int): PrivateKey? = withContext(Dispatchers.IO) {
-        val record = dao.getByKeyVersion(keyVersion) ?: return@withContext null
+        // Fast path: already loaded in this process for this keyVersion.
+        privateKeyCache[keyVersion]?.let { return@withContext it }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            getKeyFromKeystore(keyAlias(record.keyVersion))
-        } else {
-            if (record.privateKeyBlob.isEmpty()) return@withContext null
-            decryptPrivateKeyFromStorage(record.privateKeyBlob)
+        rotationMutex.withLock {
+            // Double-checked: another batch may have loaded it while we waited.
+            privateKeyCache[keyVersion]?.let { return@withLock it }
+
+            val record = dao.getByKeyVersion(keyVersion) ?: return@withLock null
+            val loaded = keyStore.getPrivateKey(keyAlias(record.keyVersion), record.privateKeyBlob)
+                ?: return@withLock null
+            loaded.privateKey.also { privateKeyCache[keyVersion] = it }
         }
-    }
-
-    // -------------------------------------------------------------------------
-    // API 23+ : AndroidKeyStore
-    // -------------------------------------------------------------------------
-
-    @RequiresApi(Build.VERSION_CODES.M)
-    private fun generateKeyPairInKeystore(alias: String): KeyPair {
-        val kpg = KeyPairGenerator.getInstance(
-            KeyProperties.KEY_ALGORITHM_RSA,
-            ANDROID_KEYSTORE,
-        )
-        val spec = KeyGenParameterSpec.Builder(
-            alias,
-            KeyProperties.PURPOSE_DECRYPT or KeyProperties.PURPOSE_ENCRYPT,
-        )
-            .setKeySize(2048)
-            .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
-            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_OAEP)
-            .setDigests(KeyProperties.DIGEST_SHA256)
-            .build()
-        kpg.initialize(spec)
-        return kpg.generateKeyPair()
-    }
-
-    private fun getKeyFromKeystore(alias: String): PrivateKey? {
-        val ks = KeyStore.getInstance(ANDROID_KEYSTORE)
-        ks.load(null)
-        return ks.getKey(alias, null) as? PrivateKey
-    }
-
-    private fun deleteKeyFromKeystore(alias: String) {
-        val ks = KeyStore.getInstance(ANDROID_KEYSTORE)
-        ks.load(null)
-        ks.deleteEntry(alias)
-    }
-
-    // -------------------------------------------------------------------------
-    // API 21-22 : Software keypair, encrypted private key in Room
-    // -------------------------------------------------------------------------
-
-    private fun generateKeyPairSoftware(): KeyPair {
-        val kpg = KeyPairGenerator.getInstance("RSA")
-        kpg.initialize(2048)
-        return kpg.generateKeyPair()
-    }
-
-    private fun encryptPrivateKeyForStorage(privateKey: PrivateKey): ByteArray {
-        val secretKey = deriveStorageKey()
-        val cipher = Cipher.getInstance(AES_GCM)
-        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
-        val iv = cipher.iv
-        val encrypted = cipher.doFinal(privateKey.encoded)
-        return iv + encrypted
-    }
-
-    private fun decryptPrivateKeyFromStorage(encryptedBlob: ByteArray): PrivateKey {
-        val secretKey = deriveStorageKey()
-        val cipher = Cipher.getInstance(AES_GCM)
-        val iv = encryptedBlob.copyOf(GCM_IV_LENGTH)
-        val encrypted = encryptedBlob.copyOfRange(GCM_IV_LENGTH, encryptedBlob.size)
-        val gcmSpec = GCMParameterSpec(128, iv)
-        cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmSpec)
-        val keyBytes = cipher.doFinal(encrypted)
-
-        val keySpec = PKCS8EncodedKeySpec(keyBytes)
-        return KeyFactory.getInstance("RSA").generatePrivate(keySpec)
-    }
-
-    /**
-     * Derives a 256-bit AES key from ANDROID_ID + package name.
-     * Not hardware-backed; provides at-rest encryption only.
-     */
-    @SuppressLint("HardwareIds")
-    private fun deriveStorageKey(): SecretKeySpec {
-        val androidId = android.provider.Settings.Secure.getString(
-            context.contentResolver,
-            android.provider.Settings.Secure.ANDROID_ID,
-        ) ?: "fallback"
-        val keyMaterial = "$androidId:${context.packageName}".toByteArray()
-        val digest = MessageDigest.getInstance("SHA-256")
-        val keyBytes = digest.digest(keyMaterial).copyOf(AES_KEY_LENGTH)
-        return SecretKeySpec(keyBytes, "AES")
     }
 
     /**
      * Checks if the device has reached the maximum number of active keys.
-     * If so, cleans up old ones.
+     * If so, retires the oldest ones (Room-only; key material is retained so
+     * old keys remain decryptable) and purges entries past the retention
+     * period.
      */
     suspend fun enforceKeyLimit() = withContext(Dispatchers.IO) {
         val activeKeys = dao.getAllActive()
@@ -240,32 +160,48 @@ class E2EKeyService(
     }
 
     /**
-     * Retires the key with the given [keyVersion].
+     * Retires the key with the given [keyVersion]: marks the Room row retired
+     * only. The AndroidKeyStore entry is intentionally left intact so
+     * messages encrypted to this version remain decryptable; it is removed
+     * later by [cleanupOldKeys] after the 7-day retention cutoff.
      */
     private suspend fun retireKey(keyVersion: Int) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            deleteKeyFromKeystore(keyAlias(keyVersion))
-        }
         dao.retire(keyVersion)
+        // The key is no longer active; drop any cached material for it.
+        privateKeyCache.remove(keyVersion)
     }
 
     /**
-     * Deletes keys that are retired and older than 7 days.
+     * Deletes keys that are retired and older than 7 days: removes the
+     * AndroidKeyStore entry and the Room row in the same pass.
      */
-    private suspend fun cleanupOldKeys() = withContext(Dispatchers.IO) {
-        val cutoff = System.currentTimeMillis() - 7L * 24 * 60 * 60 * 1000
+    internal suspend fun cleanupOldKeys() = withContext(Dispatchers.IO) {
+        val cutoff = System.currentTimeMillis() - RETENTION_MS
+        val expired = dao.getRetiredOlderThan(cutoff)
+        if (expired.isEmpty()) return@withContext
+
+        for (key in expired) {
+            try {
+                keyStore.delete(keyAlias(key.keyVersion))
+            } catch (e: Exception) {
+                logsSvc.insert(
+                    LogEntry.Priority.WARN,
+                    MODULE_NAME,
+                    "Failed to delete keystore entry for key ${key.keyVersion}",
+                    e,
+                )
+            }
+            // Key material is gone from both Room and the keystore: drop the
+            // cached private key so it is not retained in memory.
+            privateKeyCache.remove(key.keyVersion)
+        }
         dao.deleteOld(cutoff)
     }
 
     private fun keyAlias(version: Int): String = "e2e_key_v$version"
 
     companion object {
-        private const val TAG = "E2EKeyService"
-
-        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
-        private const val AES_GCM = "AES/GCM/NoPadding"
-        private const val GCM_IV_LENGTH = 12
-        private const val AES_KEY_LENGTH = 32
         private const val MAX_ACTIVE_KEYS = 3
+        private const val RETENTION_MS = 7L * 24 * 60 * 60 * 1000
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/E2EKeyService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/E2EKeyService.kt
@@ -1,11 +1,13 @@
 package me.capcom.smsgateway.modules.encryption
 
+import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import me.capcom.smsgateway.modules.encryption.db.EncryptionKey
 import me.capcom.smsgateway.modules.encryption.db.EncryptionKeysDao
+import me.capcom.smsgateway.modules.encryption.workers.KeyRotationWorker
 import me.capcom.smsgateway.modules.logs.LogsService
 import me.capcom.smsgateway.modules.logs.db.LogEntry
 import java.security.PrivateKey
@@ -15,6 +17,7 @@ class E2EKeyService(
     private val keyStore: EncryptionKeyStore,
     private val dao: EncryptionKeysDao,
     private val logsSvc: LogsService,
+    private val settings: EncryptionSettings,
 ) {
     private val rotationMutex = Mutex()
 
@@ -64,6 +67,50 @@ class E2EKeyService(
      */
     suspend fun rotateKey(): EncryptionKey {
         return rotationMutex.withLock {
+            rotateKeyLocked()
+        }
+    }
+
+    fun start(context: Context) {
+        KeyRotationWorker.start(context)
+    }
+
+    fun stop(context: Context) {
+        KeyRotationWorker.stop(context)
+    }
+
+    /**
+     * Rotates the active E2E key when the configured rotation interval has
+     * elapsed since the current key was created. No-op when rotation is
+     * disabled (interval null or <= 0). Creates a baseline key when none
+     * exists so future due-checks have an anchor. The interval is re-read
+     * from settings on every invocation.
+     */
+    suspend fun rotateKeyIfDue() {
+        val intervalDays = settings.rotationIntervalDays ?: return
+        if (intervalDays <= 0) return
+
+        val current = getCurrentKey()
+        if (current == null) {
+            ensureKey()
+            return
+        }
+
+        rotationMutex.withLock {
+            rotateKeyIfDueLocked(intervalDays)
+        }
+    }
+
+    /**
+     * Due-check + rotation under [rotationMutex]: the current key is re-read
+     * inside the lock so the due-decision is atomic with the rotation and a
+     * concurrent manual [rotateKey] cannot cause a double rotation. Calls
+     * [rotateKeyLocked] directly because [rotateKey] re-acquires
+     * [rotationMutex] and Kotlin Mutex is not reentrant.
+     */
+    private suspend fun rotateKeyIfDueLocked(intervalDays: Int) {
+        val current = getCurrentKey() ?: return
+        if (current.createdAt + intervalDays * 86400000L <= System.currentTimeMillis()) {
             rotateKeyLocked()
         }
     }

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/E2EKeyService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/E2EKeyService.kt
@@ -1,0 +1,245 @@
+package me.capcom.smsgateway.modules.encryption
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import me.capcom.smsgateway.modules.encryption.db.EncryptionKey
+import me.capcom.smsgateway.modules.encryption.db.EncryptionKeysDao
+import me.capcom.smsgateway.modules.logs.LogsService
+import me.capcom.smsgateway.modules.logs.db.LogEntry
+import java.security.KeyFactory
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.MessageDigest
+import java.security.PrivateKey
+import java.security.spec.PKCS8EncodedKeySpec
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+class E2EKeyService(
+    private val context: Context,
+    private val dao: EncryptionKeysDao,
+    private val logsSvc: LogsService,
+) {
+    /**
+     * Ensures the device has an E2E keypair. Generates one if missing.
+     * Returns the public key base64 or null if generation failed.
+     */
+    suspend fun ensureKey(): EncryptionKey? {
+        val existing = getCurrentKey()
+        if (existing != null) return existing
+
+        return try {
+            rotateKey()
+        } catch (e: Exception) {
+            logsSvc.insert(
+                LogEntry.Priority.WARN,
+                MODULE_NAME,
+                "Failed to rotate device key",
+                mapOf("exception" to e),
+            )
+            return null
+        }
+    }
+
+    /**
+     * Generates a new RSA-2048 keypair and stores it.
+     * Retires the current active key if one exists.
+     * Returns the newly created [EncryptionKey].
+     */
+    private suspend fun rotateKey(): EncryptionKey = withContext(Dispatchers.IO) {
+        val nextVersion = (dao.getAll().firstOrNull()?.keyVersion ?: 0) + 1
+        val alias = keyAlias(nextVersion)
+
+        val keyPair = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            generateKeyPairInKeystore(alias)
+        } else {
+            generateKeyPairSoftware()
+        }
+
+        // Retire current active key
+        dao.getCurrent()?.let { current ->
+            dao.retire(current.keyVersion)
+        }
+
+        val privateKeyBlob = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            ByteArray(0) // stored in AndroidKeyStore
+        } else {
+            encryptPrivateKeyForStorage(keyPair.private)
+        }
+
+        val publicKeyBase64 = Base64.encodeToString(
+            keyPair.public.encoded,
+            Base64.NO_WRAP,
+        )
+
+        val entity = EncryptionKey(
+            keyVersion = nextVersion,
+            privateKeyBlob = privateKeyBlob,
+            publicKeyBase64 = publicKeyBase64,
+        )
+        val id = dao.insert(entity)
+        entity.copy(id = id)
+    }
+
+    /**
+     * Returns the current active [EncryptionKey], or null if no key exists.
+     */
+    private suspend fun getCurrentKey(): EncryptionKey? = withContext(Dispatchers.IO) {
+        dao.getCurrent()
+    }
+
+    /**
+     * Returns the [PrivateKey] for the given [keyVersion], or the current
+     * active key when null. Returns null if the key cannot be found or loaded.
+     */
+    suspend fun getPrivateKey(keyVersion: Int): PrivateKey? = withContext(Dispatchers.IO) {
+        val record = dao.getByKeyVersion(keyVersion) ?: return@withContext null
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            getKeyFromKeystore(keyAlias(record.keyVersion))
+        } else {
+            if (record.privateKeyBlob.isEmpty()) return@withContext null
+            decryptPrivateKeyFromStorage(record.privateKeyBlob)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // API 23+ : AndroidKeyStore
+    // -------------------------------------------------------------------------
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private fun generateKeyPairInKeystore(alias: String): KeyPair {
+        val kpg = KeyPairGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_RSA,
+            ANDROID_KEYSTORE,
+        )
+        val spec = KeyGenParameterSpec.Builder(
+            alias,
+            KeyProperties.PURPOSE_DECRYPT or KeyProperties.PURPOSE_ENCRYPT,
+        )
+            .setKeySize(2048)
+            .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_OAEP)
+            .setDigests(KeyProperties.DIGEST_SHA256)
+            .build()
+        kpg.initialize(spec)
+        return kpg.generateKeyPair()
+    }
+
+    private fun getKeyFromKeystore(alias: String): PrivateKey? {
+        val ks = KeyStore.getInstance(ANDROID_KEYSTORE)
+        ks.load(null)
+        return ks.getKey(alias, null) as? PrivateKey
+    }
+
+    private fun deleteKeyFromKeystore(alias: String) {
+        val ks = KeyStore.getInstance(ANDROID_KEYSTORE)
+        ks.load(null)
+        ks.deleteEntry(alias)
+    }
+
+    // -------------------------------------------------------------------------
+    // API 21-22 : Software keypair, encrypted private key in Room
+    // -------------------------------------------------------------------------
+
+    private fun generateKeyPairSoftware(): KeyPair {
+        val kpg = KeyPairGenerator.getInstance("RSA")
+        kpg.initialize(2048)
+        return kpg.generateKeyPair()
+    }
+
+    private fun encryptPrivateKeyForStorage(privateKey: PrivateKey): ByteArray {
+        val secretKey = deriveStorageKey()
+        val cipher = Cipher.getInstance(AES_GCM)
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+        val iv = cipher.iv
+        val encrypted = cipher.doFinal(privateKey.encoded)
+        return iv + encrypted
+    }
+
+    private fun decryptPrivateKeyFromStorage(encryptedBlob: ByteArray): PrivateKey {
+        val secretKey = deriveStorageKey()
+        val cipher = Cipher.getInstance(AES_GCM)
+        val iv = encryptedBlob.copyOf(GCM_IV_LENGTH)
+        val encrypted = encryptedBlob.copyOfRange(GCM_IV_LENGTH, encryptedBlob.size)
+        val gcmSpec = GCMParameterSpec(128, iv)
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmSpec)
+        val keyBytes = cipher.doFinal(encrypted)
+
+        val keySpec = PKCS8EncodedKeySpec(keyBytes)
+        return KeyFactory.getInstance("RSA").generatePrivate(keySpec)
+    }
+
+    /**
+     * Derives a 256-bit AES key from ANDROID_ID + package name.
+     * Not hardware-backed; provides at-rest encryption only.
+     */
+    @SuppressLint("HardwareIds")
+    private fun deriveStorageKey(): SecretKeySpec {
+        val androidId = android.provider.Settings.Secure.getString(
+            context.contentResolver,
+            android.provider.Settings.Secure.ANDROID_ID,
+        ) ?: "fallback"
+        val keyMaterial = "$androidId:${context.packageName}".toByteArray()
+        val digest = MessageDigest.getInstance("SHA-256")
+        val keyBytes = digest.digest(keyMaterial).copyOf(AES_KEY_LENGTH)
+        return SecretKeySpec(keyBytes, "AES")
+    }
+
+    /**
+     * Checks if the device has reached the maximum number of active keys.
+     * If so, cleans up old ones.
+     */
+    suspend fun enforceKeyLimit() = withContext(Dispatchers.IO) {
+        val activeKeys = dao.getAllActive()
+        if (activeKeys.size <= MAX_ACTIVE_KEYS) return@withContext
+
+        // Keep the latest MAX_ACTIVE_KEYS, retire the rest
+        val toRetire = activeKeys.drop(MAX_ACTIVE_KEYS)
+        for (key in toRetire) {
+            retireKey(key.keyVersion)
+        }
+        cleanupOldKeys()
+
+        return@withContext
+    }
+
+    /**
+     * Retires the key with the given [keyVersion].
+     */
+    private suspend fun retireKey(keyVersion: Int) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            deleteKeyFromKeystore(keyAlias(keyVersion))
+        }
+        dao.retire(keyVersion)
+    }
+
+    /**
+     * Deletes keys that are retired and older than 7 days.
+     */
+    private suspend fun cleanupOldKeys() = withContext(Dispatchers.IO) {
+        val cutoff = System.currentTimeMillis() - 7L * 24 * 60 * 60 * 1000
+        dao.deleteOld(cutoff)
+    }
+
+    private fun keyAlias(version: Int): String = "e2e_key_v$version"
+
+    companion object {
+        private const val TAG = "E2EKeyService"
+
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        private const val AES_GCM = "AES/GCM/NoPadding"
+        private const val GCM_IV_LENGTH = 12
+        private const val AES_KEY_LENGTH = 32
+        private const val MAX_ACTIVE_KEYS = 3
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/E2EKeyService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/E2EKeyService.kt
@@ -8,6 +8,8 @@ import android.security.keystore.KeyProperties
 import android.util.Base64
 import androidx.annotation.RequiresApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import me.capcom.smsgateway.modules.encryption.db.EncryptionKey
 import me.capcom.smsgateway.modules.encryption.db.EncryptionKeysDao
@@ -29,24 +31,28 @@ class E2EKeyService(
     private val dao: EncryptionKeysDao,
     private val logsSvc: LogsService,
 ) {
+    private val rotationMutex = Mutex()
+
     /**
      * Ensures the device has an E2E keypair. Generates one if missing.
      * Returns the public key base64 or null if generation failed.
      */
     suspend fun ensureKey(): EncryptionKey? {
-        val existing = getCurrentKey()
-        if (existing != null) return existing
+        return rotationMutex.withLock {
+            val existing = getCurrentKey()
+            if (existing != null) return@withLock existing
 
-        return try {
-            rotateKey()
-        } catch (e: Exception) {
-            logsSvc.insert(
-                LogEntry.Priority.WARN,
-                MODULE_NAME,
-                "Failed to rotate device key",
-                mapOf("exception" to e),
-            )
-            return null
+            try {
+                rotateKey()
+            } catch (e: Exception) {
+                logsSvc.insert(
+                    LogEntry.Priority.WARN,
+                    MODULE_NAME,
+                    "Failed to rotate device key",
+                    mapOf("exception" to e),
+                )
+                return@withLock null
+            }
         }
     }
 
@@ -65,9 +71,9 @@ class E2EKeyService(
             generateKeyPairSoftware()
         }
 
-        // Retire current active key
+        // Retire current active key (also deletes its AndroidKeyStore entry)
         dao.getCurrent()?.let { current ->
-            dao.retire(current.keyVersion)
+            retireKey(current.keyVersion)
         }
 
         val privateKeyBlob = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -86,8 +92,28 @@ class E2EKeyService(
             privateKeyBlob = privateKeyBlob,
             publicKeyBase64 = publicKeyBase64,
         )
-        val id = dao.insert(entity)
-        entity.copy(id = id)
+        val id = try {
+            dao.insert(entity)
+        } catch (e: Exception) {
+            // Remove the keystore entry so it is not orphaned when persistence fails
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                deleteKeyFromKeystore(alias)
+            }
+            throw e
+        }
+
+        val saved = entity.copy(id = id)
+        try {
+            enforceKeyLimit()
+        } catch (e: Exception) {
+            logsSvc.insert(
+                LogEntry.Priority.WARN,
+                MODULE_NAME,
+                "Failed to enforce key limit",
+                mapOf("exception" to e),
+            )
+        }
+        saved
     }
 
     /**

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionService.kt
@@ -1,12 +1,15 @@
 package me.capcom.smsgateway.modules.encryption
 
 import android.util.Base64
+import java.security.spec.MGF1ParameterSpec
 import javax.crypto.Cipher
 import javax.crypto.SecretKey
 import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.OAEPParameterSpec
 import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.PSource
 import javax.crypto.spec.SecretKeySpec
 
 class EncryptionService(
@@ -76,7 +79,16 @@ class EncryptionService(
             ?: throw RuntimeException("No E2E private key available for version $keyVersion")
 
         val rsaCipher = Cipher.getInstance(RSA_OAEP_ALGORITHM)
-        rsaCipher.init(Cipher.DECRYPT_MODE, privateKey)
+        rsaCipher.init(
+            Cipher.DECRYPT_MODE,
+            privateKey,
+            OAEPParameterSpec(
+                "SHA-256",
+                "MGF1",
+                MGF1ParameterSpec.SHA256,
+                PSource.PSpecified.DEFAULT,
+            ),
+        )
         val aesKeyBytes = rsaCipher.doFinal(encryptedAesKey)
 
         // 2. Decrypt payload with AES-GCM

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionService.kt
@@ -4,20 +4,32 @@ import android.util.Base64
 import javax.crypto.Cipher
 import javax.crypto.SecretKey
 import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.PBEKeySpec
 import javax.crypto.spec.SecretKeySpec
 
 class EncryptionService(
     private val settings: EncryptionSettings,
+    private val e2eKeyService: E2EKeyService,
 ) {
-    fun decrypt(encryptedText: String): String {
+    suspend fun decrypt(encryptedText: String): String {
         val chunks = encryptedText.split('$')
-        if (chunks.size < 5)
+        if (chunks.size < 3) {
             throw RuntimeException("Invalid encrypted data format")
+        }
 
-        if (chunks[1] != "aes-256-cbc/pbkdf2-sha1") {
-            throw RuntimeException("Unsupported algorithm")
+        val algorithm = chunks[1]
+        return when (algorithm) {
+            PASSPHRASE_FORMAT -> decryptPassphrase(chunks)
+            E2E_FORMAT -> decryptE2E(chunks)
+            else -> throw RuntimeException("Unsupported algorithm: $algorithm")
+        }
+    }
+
+    private fun decryptPassphrase(chunks: List<String>): String {
+        if (chunks.size < 5) {
+            throw RuntimeException("Invalid passphrase encrypted data format")
         }
 
         val params = parseParams(chunks[2])
@@ -37,6 +49,44 @@ class EncryptionService(
         )
 
         return decryptText(text, secretKey, salt)
+    }
+
+    private suspend fun decryptE2E(chunks: List<String>): String {
+        // Format: $rsa-oaep-aes-256-gcm$v=1$k=N$<base64(encrypted_aes_key)>$<base64(iv)>$<base64(ciphertext)>
+        if (chunks.size < 7) {
+            throw RuntimeException("Invalid E2E encrypted data format: expected at least 7 chunks")
+        }
+
+        val versionParam = chunks[2]
+        val version = versionParam.removePrefix("v=")
+        if (version != E2E_VERSION) {
+            throw RuntimeException("Unsupported E2E version: $version")
+        }
+
+        val keyVersionParam = chunks[3]
+        val keyVersion = keyVersionParam.removePrefix("k=").toIntOrNull()
+            ?: throw RuntimeException("Invalid E2E key version: $keyVersionParam")
+
+        val encryptedAesKey = Base64.decode(chunks[4], Base64.DEFAULT)
+        val iv = Base64.decode(chunks[5], Base64.DEFAULT)
+        val ciphertext = Base64.decode(chunks[6], Base64.DEFAULT)
+
+        // 1. Decrypt AES key with RSA private key (using specific key version)
+        val privateKey = e2eKeyService.getPrivateKey(keyVersion)
+            ?: throw RuntimeException("No E2E private key available for version $keyVersion")
+
+        val rsaCipher = Cipher.getInstance(RSA_OAEP_ALGORITHM)
+        rsaCipher.init(Cipher.DECRYPT_MODE, privateKey)
+        val aesKeyBytes = rsaCipher.doFinal(encryptedAesKey)
+
+        // 2. Decrypt payload with AES-GCM
+        val aesKey = SecretKeySpec(aesKeyBytes, "AES")
+        val gcmSpec = GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv)
+        val aesCipher = Cipher.getInstance(AES_GCM_ALGORITHM)
+        aesCipher.init(Cipher.DECRYPT_MODE, aesKey, gcmSpec)
+        val decryptedBytes = aesCipher.doFinal(ciphertext)
+
+        return String(decryptedBytes)
     }
 
     private fun decryptText(encryptedText: String, secretKey: SecretKey, iv: ByteArray): String {
@@ -68,5 +118,14 @@ class EncryptionService(
         return params.split(',')
             .map { it.split('=', limit = 2) }
             .associate { it[0] to it[1] }
+    }
+
+    companion object {
+        internal const val PASSPHRASE_FORMAT = "aes-256-cbc/pbkdf2-sha1"
+        internal const val E2E_FORMAT = "rsa-oaep-aes-256-gcm"
+        private const val E2E_VERSION = "1"
+        private const val GCM_TAG_LENGTH_BITS = 128
+        private const val RSA_OAEP_ALGORITHM = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"
+        private const val AES_GCM_ALGORITHM = "AES/GCM/NoPadding"
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionService.kt
@@ -1,21 +1,8 @@
 package me.capcom.smsgateway.modules.encryption
 
-import android.util.Base64
-import java.security.spec.MGF1ParameterSpec
-import javax.crypto.Cipher
-import javax.crypto.SecretKey
-import javax.crypto.SecretKeyFactory
-import javax.crypto.spec.GCMParameterSpec
-import javax.crypto.spec.IvParameterSpec
-import javax.crypto.spec.OAEPParameterSpec
-import javax.crypto.spec.PBEKeySpec
-import javax.crypto.spec.PSource
-import javax.crypto.spec.SecretKeySpec
+import me.capcom.smsgateway.modules.encryption.providers.EncryptionProviderFactory
 
-class EncryptionService(
-    private val settings: EncryptionSettings,
-    private val e2eKeyService: E2EKeyService,
-) {
+class EncryptionService() {
     suspend fun decrypt(encryptedText: String): String {
         val chunks = encryptedText.split('$')
         if (chunks.size < 3) {
@@ -23,121 +10,7 @@ class EncryptionService(
         }
 
         val algorithm = chunks[1]
-        return when (algorithm) {
-            PASSPHRASE_FORMAT -> decryptPassphrase(chunks)
-            E2E_FORMAT -> decryptE2E(chunks)
-            else -> throw RuntimeException("Unsupported algorithm: $algorithm")
-        }
-    }
-
-    private fun decryptPassphrase(chunks: List<String>): String {
-        if (chunks.size < 5) {
-            throw RuntimeException("Invalid passphrase encrypted data format")
-        }
-
-        val params = parseParams(chunks[2])
-        if (!params.containsKey("i")) {
-            throw RuntimeException("Missing iteration count")
-        }
-
-        val salt = decode(chunks[3])
-        val text = chunks[4]
-
-        val passphrase = requireNotNull(settings.passphrase) { "Passphrase is not set" }
-        val secretKey = generateSecretKeyFromPassphrase(
-            passphrase.toCharArray(),
-            salt,
-            256,
-            params.getValue("i").toInt()
-        )
-
-        return decryptText(text, secretKey, salt)
-    }
-
-    private suspend fun decryptE2E(chunks: List<String>): String {
-        // Format: $rsa-oaep-aes-256-gcm$v=1$k=N$<base64(encrypted_aes_key)>$<base64(iv)>$<base64(ciphertext)>
-        if (chunks.size < 7) {
-            throw RuntimeException("Invalid E2E encrypted data format: expected at least 7 chunks")
-        }
-
-        val versionParam = chunks[2]
-        val version = versionParam.removePrefix("v=")
-        if (version != E2E_VERSION) {
-            throw RuntimeException("Unsupported E2E version: $version")
-        }
-
-        val keyVersionParam = chunks[3]
-        val keyVersion = keyVersionParam.removePrefix("k=").toIntOrNull()
-            ?: throw RuntimeException("Invalid E2E key version: $keyVersionParam")
-
-        val encryptedAesKey = Base64.decode(chunks[4], Base64.DEFAULT)
-        val iv = Base64.decode(chunks[5], Base64.DEFAULT)
-        val ciphertext = Base64.decode(chunks[6], Base64.DEFAULT)
-
-        // 1. Decrypt AES key with RSA private key (using specific key version)
-        val privateKey = e2eKeyService.getPrivateKey(keyVersion)
-            ?: throw RuntimeException("No E2E private key available for version $keyVersion")
-
-        val rsaCipher = Cipher.getInstance(RSA_OAEP_ALGORITHM)
-        rsaCipher.init(
-            Cipher.DECRYPT_MODE,
-            privateKey,
-            OAEPParameterSpec(
-                "SHA-256",
-                "MGF1",
-                MGF1ParameterSpec.SHA256,
-                PSource.PSpecified.DEFAULT,
-            ),
-        )
-        val aesKeyBytes = rsaCipher.doFinal(encryptedAesKey)
-
-        // 2. Decrypt payload with AES-GCM
-        val aesKey = SecretKeySpec(aesKeyBytes, "AES")
-        val gcmSpec = GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv)
-        val aesCipher = Cipher.getInstance(AES_GCM_ALGORITHM)
-        aesCipher.init(Cipher.DECRYPT_MODE, aesKey, gcmSpec)
-        val decryptedBytes = aesCipher.doFinal(ciphertext)
-
-        return String(decryptedBytes)
-    }
-
-    private fun decryptText(encryptedText: String, secretKey: SecretKey, iv: ByteArray): String {
-        val ivSpec = IvParameterSpec(iv)
-        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
-        cipher.init(Cipher.DECRYPT_MODE, secretKey, ivSpec)
-        val encryptedBytes = decode(encryptedText)
-        val decryptedBytes = cipher.doFinal(encryptedBytes)
-        return String(decryptedBytes)
-    }
-
-    private fun decode(input: String): ByteArray {
-        return Base64.decode(input, Base64.DEFAULT)
-    }
-
-    private fun generateSecretKeyFromPassphrase(
-        passphrase: CharArray,
-        salt: ByteArray,
-        keyLength: Int = 256,
-        iterationCount: Int = 300_000
-    ): SecretKey {
-        val keySpec = PBEKeySpec(passphrase, salt, iterationCount, keyLength)
-        val keyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")
-        val keyBytes = keyFactory.generateSecret(keySpec).encoded
-        return SecretKeySpec(keyBytes, "AES")
-    }
-
-    private fun parseParams(params: String): Map<String, String> {
-        return params.split(',')
-            .map { it.split('=', limit = 2) }
-            .associate { it[0] to it[1] }
-    }
-
-    companion object {
-        internal const val PASSPHRASE_FORMAT = "aes-256-cbc/pbkdf2-sha1"
-        internal const val E2E_FORMAT = "rsa-oaep-aes-256-gcm"
-        private const val E2E_VERSION = "1"
-        private const val GCM_TAG_LENGTH_BITS = 128
-        private const val RSA_OAEP_ALGORITHM = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"
-        private const val AES_GCM_ALGORITHM = "AES/GCM/NoPadding"
+        
+        return EncryptionProviderFactory.create(algorithm).decrypt(encryptedText)
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionSettings.kt
@@ -14,6 +14,13 @@ class EncryptionSettings(
         get() = storage.get<Int>(VERSION) ?: 0
         set(value) = storage.set(VERSION, value)
 
+    /**
+     * Automatic E2E key rotation interval in days; null or <= 0 disables it.
+     */
+    var rotationIntervalDays: Int?
+        get() = storage.get<Int>(ROTATION_INTERVAL_DAYS)
+        set(value) = storage.set(ROTATION_INTERVAL_DAYS, value)
+
     init {
         migrate()
     }
@@ -38,6 +45,8 @@ class EncryptionSettings(
         private const val PASSPHRASE = "passphrase"
 
         private const val VERSION = "version"
+
+        private const val ROTATION_INTERVAL_DAYS = "rotate_interval_days"
     }
 
     override fun import(data: Map<String, *>): Boolean {

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/Module.kt
@@ -10,4 +10,4 @@ val encryptionModule = module {
     singleOf(::E2EKeyService)
 }
 
-val MODULE_NAME = "Encryption"
+internal const val MODULE_NAME = "Encryption"

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/Module.kt
@@ -4,10 +4,11 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val encryptionModule = module {
-    single {
-        EncryptionService(get(), get())
-    }
+    singleOf(::EncryptionService)
     singleOf(::E2EKeyService)
+    single<EncryptionKeyStore> {
+        AndroidEncryptionKeyStore(get())
+    }
 }
 
 internal const val MODULE_NAME = "Encryption"

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/Module.kt
@@ -1,9 +1,13 @@
 package me.capcom.smsgateway.modules.encryption
 
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val encryptionModule = module {
     single {
-        EncryptionService(get())
+        EncryptionService(get(), get())
     }
+    singleOf(::E2EKeyService)
 }
+
+val MODULE_NAME = "Encryption"

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/StorageBlobCipher.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/StorageBlobCipher.kt
@@ -1,0 +1,160 @@
+package me.capcom.smsgateway.modules.encryption
+
+import java.security.GeneralSecurityException
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Encrypts/decrypts the software (API 21-22) E2E private-key blobs stored in
+ * the "gateway" Room database.
+ *
+ * Blob format:
+ *  - v1 (current, KDF):
+ *    `"SMSK" || version(1) || kdfId(1) || iterations(4 BE) || salt(16) ||
+ *     iv(12) || AES-GCM(ciphertext)`, key = PBKDF2WithHmacSHA1(password =
+ *    same ANDROID_ID material, salt = fresh random per blob, >= 100k
+ *    iterations, 256-bit output).
+ *
+ * The class is pure JVM (no android.* imports) so it is unit-testable on the
+ * host. Throws [IllegalArgumentException] on malformed/unsupported blobs and
+ * [GeneralSecurityException] when authentication fails (tampered key
+ * material, salt, params, IV or ciphertext).
+ */
+class StorageBlobCipher(private val legacyKeyMaterial: String) {
+
+    private val random = SecureRandom()
+
+    /** Encrypts [plaintext] into a v1 blob with a fresh random salt. */
+    fun encrypt(plaintext: ByteArray): ByteArray {
+        val salt = ByteArray(SALT_LENGTH).also { random.nextBytes(it) }
+        val key = deriveKey(legacyKeyMaterial, salt, KDF_ITERATIONS)
+        val cipher = Cipher.getInstance(AES_GCM)
+        cipher.init(Cipher.ENCRYPT_MODE, key)
+        val iv = cipher.iv
+        val ciphertext = cipher.doFinal(plaintext)
+        return encodeBlob(KDF_ID_PBKDF2, KDF_ITERATIONS, salt, iv, ciphertext)
+    }
+
+    /**
+     * Decrypts [blob]. v1 blobs derive the key from their embedded
+     * salt/iterations; headerless legacy blobs use the legacy SHA-256
+     * derivation and yield an [BlobDecryptResult.upgradedBlob] for the
+     * caller to persist.
+     */
+    fun decrypt(blob: ByteArray): BlobDecryptResult {
+        return decryptV1(blob)
+    }
+
+    private fun decryptV1(blob: ByteArray): BlobDecryptResult {
+        require(blob.size >= HEADER_LENGTH) { "v1 blob too short" }
+        require(blob[VERSION_OFFSET].toInt() == BLOB_VERSION) {
+            "unsupported blob version: ${blob[VERSION_OFFSET].toInt()}"
+        }
+        val kdfId = blob[KDF_ID_OFFSET].toInt()
+        require(kdfId == KDF_ID_PBKDF2) { "unsupported KDF id: $kdfId" }
+        val iterations = readInt(blob, ITERATIONS_OFFSET)
+        require(iterations > 0 && iterations <= MAX_ITERATIONS) {
+            "invalid PBKDF2 iteration count: $iterations"
+        }
+        val salt = blob.copyOfRange(SALT_OFFSET, IV_OFFSET)
+        val iv = blob.copyOfRange(IV_OFFSET, HEADER_LENGTH)
+        val ciphertext = blob.copyOfRange(HEADER_LENGTH, blob.size)
+
+        val key = deriveKey(legacyKeyMaterial, salt, iterations)
+        return BlobDecryptResult(aesDecrypt(key, iv, ciphertext))
+    }
+
+    /**
+     * PBKDF2WithHmacSHA1 over the legacy material string. The password source
+     * is unchanged (ANDROID_ID:packageName is the only per-device secret
+     * available without user interaction on API 21-22), but the random salt
+     * and >= 100k iterations raise the per-blob cost of a brute-force attack
+     * by ~6 orders of magnitude over the legacy single SHA-256.
+     */
+    private fun deriveKey(password: String, salt: ByteArray, iterations: Int): SecretKey {
+        val spec = PBEKeySpec(password.toCharArray(), salt, iterations, AES_KEY_LENGTH * 8)
+        val factory = SecretKeyFactory.getInstance(PBKDF2_ALGORITHM)
+        val keyBytes = factory.generateSecret(spec).encoded
+        return SecretKeySpec(keyBytes, "AES")
+    }
+
+    private fun aesDecrypt(key: SecretKey, iv: ByteArray, ciphertext: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance(AES_GCM)
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv))
+        return cipher.doFinal(ciphertext)
+    }
+
+    private fun encodeBlob(
+        kdfId: Int,
+        iterations: Int,
+        salt: ByteArray,
+        iv: ByteArray,
+        ciphertext: ByteArray,
+    ): ByteArray {
+        val blob = ByteArray(HEADER_LENGTH + ciphertext.size)
+        MAGIC.copyInto(blob, 0)
+        blob[VERSION_OFFSET] = BLOB_VERSION.toByte()
+        blob[KDF_ID_OFFSET] = kdfId.toByte()
+        writeInt(blob, ITERATIONS_OFFSET, iterations)
+        salt.copyInto(blob, SALT_OFFSET)
+        iv.copyInto(blob, IV_OFFSET)
+        ciphertext.copyInto(blob, HEADER_LENGTH)
+        return blob
+    }
+
+    private fun writeInt(target: ByteArray, offset: Int, value: Int) {
+        target[offset] = (value ushr 24).toByte()
+        target[offset + 1] = (value ushr 16).toByte()
+        target[offset + 2] = (value ushr 8).toByte()
+        target[offset + 3] = value.toByte()
+    }
+
+    private fun readInt(source: ByteArray, offset: Int): Int =
+        (source[offset].toInt() and 0xFF shl 24) or
+                (source[offset + 1].toInt() and 0xFF shl 16) or
+                (source[offset + 2].toInt() and 0xFF shl 8) or
+                (source[offset + 3].toInt() and 0xFF)
+
+    companion object {
+        // "SMSK" - SMS gateway key blob
+        private val MAGIC = byteArrayOf(0x53, 0x4D, 0x53, 0x4B)
+
+        private const val BLOB_VERSION = 1
+        private const val VERSION_OFFSET = 4
+        private const val KDF_ID_OFFSET = 5
+        private const val ITERATIONS_OFFSET = 6
+        private const val SALT_OFFSET = 10
+        private const val IV_OFFSET = 26
+        private const val HEADER_LENGTH = 38
+
+        internal const val KDF_ID_PBKDF2 = 1
+
+        internal const val KDF_ITERATIONS = 100_000
+        private const val MAX_ITERATIONS = 10_000_000
+
+        private const val SALT_LENGTH = 16
+        private const val GCM_TAG_LENGTH_BITS = 128
+        private const val AES_KEY_LENGTH = 32
+
+        private const val AES_GCM = "AES/GCM/NoPadding"
+        private const val PBKDF2_ALGORITHM = "PBKDF2WithHmacSHA1"
+    }
+}
+
+/**
+ * Result of decrypting a stored key blob.
+ *
+ * @param plaintext the decrypted private-key encoding (PKCS#8).
+ * @param upgradedBlob non-null when [StorageBlobCipher.decrypt] re-encrypted
+ *   a legacy blob to the v1 PBKDF2 format; the caller must persist it to
+ *   replace the legacy blob.
+ */
+data class BlobDecryptResult(
+    val plaintext: ByteArray,
+    val upgradedBlob: ByteArray? = null,
+)

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/db/EncryptionKey.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/db/EncryptionKey.kt
@@ -1,0 +1,44 @@
+package me.capcom.smsgateway.modules.encryption.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "encryption_keys",
+    indices = [
+        Index("retired_at"),
+        Index("key_version", unique = true)
+    ],
+)
+data class EncryptionKey(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+
+    @ColumnInfo(name = "key_version")
+    val keyVersion: Int,
+
+    @ColumnInfo(name = "private_key_blob")
+    val privateKeyBlob: ByteArray,
+
+    @ColumnInfo(name = "public_key_base64")
+    val publicKeyBase64: String,
+
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis(),
+
+    @ColumnInfo(name = "retired_at")
+    val retiredAt: Long? = null,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as EncryptionKey
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/db/EncryptionKeysDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/db/EncryptionKeysDao.kt
@@ -1,0 +1,32 @@
+package me.capcom.smsgateway.modules.encryption.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface EncryptionKeysDao {
+    @Insert
+    suspend fun insert(encryptionKey: EncryptionKey): Long
+
+    @Query("SELECT * FROM encryption_keys WHERE retired_at IS NULL ORDER BY id DESC LIMIT 1")
+    suspend fun getCurrent(): EncryptionKey?
+
+    @Query("SELECT * FROM encryption_keys WHERE retired_at IS NULL ORDER BY id DESC")
+    suspend fun getAllActive(): List<EncryptionKey>
+
+    @Query("SELECT * FROM encryption_keys ORDER BY id DESC")
+    suspend fun getAll(): List<EncryptionKey>
+
+    @Query("SELECT * FROM encryption_keys WHERE key_version = :keyVersion LIMIT 1")
+    suspend fun getByKeyVersion(keyVersion: Int): EncryptionKey?
+
+    @Query("UPDATE encryption_keys SET retired_at = :retiredAt WHERE key_version = :keyVersion")
+    suspend fun retire(keyVersion: Int, retiredAt: Long = System.currentTimeMillis())
+
+    @Query("DELETE FROM encryption_keys WHERE retired_at IS NOT NULL AND retired_at < :cutoffTime")
+    suspend fun deleteOld(cutoffTime: Long)
+
+    @Query("SELECT COUNT(*) FROM encryption_keys WHERE retired_at IS NULL")
+    suspend fun countActive(): Int
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/db/EncryptionKeysDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/db/EncryptionKeysDao.kt
@@ -24,6 +24,9 @@ interface EncryptionKeysDao {
     @Query("UPDATE encryption_keys SET retired_at = :retiredAt WHERE key_version = :keyVersion")
     suspend fun retire(keyVersion: Int, retiredAt: Long = System.currentTimeMillis())
 
+    @Query("SELECT * FROM encryption_keys WHERE retired_at IS NOT NULL AND retired_at < :cutoffTime")
+    suspend fun getRetiredOlderThan(cutoffTime: Long): List<EncryptionKey>
+
     @Query("DELETE FROM encryption_keys WHERE retired_at IS NOT NULL AND retired_at < :cutoffTime")
     suspend fun deleteOld(cutoffTime: Long)
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/providers/EncryptionProvider.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/providers/EncryptionProvider.kt
@@ -1,0 +1,5 @@
+package me.capcom.smsgateway.modules.encryption.providers
+
+interface EncryptionProvider {
+    suspend fun decrypt(encryptedText: String): String
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/providers/EncryptionProviderFactory.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/providers/EncryptionProviderFactory.kt
@@ -1,0 +1,21 @@
+package me.capcom.smsgateway.modules.encryption.providers
+
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+import java.util.concurrent.ConcurrentHashMap
+
+object EncryptionProviderFactory : KoinComponent {
+    private val providers = ConcurrentHashMap<String, EncryptionProvider>()
+
+    fun create(algorithm: String): EncryptionProvider {
+        return providers[algorithm]
+            ?: (when (algorithm) {
+                PASSPHRASE_FORMAT -> PassphraseEncryptionProvider(get())
+                RSA_FORMAT -> RSAEncryptionProvider(get())
+                else -> throw RuntimeException("Method is not supported")
+            }.also { providers[algorithm] = it })
+    }
+
+    private const val PASSPHRASE_FORMAT = "aes-256-cbc/pbkdf2-sha1"
+    private const val RSA_FORMAT = "rsa-oaep-aes-256-gcm"
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/providers/PassphraseEncryptionProvider.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/providers/PassphraseEncryptionProvider.kt
@@ -1,0 +1,70 @@
+package me.capcom.smsgateway.modules.encryption.providers
+
+import android.util.Base64
+import me.capcom.smsgateway.modules.encryption.EncryptionSettings
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+class PassphraseEncryptionProvider(
+    private val settings: EncryptionSettings,
+) : EncryptionProvider {
+    override suspend fun decrypt(encryptedText: String): String {
+        val chunks = encryptedText.split('$')
+        if (chunks.size < 5) {
+            throw RuntimeException("Invalid passphrase encrypted data format")
+        }
+
+        val params = parseParams(chunks[2])
+        if (!params.containsKey("i")) {
+            throw RuntimeException("Missing iteration count")
+        }
+
+        val salt = decode(chunks[3])
+        val text = chunks[4]
+
+        val passphrase = requireNotNull(settings.passphrase) { "Passphrase is not set" }
+        val secretKey = generateSecretKeyFromPassphrase(
+            passphrase.toCharArray(),
+            salt,
+            256,
+            params.getValue("i").toInt()
+        )
+
+        return decryptText(text, secretKey, salt)
+    }
+
+    private fun decryptText(encryptedText: String, secretKey: SecretKey, iv: ByteArray): String {
+        val ivSpec = IvParameterSpec(iv)
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, ivSpec)
+        val encryptedBytes = decode(encryptedText)
+        val decryptedBytes = cipher.doFinal(encryptedBytes)
+        return String(decryptedBytes)
+    }
+
+    private fun decode(input: String): ByteArray {
+        return Base64.decode(input, Base64.DEFAULT)
+    }
+
+    private fun generateSecretKeyFromPassphrase(
+        passphrase: CharArray,
+        salt: ByteArray,
+        keyLength: Int = 256,
+        iterationCount: Int = 300_000
+    ): SecretKey {
+        val keySpec = PBEKeySpec(passphrase, salt, iterationCount, keyLength)
+        val keyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")
+        val keyBytes = keyFactory.generateSecret(keySpec).encoded
+        return SecretKeySpec(keyBytes, "AES")
+    }
+
+    private fun parseParams(params: String): Map<String, String> {
+        return params.split(',')
+            .map { it.split('=', limit = 2) }
+            .associate { it[0] to it[1] }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/providers/RSAEncryptionProvider.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/providers/RSAEncryptionProvider.kt
@@ -1,0 +1,70 @@
+package me.capcom.smsgateway.modules.encryption.providers
+
+import android.util.Base64
+import me.capcom.smsgateway.modules.encryption.E2EKeyService
+import java.security.spec.MGF1ParameterSpec
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.OAEPParameterSpec
+import javax.crypto.spec.PSource
+import javax.crypto.spec.SecretKeySpec
+
+class RSAEncryptionProvider(
+    private val e2eKeyService: E2EKeyService,
+) : EncryptionProvider {
+    override suspend fun decrypt(encryptedText: String): String {
+        val chunks = encryptedText.split('$')
+        // Format: $rsa-oaep-aes-256-gcm$v=1$k=N$<base64(encrypted_aes_key)>$<base64(iv)>$<base64(ciphertext)>
+        if (chunks.size < 7) {
+            throw RuntimeException("Invalid E2E encrypted data format: expected at least 7 chunks")
+        }
+
+        val versionParam = chunks[2]
+        val version = versionParam.removePrefix("v=")
+        if (version != E2E_VERSION) {
+            throw RuntimeException("Unsupported E2E version: $version")
+        }
+
+        val keyVersionParam = chunks[3]
+        val keyVersion = keyVersionParam.removePrefix("k=").toIntOrNull()
+            ?: throw RuntimeException("Invalid E2E key version: $keyVersionParam")
+
+        val encryptedAesKey = Base64.decode(chunks[4], Base64.DEFAULT)
+        val iv = Base64.decode(chunks[5], Base64.DEFAULT)
+        val ciphertext = Base64.decode(chunks[6], Base64.DEFAULT)
+
+        // 1. Decrypt AES key with RSA private key (using specific key version)
+        val privateKey = e2eKeyService.getPrivateKey(keyVersion)
+            ?: throw RuntimeException("No E2E private key available for version $keyVersion")
+
+        val rsaCipher = Cipher.getInstance(RSA_OAEP_ALGORITHM)
+        rsaCipher.init(
+            Cipher.DECRYPT_MODE,
+            privateKey,
+            OAEPParameterSpec(
+                "SHA-256",
+                "MGF1",
+                MGF1ParameterSpec.SHA256,
+                PSource.PSpecified.DEFAULT,
+            ),
+        )
+        val aesKeyBytes = rsaCipher.doFinal(encryptedAesKey)
+
+        // 2. Decrypt payload with AES-GCM
+        val aesKey = SecretKeySpec(aesKeyBytes, "AES")
+        val gcmSpec = GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv)
+        val aesCipher = Cipher.getInstance(AES_GCM_ALGORITHM)
+        aesCipher.init(Cipher.DECRYPT_MODE, aesKey, gcmSpec)
+        val decryptedBytes = aesCipher.doFinal(ciphertext)
+
+        return String(decryptedBytes)
+    }
+
+    companion object {
+        internal const val E2E_FORMAT = "rsa-oaep-aes-256-gcm"
+        private const val E2E_VERSION = "1"
+        private const val GCM_TAG_LENGTH_BITS = 128
+        private const val RSA_OAEP_ALGORITHM = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"
+        private const val AES_GCM_ALGORITHM = "AES/GCM/NoPadding"
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/encryption/workers/KeyRotationWorker.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/encryption/workers/KeyRotationWorker.kt
@@ -1,0 +1,62 @@
+package me.capcom.smsgateway.modules.encryption.workers
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import me.capcom.smsgateway.modules.encryption.E2EKeyService
+import me.capcom.smsgateway.modules.encryption.MODULE_NAME
+import me.capcom.smsgateway.modules.logs.LogsService
+import me.capcom.smsgateway.modules.logs.db.LogEntry
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.concurrent.TimeUnit
+
+class KeyRotationWorker(appContext: Context, params: WorkerParameters) :
+    CoroutineWorker(appContext, params), KoinComponent {
+
+    private val e2eKeySvc: E2EKeyService by inject()
+    private val logsSvc: LogsService by inject()
+
+    override suspend fun doWork(): Result = try {
+        e2eKeySvc.rotateKeyIfDue()
+        Result.success()
+    } catch (e: Throwable) {
+        logsSvc.insert(
+            LogEntry.Priority.ERROR,
+            MODULE_NAME,
+            "Failed to rotate encryption key: ${e.message}"
+        )
+        e.printStackTrace()
+        Result.retry()
+    }
+
+    companion object {
+        private const val NAME = "KeyRotationWorker"
+
+        fun start(context: Context) {
+            val work = PeriodicWorkRequestBuilder<KeyRotationWorker>(1L, TimeUnit.DAYS)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiresBatteryNotLow(true)
+                        .build()
+                )
+                .build()
+
+            WorkManager.getInstance(context)
+                .enqueueUniquePeriodicWork(
+                    NAME,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    work
+                )
+        }
+
+        fun stop(context: Context) {
+            WorkManager.getInstance(context)
+                .cancelUniqueWork(NAME)
+        }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayApi.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayApi.kt
@@ -143,6 +143,8 @@ class GatewayApi(
         val name: String,
         val pushToken: String?,
         val simCards: List<SimCard>,
+        val publicKey: String? = null,
+        val keyVersion: Int? = null,
     )
 
     data class DeviceRegisterResponse(
@@ -155,6 +157,8 @@ class GatewayApi(
     data class DevicePatchRequest(
         val id: String,
         val pushToken: String?,
+        val publicKey: String?,
+        val keyVersion: Int?,
         val simCards: List<SimCard>?,
     )
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
@@ -8,6 +8,7 @@ import me.capcom.smsgateway.domain.EntitySource
 import me.capcom.smsgateway.domain.MessageContent
 import me.capcom.smsgateway.domain.ProcessingState
 import me.capcom.smsgateway.helpers.SubscriptionsHelper
+import me.capcom.smsgateway.modules.encryption.E2EKeyService
 import me.capcom.smsgateway.modules.events.EventBus
 import me.capcom.smsgateway.modules.gateway.events.DeviceRegisteredEvent
 import me.capcom.smsgateway.modules.gateway.services.SSEForegroundService
@@ -30,6 +31,7 @@ class GatewayService(
     private val settings: GatewaySettings,
     private val events: EventBus,
     private val logsService: LogsService,
+    private val e2eKeyService: E2EKeyService,
 ) {
     private val eventsReceiver by lazy { EventsReceiver() }
 
@@ -130,10 +132,13 @@ class GatewayService(
         try {
             val deviceName = "${Build.MANUFACTURER}/${Build.PRODUCT}"
             val simCards = SubscriptionsHelper.getActiveSimCards(context)
+            val keyInfo = e2eKeyService.ensureKey()
             val request = GatewayApi.DeviceRegisterRequest(
                 deviceName,
                 pushToken,
                 simCards.toDTO(),
+                publicKey = keyInfo?.publicKeyBase64,
+                keyVersion = keyInfo?.keyVersion,
             )
             val response = when (registerMode) {
                 RegistrationMode.Anonymous -> api.deviceRegister(request, null)
@@ -172,12 +177,15 @@ class GatewayService(
         val settings = settings.registrationInfo ?: return
         val accessToken = settings.token
         val simCards = SubscriptionsHelper.getActiveSimCards(context)
+        val encryptionKey = e2eKeyService.ensureKey()
 
         api.devicePatch(
             accessToken,
             GatewayApi.DevicePatchRequest(
                 settings.id,
                 pushToken,
+                encryptionKey?.publicKeyBase64,
+                encryptionKey?.keyVersion,
                 simCards.toDTO(),
             )
         )

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/Module.kt
@@ -5,10 +5,6 @@ import org.koin.dsl.module
 
 val gatewayModule = module {
     singleOf(::GatewayService)
-    factory {
-        val settings: GatewaySettings = get()
-        GatewayApi(settings.serverUrl, settings.privateToken)
-    }
 }
 
-val MODULE_NAME = "gateway"
+internal const val MODULE_NAME = "gateway"

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/Module.kt
@@ -5,6 +5,10 @@ import org.koin.dsl.module
 
 val gatewayModule = module {
     singleOf(::GatewayService)
+    factory {
+        val settings: GatewaySettings = get()
+        GatewayApi(settings.serverUrl, settings.privateToken)
+    }
 }
 
 val MODULE_NAME = "gateway"

--- a/app/src/main/java/me/capcom/smsgateway/modules/health/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/health/Module.kt
@@ -1,4 +1,5 @@
-import me.capcom.smsgateway.modules.health.HealthService
+package me.capcom.smsgateway.modules.health
+
 import me.capcom.smsgateway.modules.health.monitors.BatteryMonitor
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/WebService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/WebService.kt
@@ -38,21 +38,17 @@ import me.capcom.smsgateway.domain.HealthResponse
 import me.capcom.smsgateway.extensions.configure
 import me.capcom.smsgateway.modules.health.HealthService
 import me.capcom.smsgateway.modules.health.domain.Status
-import me.capcom.smsgateway.modules.localserver.auth.AuthScopes
 import me.capcom.smsgateway.modules.localserver.auth.JwtService
-import me.capcom.smsgateway.modules.localserver.auth.requireScope
-import me.capcom.smsgateway.modules.localserver.domain.Device
 import me.capcom.smsgateway.modules.localserver.routes.AuthRoutes
+import me.capcom.smsgateway.modules.localserver.routes.DeviceRoutes
 import me.capcom.smsgateway.modules.localserver.routes.DocsRoutes
 import me.capcom.smsgateway.modules.localserver.routes.InboxRoutes
 import me.capcom.smsgateway.modules.localserver.routes.LogsRoutes
 import me.capcom.smsgateway.modules.localserver.routes.MessagesRoutes
 import me.capcom.smsgateway.modules.localserver.routes.WebhooksRoutes
 import me.capcom.smsgateway.modules.notifications.NotificationsService
-import me.capcom.smsgateway.helpers.SubscriptionsHelper
 import org.koin.android.ext.android.get
 import org.koin.android.ext.android.inject
-import java.util.Date
 import kotlin.concurrent.thread
 
 class WebService : Service() {
@@ -152,27 +148,15 @@ class WebService : Service() {
                     get("/") {
                         call.respond(mapOf("status" to "ok", "model" to Build.MODEL))
                     }
-                    route("/device") {
-                        get {
-                            if (!requireScope(AuthScopes.DevicesList)) return@get
-                            val firstInstallTime = packageManager.getPackageInfo(
-                                packageName,
-                                0
-                            ).firstInstallTime
-                            val deviceName = "${Build.MANUFACTURER}/${Build.PRODUCT}"
-                            val simCards = SubscriptionsHelper.getActiveSimCards(applicationContext)
-                            val device = Device(
-                                requireNotNull(settings.deviceId),
-                                deviceName,
-                                Date(firstInstallTime),
-                                Date(),
-                                Date(),
-                                simCards
-                            )
-
-                            call.respond(listOf(device))
+                    DeviceRoutes(applicationContext, get(), get()).let {
+                        route("/device") {
+                            it.register(this)
+                        }
+                        route("/devices") {
+                            it.register(this)
                         }
                     }
+
                     MessagesRoutes(applicationContext, get(), get(), get()).let {
                         route("/message") {
                             it.register(this)

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/Device.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/Device.kt
@@ -8,5 +8,7 @@ data class Device(
     val createdAt: Date,
     val updatedAt: Date,
     val lastSeen: Date,
-    val simCards: List<SimCard> = emptyList()
+    val simCards: List<SimCard> = emptyList(),
+    val publicKey: String? = null,
+    val keyVersion: Int? = null,
 )

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/DeviceRoutes.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/DeviceRoutes.kt
@@ -1,0 +1,52 @@
+package me.capcom.smsgateway.modules.localserver.routes
+
+import android.content.Context
+import android.os.Build
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import me.capcom.smsgateway.helpers.SubscriptionsHelper
+import me.capcom.smsgateway.modules.encryption.E2EKeyService
+import me.capcom.smsgateway.modules.localserver.LocalServerSettings
+import me.capcom.smsgateway.modules.localserver.auth.AuthScopes
+import me.capcom.smsgateway.modules.localserver.auth.requireScope
+import me.capcom.smsgateway.modules.localserver.domain.Device
+import java.util.Date
+
+class DeviceRoutes(
+    private val applicationContext: Context,
+    private val settings: LocalServerSettings,
+    private val e2eKeyService: E2EKeyService,
+) {
+    fun register(routing: Route) {
+        routing.apply {
+            deviceRoutes()
+        }
+    }
+
+    private fun Route.deviceRoutes() {
+        get {
+            if (!requireScope(AuthScopes.DevicesList)) return@get
+            val firstInstallTime = applicationContext.packageManager.getPackageInfo(
+                applicationContext.packageName,
+                0
+            ).firstInstallTime
+            val deviceName = "${Build.MANUFACTURER}/${Build.PRODUCT}"
+            val simCards = SubscriptionsHelper.getActiveSimCards(applicationContext)
+            val currentKey = e2eKeyService.ensureKey()
+            val device = Device(
+                requireNotNull(settings.deviceId),
+                deviceName,
+                Date(firstInstallTime),
+                Date(),
+                Date(),
+                simCards,
+                publicKey = currentKey?.publicKeyBase64,
+                keyVersion = currentKey?.keyVersion,
+            )
+
+            call.respond(listOf(device))
+        }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/orchestrator/OrchestratorService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/orchestrator/OrchestratorService.kt
@@ -3,6 +3,7 @@ package me.capcom.smsgateway.modules.orchestrator
 import android.content.Context
 import me.capcom.smsgateway.helpers.SettingsHelper
 import me.capcom.smsgateway.helpers.SubscriptionsHelper
+import me.capcom.smsgateway.modules.encryption.E2EKeyService
 import me.capcom.smsgateway.modules.gateway.GatewayService
 import me.capcom.smsgateway.modules.incoming.IncomingMessagesService
 import me.capcom.smsgateway.modules.localserver.LocalServerService
@@ -24,6 +25,7 @@ class OrchestratorService(
     private val receiverService: ReceiverService,
     private val pingSvc: PingService,
     private val logsSvc: LogsService,
+    private val e2eKeySvc: E2EKeyService,
     private val settings: SettingsHelper,
 ) {
     fun start(context: Context, autostart: Boolean) {
@@ -32,6 +34,7 @@ class OrchestratorService(
         }
 
         logsSvc.start(context)
+        e2eKeySvc.start(context)
         messagesSvc.start(context)
         incomingSvc.start(context)
         webHooksSvc.start(context)
@@ -75,6 +78,7 @@ class OrchestratorService(
         webHooksSvc.stop(context)
         messagesSvc.stop(context)
         incomingSvc.stop(context)
+        e2eKeySvc.stop(context)
         logsSvc.stop(context)
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/ui/SettingsFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/SettingsFragment.kt
@@ -48,14 +48,6 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     override fun onDisplayPreferenceDialog(preference: Preference) {
-        if (preference.key == "encryption.passphrase") {
-            (preference as EditTextPreference).setOnBindEditTextListener {
-                it.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
-                it.setSelectAllOnFocus(true)
-                it.selectAll()
-            }
-        }
-
         if (preference.key == "ping.interval_seconds"
             || preference.key == "logs.lifetime_days"
         ) {

--- a/app/src/main/java/me/capcom/smsgateway/ui/settings/EncryptionSettingsFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/settings/EncryptionSettingsFragment.kt
@@ -1,0 +1,58 @@
+package me.capcom.smsgateway.ui.settings
+
+import android.os.Bundle
+import android.text.InputType
+import android.view.View
+import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
+import androidx.preference.EditTextPreference
+import androidx.preference.Preference
+import kotlinx.coroutines.launch
+import me.capcom.smsgateway.R
+import me.capcom.smsgateway.modules.encryption.E2EKeyService
+import org.koin.android.ext.android.inject
+
+class EncryptionSettingsFragment : BasePreferenceFragment() {
+    private val e2eKeySvc: E2EKeyService by inject()
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.encryption_preferences, null)
+    }
+
+    override fun onDisplayPreferenceDialog(preference: Preference) {
+        if (preference.key == "encryption.passphrase") {
+            (preference as EditTextPreference).setOnBindEditTextListener {
+                it.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+                it.setSelectAllOnFocus(true)
+                it.selectAll()
+            }
+        }
+
+        super.onDisplayPreferenceDialog(preference)
+    }
+
+    override fun onPreferenceTreeClick(preference: Preference): Boolean {
+        if (preference.key == "encryption.rotate_key") {
+            rotateEncryptionKey()
+            return true
+        }
+
+        return super.onPreferenceTreeClick(preference)
+    }
+
+    private fun rotateEncryptionKey() {
+        lifecycleScope.launch {
+            try {
+                requireActivity().findViewById<View>(R.id.progressBar).isVisible = true
+
+                e2eKeySvc.rotateKey()
+
+                showToast(R.string.key_rotated_successfully)
+            } catch (e: Exception) {
+                showToast(getString(R.string.key_rotation_failed, e.message))
+            } finally {
+                requireActivity().findViewById<View>(R.id.progressBar).isVisible = false
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/ui/settings/EncryptionSettingsFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/settings/EncryptionSettingsFragment.kt
@@ -1,5 +1,6 @@
 package me.capcom.smsgateway.ui.settings
 
+import android.content.SharedPreferences
 import android.os.Bundle
 import android.text.InputType
 import android.view.View
@@ -17,6 +18,22 @@ class EncryptionSettingsFragment : BasePreferenceFragment() {
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.encryption_preferences, null)
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        preferenceManager.sharedPreferences?.registerOnSharedPreferenceChangeListener(
+            onPreferenceChanged
+        )
+    }
+
+    override fun onPause() {
+        preferenceManager.sharedPreferences?.unregisterOnSharedPreferenceChangeListener(
+            onPreferenceChanged
+        )
+
+        super.onPause()
     }
 
     override fun onDisplayPreferenceDialog(preference: Preference) {
@@ -55,4 +72,11 @@ class EncryptionSettingsFragment : BasePreferenceFragment() {
             }
         }
     }
+
+    private val onPreferenceChanged =
+        SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == "encryption.rotate_interval_days") {
+                e2eKeySvc.start(requireContext())
+            }
+        }
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -53,4 +53,16 @@
         <item>ru</item>
         <item>zh</item>
     </string-array>
+    <string-array name="rotation_intervals_titles">
+        <item>@string/disabled</item>
+        <item>30 days</item>
+        <item>60 days</item>
+        <item>90 days</item>
+    </string-array>
+    <string-array name="rotation_intervals_values" translatable="false">
+        <item>0</item>
+        <item>30</item>
+        <item>60</item>
+        <item>90</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="api_url">API URL</string>
     <string name="app_name" translatable="false">SMSGate</string>
     <string name="app_version_build">App version (build)</string>
+    <string name="automatic_key_rotation">Automatic key rotation</string>
     <string name="battery_optimization_already_disabled">Battery optimization already disabled</string>
     <string name="battery_optimization_is_not_supported_on_this_device">Battery optimization is not
         supported on this device</string>
@@ -12,8 +13,7 @@
     <string name="btn_continue">Continue</string>
     <string name="by_code">By Code</string>
     <string name="can_affect_battery_life">can affect battery life</string>
-    <string
-        name="click_continue_to_create_an_account_no_personal_information_is_required_nby_continuing_you_agree_to_our_privacy_policy_at_https_docs_sms_gate_app_privacy_policy">Click
+    <string name="click_continue_to_create_an_account_no_personal_information_is_required_nby_continuing_you_agree_to_our_privacy_policy_at_https_docs_sms_gate_app_privacy_policy">Click
         Continue to create an account. No personal information is required.\nBy continuing, you
         agree to our Privacy Policy at https://docs.sms-gate.app/privacy/policy/</string>
     <string name="cloud_server_dotdotdot">Cloud server…</string>
@@ -36,6 +36,9 @@
     <string name="failed_to_register_device">Failed to register device: %1$s</string>
     <string name="id_copied">Webhook ID copied to clipboard</string>
     <string name="if_sim_number_is_not_specified_use">If SIM number is not specified, use</string>
+    <string name="key_rotation_failed">Key rotation failed: %1$s</string>
+    <string name="key_rotation_upload_failed">Key rotated, but the server upload failed. Will retry on the next launch.</string>
+    <string name="key_rotated_successfully">Encryption key rotated</string>
     <string name="ignored_for_public_server">Ignored for public server</string>
     <string name="information">Information</string>
     <string name="internet_connection_available">Internet connection: available</string>
@@ -89,6 +92,8 @@
     <string name="restart_required_to_apply_changes">Restart required to apply changes</string>
     <string name="retries_signing_etc">Retries, signing, etc.</string>
     <string name="retry_count">Retry count</string>
+    <string name="rotate_encryption_key_summary">Generate a new key pair and upload the new public key to the server. Old keys stay valid for 7 days.</string>
+    <string name="rotate_encryption_key">Rotate encryption key</string>
     <string name="send_messages_notification">Sending messages…</string>
     <string name="sending_webhook">Sending webhook…</string>
     <string name="processing_webhook_queue">Processing webhook queue…</string>
@@ -185,4 +190,8 @@
     <string name="inbox_dotdotdot">Inbox…</string>
     <string name="inbox_settings_summary">Content provider monitoring, retention, etc.</string>
     <string name="inbox">Inbox</string>
+    <string name="passphrase_encryption">Passphrase encryption</string>
+    <string name="public_key_encryption">Public key encryption</string>
+    <string name="passphrase_public_key_etc">Passphrase, public key, etc.</string>
+    <string name="encryption_dotdotdot">Encryption…</string>
 </resources>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Legacy full-backup exclusions (adb backup on API 21-30 and cloud backup
+  before API 31). The E2E encryption-key material lives in the Room "gateway"
+  database (file gateway plus WAL/SHM companions); it must never leave the
+  device, so the whole database is excluded from backups.
+-->
+<full-backup-content>
+    <exclude
+        domain="database"
+        path="gateway" />
+    <exclude
+        domain="database"
+        path="gateway-wal" />
+    <exclude
+        domain="database"
+        path="gateway-shm" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  API 31+ backup/transfer exclusions. The E2E encryption-key material lives
+  in the Room "gateway" database (file gateway plus WAL/SHM companions); it is
+  excluded from both cloud backup and device-to-device transfer.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude
+            domain="database"
+            path="gateway" />
+        <exclude
+            domain="database"
+            path="gateway-wal" />
+        <exclude
+            domain="database"
+            path="gateway-shm" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude
+            domain="database"
+            path="gateway" />
+        <exclude
+            domain="database"
+            path="gateway-wal" />
+        <exclude
+            domain="database"
+            path="gateway-shm" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/main/res/xml/encryption_preferences.xml
+++ b/app/src/main/res/xml/encryption_preferences.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <PreferenceCategory app:title="@string/passphrase_encryption">
+        <EditTextPreference
+            app:icon="@drawable/ic_encryption"
+            app:key="encryption.passphrase"
+            app:summary="@string/use_empty_to_disable"
+            app:title="@string/passphrase" />
+    </PreferenceCategory>
+    <PreferenceCategory app:title="@string/public_key_encryption">
+        <Preference
+            android:icon="@drawable/ic_encryption"
+            android:key="encryption.rotate_key"
+            android:persistent="false"
+            android:summary="@string/rotate_encryption_key_summary"
+            android:title="@string/rotate_encryption_key" />
+        <ListPreference
+            android:icon="@drawable/ic_encryption"
+            android:entries="@array/rotation_intervals_titles"
+            android:entryValues="@array/rotation_intervals_values"
+            android:key="encryption.rotate_interval_days"
+            android:title="@string/automatic_key_rotation"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -14,8 +14,8 @@
     <Preference
         android:icon="@drawable/ic_messages"
         app:fragment="me.capcom.smsgateway.ui.settings.MessagesSettingsFragment"
-        app:title="@string/messages"
-        app:summary="@string/delays_limits_etc" />
+        app:summary="@string/delays_limits_etc"
+        app:title="@string/messages" />
 
     <Preference
         android:icon="@drawable/ic_inbox"
@@ -29,13 +29,11 @@
         app:summary="@string/retries_signing_etc"
         app:title="@string/webhooks_dotdotdot" />
 
-    <PreferenceCategory app:title="@string/encryption">
-        <EditTextPreference
-            app:icon="@drawable/ic_encryption"
-            app:key="encryption.passphrase"
-            app:summary="@string/use_empty_to_disable"
-            app:title="@string/passphrase" />
-    </PreferenceCategory>
+    <Preference
+        app:fragment="me.capcom.smsgateway.ui.settings.EncryptionSettingsFragment"
+        app:icon="@drawable/ic_encryption"
+        app:summary="@string/encryption_dotdotdot"
+        app:title="@string/passphrase_public_key_etc" />
 
     <PreferenceCategory
         android:summary="@string/online_status_at_the_cost_of_battery_life"
@@ -67,9 +65,9 @@
             app:summary="@string/can_affect_battery_life"
             app:title="@string/battery_optimization" />
         <ListPreference
-            android:icon="@drawable/ic_language"
             android:entries="@array/language_entries"
             android:entryValues="@array/language_values"
+            android:icon="@drawable/ic_language"
             android:key="app.language"
             android:title="@string/language"
             app:useSimpleSummaryProvider="true" />

--- a/app/src/test/java/android/util/Base64.kt
+++ b/app/src/test/java/android/util/Base64.kt
@@ -1,0 +1,45 @@
+package android.util
+
+import java.util.Base64
+
+/**
+ * Test-only shadow of android.util.Base64. AGP's mockable android.jar throws
+ * "not mocked" for this class in local JVM unit tests, but production code
+ * (PassphraseDecryptor) must keep android.util.Base64 for minSdk 21. This
+ * shadow mirrors the Android contract for the flags used by production
+ * (DEFAULT, NO_WRAP, NO_PADDING, CRLF, URL_SAFE) with a faithful JVM
+ * implementation; the unit-test output directory precedes android.jar on the
+ * test runtime classpath.
+ */
+object Base64 {
+
+    const val DEFAULT = 0
+    const val NO_PADDING = 1
+    const val NO_WRAP = 2
+    const val CRLF = 4
+    const val URL_SAFE = 8
+
+    @JvmStatic
+    fun decode(str: String, flags: Int): ByteArray {
+        val decoder = if (flags and URL_SAFE != 0) {
+            Base64.getUrlDecoder()
+        } else {
+            Base64.getDecoder()
+        }
+        return decoder.decode(str.filterNot { it.isWhitespace() })
+    }
+
+    @JvmStatic
+    fun encodeToString(input: ByteArray, flags: Int): String {
+        val encoder = if (flags and URL_SAFE != 0) {
+            Base64.getUrlEncoder()
+        } else {
+            Base64.getEncoder()
+        }
+        return if (flags and NO_PADDING != 0) {
+            encoder.withoutPadding().encodeToString(input)
+        } else {
+            encoder.encodeToString(input)
+        }
+    }
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/encryption/E2EKeyServiceTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/encryption/E2EKeyServiceTest.kt
@@ -1,0 +1,488 @@
+package me.capcom.smsgateway.modules.encryption
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import me.capcom.smsgateway.modules.encryption.db.EncryptionKey
+import me.capcom.smsgateway.modules.encryption.db.EncryptionKeysDao
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.SecureRandom
+import java.security.spec.MGF1ParameterSpec
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.OAEPParameterSpec
+import javax.crypto.spec.PSource
+import javax.crypto.spec.SecretKeySpec
+
+class E2EKeyServiceTest {
+
+    private val now = 1_700_000_000_000L
+    private val dayMs = 24L * 60 * 60 * 1000
+
+    // region fakes
+
+    private class FakeEncryptionKeysDao : EncryptionKeysDao {
+        val rows = mutableListOf<EncryptionKey>()
+        val events = mutableListOf<String>()
+        private var idSeq = 1L
+        var throwOnInsert = false
+        var getByKeyVersionCount = 0
+
+        override suspend fun insert(encryptionKey: EncryptionKey): Long {
+            events += "insert:${encryptionKey.keyVersion}"
+            if (throwOnInsert) throw RuntimeException("insert failed")
+            val id = idSeq++
+            rows += encryptionKey.copy(id = id)
+            return id
+        }
+
+        override suspend fun getCurrent(): EncryptionKey? =
+            rows.filter { it.retiredAt == null }.maxByOrNull { it.id }
+
+        override suspend fun getAllActive(): List<EncryptionKey> =
+            rows.filter { it.retiredAt == null }.sortedByDescending { it.id }
+
+        override suspend fun getAll(): List<EncryptionKey> = rows.sortedByDescending { it.id }
+
+        override suspend fun getByKeyVersion(keyVersion: Int): EncryptionKey? {
+            getByKeyVersionCount++
+            return rows.firstOrNull { it.keyVersion == keyVersion }
+        }
+
+        override suspend fun retire(keyVersion: Int, retiredAt: Long) {
+            events += "retire:$keyVersion"
+            val idx = rows.indexOfFirst { it.keyVersion == keyVersion }
+            if (idx >= 0) rows[idx] = rows[idx].copy(retiredAt = retiredAt)
+        }
+
+        override suspend fun getRetiredOlderThan(cutoffTime: Long): List<EncryptionKey> =
+            rows.filter { it.retiredAt?.let { r -> r < cutoffTime } == true }
+
+        override suspend fun deleteOld(cutoffTime: Long) {
+            rows.removeAll { it.retiredAt?.let { r -> r < cutoffTime } == true }
+        }
+
+        override suspend fun updatePrivateKeyBlob(keyVersion: Int, blob: ByteArray) {
+            events += "upgrade:$keyVersion"
+            val idx = rows.indexOfFirst { it.keyVersion == keyVersion }
+            if (idx >= 0) rows[idx] = rows[idx].copy(privateKeyBlob = blob)
+        }
+
+        override suspend fun countActive(): Int = rows.count { it.retiredAt == null }
+    }
+
+    private class FakeEncryptionKeyStore : EncryptionKeyStore {
+        val keys = mutableMapOf<String, KeyPair>()
+        val deleted = mutableListOf<String>()
+        /** Counts keystore loads per alias (keystore IPC is the expensive part). */
+        val loadCounts = mutableMapOf<String, Int>()
+        /** Simulates the store re-encrypting a legacy blob to the PBKDF2 format. */
+        var upgradedBlob: ByteArray? = null
+
+        override fun generateKeyPair(alias: String): KeyPairResult {
+            val kpg = KeyPairGenerator.getInstance("RSA")
+            kpg.initialize(2048)
+            val keyPair = kpg.generateKeyPair()
+            keys[alias] = keyPair
+            return KeyPairResult(
+                keyPair,
+                ByteArray(0),
+                Base64.getEncoder().encodeToString(keyPair.public.encoded)
+            )
+        }
+
+        override fun getPrivateKey(alias: String, persistedBlob: ByteArray): KeyLoadResult? {
+            loadCounts[alias] = (loadCounts[alias] ?: 0) + 1
+            return keys[alias]?.let { KeyLoadResult(it.private, upgradedBlob) }
+        }
+
+        override fun delete(alias: String) {
+            keys.remove(alias)
+            deleted += alias
+        }
+    }
+
+    private object NoopE2EKeyLogger : E2EKeyLogger {
+        override fun warn(message: String, exception: Any?) {}
+    }
+
+    // endregion
+
+    private fun createService(
+        dao: FakeEncryptionKeysDao = FakeEncryptionKeysDao(),
+        store: FakeEncryptionKeyStore = FakeEncryptionKeyStore(),
+    ): E2EKeyService = E2EKeyService(
+        keyStore = store,
+        dao = dao,
+        logger = NoopE2EKeyLogger,
+        nowMillis = { now },
+    )
+
+    private fun alias(version: Int): String = "e2e_key_v$version"
+
+    /**
+     * Builds an E2E ciphertext exactly in the production format:
+     * $rsa-oaep-aes-256-gcm$v=1$k={keyVersion}$b64(aesKeyRsaOaep)$b64(iv)$b64(ct+tag)
+     * Mirrors EncryptionService.decryptE2E with a JVM Base64.
+     */
+    private fun buildE2ECiphertext(
+        keyVersion: Int,
+        publicKey: PublicKey,
+        plaintext: String,
+    ): String {
+        val aesKey = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        val rsaCipher = Cipher.getInstance(RSA_OAEP_ALGORITHM)
+        rsaCipher.init(
+            Cipher.ENCRYPT_MODE,
+            publicKey,
+            OAEPParameterSpec(
+                "SHA-256",
+                "MGF1",
+                MGF1ParameterSpec.SHA256,
+                PSource.PSpecified.DEFAULT,
+            ),
+        )
+        val encryptedAesKey = rsaCipher.doFinal(aesKey)
+        val iv = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        val aesCipher = Cipher.getInstance("AES/GCM/NoPadding")
+        aesCipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(aesKey, "AES"), GCMParameterSpec(128, iv))
+        val ciphertext = aesCipher.doFinal(plaintext.toByteArray())
+        return listOf(
+            "",
+            "rsa-oaep-aes-256-gcm",
+            "v=1",
+            "k=$keyVersion",
+            Base64.getEncoder().encodeToString(encryptedAesKey),
+            Base64.getEncoder().encodeToString(iv),
+            Base64.getEncoder().encodeToString(ciphertext),
+        ).joinToString("$")
+    }
+
+    /** Mirrors the decryption steps of EncryptionService.decryptE2E. */
+    private fun decryptWithPrivateKey(privateKey: PrivateKey, ciphertext: String): String {
+        val chunks = ciphertext.split('$')
+        val encryptedAesKey = Base64.getDecoder().decode(chunks[4])
+        val iv = Base64.getDecoder().decode(chunks[5])
+        val ciphertextBytes = Base64.getDecoder().decode(chunks[6])
+        val rsaCipher = Cipher.getInstance(RSA_OAEP_ALGORITHM)
+        rsaCipher.init(
+            Cipher.DECRYPT_MODE,
+            privateKey,
+            OAEPParameterSpec(
+                "SHA-256",
+                "MGF1",
+                MGF1ParameterSpec.SHA256,
+                PSource.PSpecified.DEFAULT,
+            ),
+        )
+        val aesKey = rsaCipher.doFinal(encryptedAesKey)
+        val aesCipher = Cipher.getInstance("AES/GCM/NoPadding")
+        aesCipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(aesKey, "AES"), GCMParameterSpec(128, iv))
+        return String(aesCipher.doFinal(ciphertextBytes))
+    }
+
+    // region tests
+
+    @Test
+    fun rotateKey_insertsNewKeyBeforeRetiringOld() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val service = createService(dao)
+
+        service.rotateKey()
+        service.rotateKey()
+        service.rotateKey()
+
+        // insert of the new version always precedes retire of the previous one:
+        // no window where no active key exists
+        assertEquals(
+            listOf("insert:1", "insert:2", "retire:1", "insert:3", "retire:2"),
+            dao.events,
+        )
+        assertEquals(3, dao.getCurrent()?.keyVersion)
+        assertNull(dao.getByKeyVersion(3)?.retiredAt)
+        assertNotNull(dao.getByKeyVersion(1)?.retiredAt)
+        assertNotNull(dao.getByKeyVersion(2)?.retiredAt)
+    }
+
+    @Test
+    fun rotateKey_marksOldKeyRetiredWithoutDeletingKeystoreEntry() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val store = FakeEncryptionKeyStore()
+        val service = createService(dao, store)
+
+        service.rotateKey()
+        service.rotateKey()
+
+        assertEquals(2, dao.getCurrent()?.keyVersion)
+        assertNotNull(dao.getByKeyVersion(1)?.retiredAt)
+        // retireKey must NOT touch the AndroidKeyStore
+        assertTrue(store.deleted.isEmpty())
+        assertNotNull(store.keys[alias(1)])
+        assertNotNull(store.keys[alias(2)])
+    }
+
+    @Test
+    fun oldVersionKeyStillDecryptsAfterRotation() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val store = FakeEncryptionKeyStore()
+        val service = createService(dao, store)
+
+        service.rotateKey()
+        val v1Public = store.keys.getValue(alias(1)).public
+        val ciphertext = buildE2ECiphertext(1, v1Public, "in-flight message to old key")
+
+        service.rotateKey()
+
+        val privateKey = service.getPrivateKey(1)
+        assertNotNull(privateKey)
+        assertEquals("in-flight message to old key", decryptWithPrivateKey(privateKey!!, ciphertext))
+    }
+
+    @Test
+    fun cleanupOldKeys_purgesOnlyRetiredKeysOlderThan7Days() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val store = FakeEncryptionKeyStore()
+        val service = createService(dao, store)
+
+        dao.rows += listOf(
+            EncryptionKey(
+                keyVersion = 1,
+                privateKeyBlob = ByteArray(0),
+                publicKeyBase64 = "k1",
+                createdAt = now - 30L * dayMs,
+                retiredAt = now - 8L * dayMs,
+            ),
+            EncryptionKey(
+                keyVersion = 2,
+                privateKeyBlob = ByteArray(0),
+                publicKeyBase64 = "k2",
+                createdAt = now - 30L * dayMs,
+                retiredAt = now - dayMs,
+            ),
+            // exactly 7 days old: boundary, must be retained
+            EncryptionKey(
+                keyVersion = 3,
+                privateKeyBlob = ByteArray(0),
+                publicKeyBase64 = "k3",
+                createdAt = now - 30L * dayMs,
+                retiredAt = now - 7L * dayMs,
+            ),
+            EncryptionKey(
+                keyVersion = 4,
+                privateKeyBlob = ByteArray(0),
+                publicKeyBase64 = "k4",
+                createdAt = now - dayMs,
+                retiredAt = null,
+            ),
+        )
+        for (v in 1..4) {
+            store.generateKeyPair(alias(v))
+        }
+
+        service.cleanupOldKeys()
+
+        assertNull(dao.getByKeyVersion(1))
+        assertNotNull(dao.getByKeyVersion(2))
+        assertNotNull(dao.getByKeyVersion(3))
+        assertNotNull(dao.getByKeyVersion(4))
+        // keystore entries purged in the same pass as the Room rows
+        assertEquals(listOf(alias(1)), store.deleted)
+        assertNull(store.keys[alias(1)])
+        assertNotNull(store.keys[alias(2)])
+        assertNotNull(store.keys[alias(3)])
+    }
+
+    @Test
+    fun enforceKeyLimit_retiresOldestButKeepsDecryptability() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val store = FakeEncryptionKeyStore()
+        val service = createService(dao, store)
+
+        for (v in 1..4) {
+            store.generateKeyPair(alias(v))
+            dao.rows += EncryptionKey(
+                id = v.toLong(),
+                keyVersion = v,
+                privateKeyBlob = ByteArray(0),
+                publicKeyBase64 = "k$v",
+                createdAt = now - (5L - v) * dayMs,
+            )
+        }
+
+        service.enforceKeyLimit()
+
+        assertEquals(listOf(2, 3, 4), dao.getAllActive().map { it.keyVersion }.sorted())
+        assertNotNull(dao.getByKeyVersion(1)?.retiredAt)
+        // limit enforcement retires the Room row only; decryptability intact
+        assertTrue(store.deleted.isEmpty())
+        assertNotNull(service.getPrivateKey(1))
+    }
+
+    @Test
+    fun rotateKey_deletesOrphanedKeystoreEntryWhenInsertFails() = runBlocking {
+        val dao = FakeEncryptionKeysDao().apply { throwOnInsert = true }
+        val store = FakeEncryptionKeyStore()
+        val service = createService(dao, store)
+
+        try {
+            service.rotateKey()
+            fail("expected RuntimeException from dao.insert")
+        } catch (e: RuntimeException) {
+            assertEquals("insert failed", e.message)
+        }
+
+        assertEquals(listOf(alias(1)), store.deleted)
+        assertNull(store.keys[alias(1)])
+    }
+
+    @Test
+    fun ensureKey_createsKeyWhenMissingAndReturnsExisting() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val service = createService(dao)
+
+        val created = service.ensureKey()
+        assertEquals(1, created?.keyVersion)
+
+        val existing = service.ensureKey()
+        assertEquals(1, existing?.keyVersion)
+        assertEquals(1, dao.rows.size)
+    }
+
+    @Test
+    fun getPrivateKey_persistsReEncryptedLegacyBlob() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val store = FakeEncryptionKeyStore()
+        val service = createService(dao, store)
+
+        store.generateKeyPair(alias(1))
+        store.upgradedBlob = byteArrayOf(9, 9, 9)
+        dao.rows += EncryptionKey(
+            id = 1,
+            keyVersion = 1,
+            privateKeyBlob = byteArrayOf(1, 2, 3), // legacy blob, pre-upgrade
+            publicKeyBase64 = "k1",
+        )
+
+        val key = service.getPrivateKey(1)
+
+        assertNotNull(key)
+        assertTrue(dao.rows.first { it.keyVersion == 1 }.privateKeyBlob.contentEquals(byteArrayOf(9, 9, 9)))
+        assertEquals(listOf("upgrade:1"), dao.events)
+    }
+
+    @Test
+    fun getPrivateKey_doesNotRewriteCurrentFormatBlob() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val store = FakeEncryptionKeyStore()
+        val service = createService(dao, store)
+
+        store.generateKeyPair(alias(1))
+        store.upgradedBlob = null // current-format blob: no re-encryption
+        dao.rows += EncryptionKey(
+            id = 1,
+            keyVersion = 1,
+            privateKeyBlob = ByteArray(0),
+            publicKeyBase64 = "k1",
+        )
+
+        val key = service.getPrivateKey(1)
+
+        assertNotNull(key)
+        assertTrue(dao.events.isEmpty())
+    }
+
+    @Test
+    fun getPrivateKey_cachesLoadedKeyPerVersion() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val store = FakeEncryptionKeyStore()
+        val service = createService(dao, store)
+
+        service.rotateKey()
+
+        for (i in 1..5) {
+            assertNotNull(service.getPrivateKey(1))
+        }
+
+        // N repeated loads of the same keyVersion: exactly 1 Room lookup + 1 keystore load
+        assertEquals(1, dao.getByKeyVersionCount)
+        assertEquals(1, store.loadCounts[alias(1)])
+    }
+
+    @Test
+    fun getPrivateKey_batchLoadsOnceConcurrently() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val store = FakeEncryptionKeyStore()
+        val service = createService(dao, store)
+
+        service.rotateKey()
+
+        val keys = (1..8).map {
+            async(Dispatchers.Default) { service.getPrivateKey(1) }
+        }.awaitAll()
+
+        assertTrue(keys.all { it != null })
+        // A batch of N values with the same keyVersion: exactly 1 Room lookup + 1 keystore load
+        assertEquals(1, dao.getByKeyVersionCount)
+        assertEquals(1, store.loadCounts[alias(1)])
+    }
+
+    @Test
+    fun getPrivateKey_reloadsAfterRotation_clearsCache() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val store = FakeEncryptionKeyStore()
+        val service = createService(dao, store)
+
+        service.rotateKey()
+        assertNotNull(service.getPrivateKey(1)) // loads + caches v1
+
+        service.rotateKey() // retires v1, must invalidate the cache
+
+        assertNotNull(service.getPrivateKey(1))
+        val v1KeystoreLoads = store.loadCounts[alias(1)] ?: 0
+        assertEquals("rotation must invalidate the in-memory cache", 2, v1KeystoreLoads)
+    }
+
+    @Test
+    fun cleanupOldKeys_doesNotServeStaleCachedKey() = runBlocking {
+        val dao = FakeEncryptionKeysDao()
+        val store = FakeEncryptionKeyStore()
+        val service = createService(dao, store)
+
+        dao.rows += EncryptionKey(
+            keyVersion = 1,
+            privateKeyBlob = ByteArray(0),
+            publicKeyBase64 = "k1",
+            createdAt = now - 30L * dayMs,
+            retiredAt = now - 8L * dayMs,
+        )
+        store.generateKeyPair(alias(1))
+
+        assertNotNull(service.getPrivateKey(1)) // loads + caches v1
+        service.cleanupOldKeys() // purges v1: cache must be invalidated too
+
+        // A stale cache would return the purged key; the reload must miss in Room.
+        assertNull(service.getPrivateKey(1))
+        assertEquals(
+            "purged version must be re-resolved from Room, not served from cache",
+            2,
+            dao.getByKeyVersionCount,
+        )
+    }
+
+    // endregion
+
+    private companion object {
+        const val RSA_OAEP_ALGORITHM = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"
+    }
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/encryption/E2EKeyServiceTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/encryption/E2EKeyServiceTest.kt
@@ -6,6 +6,11 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import me.capcom.smsgateway.modules.encryption.db.EncryptionKey
 import me.capcom.smsgateway.modules.encryption.db.EncryptionKeysDao
+import me.capcom.smsgateway.modules.logs.LogsService
+import me.capcom.smsgateway.modules.logs.LogsSettings
+import me.capcom.smsgateway.modules.logs.db.LogEntriesDao
+import me.capcom.smsgateway.modules.logs.db.LogEntry
+import me.capcom.smsgateway.modules.settings.KeyValueStorage
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -17,6 +22,7 @@ import java.security.KeyPairGenerator
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.SecureRandom
+import java.lang.reflect.Type
 import java.security.spec.MGF1ParameterSpec
 import java.util.Base64
 import javax.crypto.Cipher
@@ -27,7 +33,8 @@ import javax.crypto.spec.SecretKeySpec
 
 class E2EKeyServiceTest {
 
-    private val now = 1_700_000_000_000L
+    /** Real wall clock: the service no longer accepts an injectable nowMillis. */
+    private val now = System.currentTimeMillis()
     private val dayMs = 24L * 60 * 60 * 1000
 
     // region fakes
@@ -73,12 +80,6 @@ class E2EKeyServiceTest {
             rows.removeAll { it.retiredAt?.let { r -> r < cutoffTime } == true }
         }
 
-        override suspend fun updatePrivateKeyBlob(keyVersion: Int, blob: ByteArray) {
-            events += "upgrade:$keyVersion"
-            val idx = rows.indexOfFirst { it.keyVersion == keyVersion }
-            if (idx >= 0) rows[idx] = rows[idx].copy(privateKeyBlob = blob)
-        }
-
         override suspend fun countActive(): Int = rows.count { it.retiredAt == null }
     }
 
@@ -87,8 +88,6 @@ class E2EKeyServiceTest {
         val deleted = mutableListOf<String>()
         /** Counts keystore loads per alias (keystore IPC is the expensive part). */
         val loadCounts = mutableMapOf<String, Int>()
-        /** Simulates the store re-encrypting a legacy blob to the PBKDF2 format. */
-        var upgradedBlob: ByteArray? = null
 
         override fun generateKeyPair(alias: String): KeyPairResult {
             val kpg = KeyPairGenerator.getInstance("RSA")
@@ -104,7 +103,7 @@ class E2EKeyServiceTest {
 
         override fun getPrivateKey(alias: String, persistedBlob: ByteArray): KeyLoadResult? {
             loadCounts[alias] = (loadCounts[alias] ?: 0) + 1
-            return keys[alias]?.let { KeyLoadResult(it.private, upgradedBlob) }
+            return keys[alias]?.let { KeyLoadResult(it.private) }
         }
 
         override fun delete(alias: String) {
@@ -113,8 +112,33 @@ class E2EKeyServiceTest {
         }
     }
 
-    private object NoopE2EKeyLogger : E2EKeyLogger {
-        override fun warn(message: String, exception: Any?) {}
+    private class FakeLogEntriesDao : LogEntriesDao {
+        val inserted = mutableListOf<LogEntry>()
+
+        override suspend fun selectByPeriod(from: Long, to: Long): List<LogEntry> = emptyList()
+        override fun selectLast(): androidx.lifecycle.LiveData<List<LogEntry>> =
+            TODO("not used by LogsService in these tests")
+
+        override fun insert(entry: LogEntry) {
+            inserted += entry
+        }
+
+        override suspend fun truncate(until: Long) {}
+    }
+
+    private class FakeKeyValueStorage : KeyValueStorage {
+        val values = mutableMapOf<String, Any?>()
+
+        override fun <T> set(key: String, value: T) {
+            values[key] = value
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> get(key: String, typeOfT: Type): T? = values[key] as T?
+
+        override fun remove(key: String) {
+            values.remove(key)
+        }
     }
 
     // endregion
@@ -122,12 +146,15 @@ class E2EKeyServiceTest {
     private fun createService(
         dao: FakeEncryptionKeysDao = FakeEncryptionKeysDao(),
         store: FakeEncryptionKeyStore = FakeEncryptionKeyStore(),
-    ): E2EKeyService = E2EKeyService(
-        keyStore = store,
-        dao = dao,
-        logger = NoopE2EKeyLogger,
-        nowMillis = { now },
-    )
+    ): E2EKeyService {
+        val storage = FakeKeyValueStorage()
+        return E2EKeyService(
+            keyStore = store,
+            dao = dao,
+            logsSvc = LogsService(FakeLogEntriesDao(), LogsSettings(storage)),
+            settings = EncryptionSettings(storage),
+        )
+    }
 
     private fun alias(version: Int): String = "e2e_key_v$version"
 
@@ -270,13 +297,15 @@ class E2EKeyServiceTest {
                 createdAt = now - 30L * dayMs,
                 retiredAt = now - dayMs,
             ),
-            // exactly 7 days old: boundary, must be retained
+            // boundary: retired just inside the 7-day window. The service uses
+            // the real wall clock (no injectable nowMillis), so a small clock-
+            // drift buffer keeps this row inside the retention window: retained.
             EncryptionKey(
                 keyVersion = 3,
                 privateKeyBlob = ByteArray(0),
                 publicKeyBase64 = "k3",
                 createdAt = now - 30L * dayMs,
-                retiredAt = now - 7L * dayMs,
+                retiredAt = now - 7L * dayMs + 120_000L,
             ),
             EncryptionKey(
                 keyVersion = 4,
@@ -360,13 +389,12 @@ class E2EKeyServiceTest {
     }
 
     @Test
-    fun getPrivateKey_persistsReEncryptedLegacyBlob() = runBlocking {
+    fun getPrivateKey_doesNotRewriteLegacyBlob() = runBlocking {
         val dao = FakeEncryptionKeysDao()
         val store = FakeEncryptionKeyStore()
         val service = createService(dao, store)
 
         store.generateKeyPair(alias(1))
-        store.upgradedBlob = byteArrayOf(9, 9, 9)
         dao.rows += EncryptionKey(
             id = 1,
             keyVersion = 1,
@@ -376,9 +404,12 @@ class E2EKeyServiceTest {
 
         val key = service.getPrivateKey(1)
 
+        // Current API: KeyLoadResult carries the private key only; the service
+        // never re-encrypts or persists blob upgrades (that lives in
+        // StorageBlobCipher). The stored blob must stay byte-identical.
         assertNotNull(key)
-        assertTrue(dao.rows.first { it.keyVersion == 1 }.privateKeyBlob.contentEquals(byteArrayOf(9, 9, 9)))
-        assertEquals(listOf("upgrade:1"), dao.events)
+        assertTrue(dao.rows.first { it.keyVersion == 1 }.privateKeyBlob.contentEquals(byteArrayOf(1, 2, 3)))
+        assertTrue(dao.events.isEmpty())
     }
 
     @Test
@@ -388,11 +419,10 @@ class E2EKeyServiceTest {
         val service = createService(dao, store)
 
         store.generateKeyPair(alias(1))
-        store.upgradedBlob = null // current-format blob: no re-encryption
         dao.rows += EncryptionKey(
             id = 1,
             keyVersion = 1,
-            privateKeyBlob = ByteArray(0),
+            privateKeyBlob = ByteArray(0), // current-format blob: no re-encryption
             publicKeyBase64 = "k1",
         )
 

--- a/app/src/test/java/me/capcom/smsgateway/modules/encryption/EncryptionServiceTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/encryption/EncryptionServiceTest.kt
@@ -1,0 +1,313 @@
+package me.capcom.smsgateway.modules.encryption
+
+import kotlinx.coroutines.runBlocking
+import me.capcom.smsgateway.modules.encryption.db.EncryptionKey
+import me.capcom.smsgateway.modules.encryption.db.EncryptionKeysDao
+import me.capcom.smsgateway.modules.encryption.providers.PassphraseEncryptionProvider
+import me.capcom.smsgateway.modules.encryption.providers.RSAEncryptionProvider
+import me.capcom.smsgateway.modules.logs.LogsService
+import me.capcom.smsgateway.modules.logs.LogsSettings
+import me.capcom.smsgateway.modules.logs.db.LogEntriesDao
+import me.capcom.smsgateway.modules.logs.db.LogEntry
+import me.capcom.smsgateway.modules.settings.KeyValueStorage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import java.lang.reflect.Type
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PublicKey
+import java.security.SecureRandom
+import java.security.spec.MGF1ParameterSpec
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.OAEPParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.PSource
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Deterministic facade tests for EncryptionService. The facade is built from
+ * real decryptors wired with fake dependencies; payloads are constructed
+ * in-test with the same JCA recipes as PassphraseDecryptorTest/E2EDecryptorTest.
+ */
+class EncryptionServiceTest {
+
+    // region fakes (mirror PassphraseDecryptorTest / E2EDecryptorTest)
+
+    private class FakeKeyValueStorage : KeyValueStorage {
+        private val values = mutableMapOf<String, Any?>()
+
+        override fun <T> set(key: String, value: T) {
+            values[key] = value
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> get(key: String, typeOfT: Type): T? = values[key] as T?
+
+        override fun remove(key: String) {
+            values.remove(key)
+        }
+    }
+
+    private class FakeEncryptionKeysDao : EncryptionKeysDao {
+        val rows = mutableListOf<EncryptionKey>()
+        private var idSeq = 1L
+
+        override suspend fun insert(encryptionKey: EncryptionKey): Long {
+            val id = idSeq++
+            rows += encryptionKey.copy(id = id)
+            return id
+        }
+
+        override suspend fun getCurrent(): EncryptionKey? =
+            rows.filter { it.retiredAt == null }.maxByOrNull { it.id }
+
+        override suspend fun getAllActive(): List<EncryptionKey> =
+            rows.filter { it.retiredAt == null }.sortedByDescending { it.id }
+
+        override suspend fun getAll(): List<EncryptionKey> = rows.sortedByDescending { it.id }
+
+        override suspend fun getByKeyVersion(keyVersion: Int): EncryptionKey? =
+            rows.firstOrNull { it.keyVersion == keyVersion }
+
+        override suspend fun retire(keyVersion: Int, retiredAt: Long) {
+            val idx = rows.indexOfFirst { it.keyVersion == keyVersion }
+            if (idx >= 0) rows[idx] = rows[idx].copy(retiredAt = retiredAt)
+        }
+
+        override suspend fun getRetiredOlderThan(cutoffTime: Long): List<EncryptionKey> =
+            rows.filter { it.retiredAt?.let { r -> r < cutoffTime } == true }
+
+        override suspend fun deleteOld(cutoffTime: Long) {
+            rows.removeAll { it.retiredAt?.let { r -> r < cutoffTime } == true }
+        }
+
+        override suspend fun countActive(): Int = rows.count { it.retiredAt == null }
+    }
+
+    private class FakeEncryptionKeyStore : EncryptionKeyStore {
+        val keys = mutableMapOf<String, KeyPair>()
+
+        override fun generateKeyPair(alias: String): KeyPairResult {
+            val kpg = KeyPairGenerator.getInstance("RSA")
+            kpg.initialize(2048)
+            val keyPair = kpg.generateKeyPair()
+            keys[alias] = keyPair
+            return KeyPairResult(
+                keyPair,
+                ByteArray(0),
+                Base64.getEncoder().encodeToString(keyPair.public.encoded)
+            )
+        }
+
+        override fun getPrivateKey(alias: String, persistedBlob: ByteArray): KeyLoadResult? =
+            keys[alias]?.let { KeyLoadResult(it.private) }
+
+        override fun delete(alias: String) {
+            keys.remove(alias)
+        }
+    }
+
+    private class FakeLogEntriesDao : LogEntriesDao {
+        override suspend fun selectByPeriod(from: Long, to: Long): List<LogEntry> = emptyList()
+        override fun selectLast(): androidx.lifecycle.LiveData<List<LogEntry>> =
+            TODO("not used by LogsService in these tests")
+
+        override fun insert(entry: LogEntry) {
+        }
+
+        override suspend fun truncate(until: Long) {
+        }
+    }
+
+    // endregion
+
+    private fun passphraseSettings(passphrase: String): EncryptionSettings =
+        EncryptionSettings(FakeKeyValueStorage().apply { set("passphrase", passphrase) })
+
+    private fun e2eKeyService(
+        dao: FakeEncryptionKeysDao = FakeEncryptionKeysDao(),
+        store: FakeEncryptionKeyStore = FakeEncryptionKeyStore(),
+    ): E2EKeyService {
+        val storage = FakeKeyValueStorage()
+        return E2EKeyService(
+            keyStore = store,
+            dao = dao,
+            logsSvc = LogsService(FakeLogEntriesDao(), LogsSettings(storage)),
+            settings = EncryptionSettings(storage),
+        )
+    }
+
+    private fun service(): EncryptionService =
+        EncryptionService(
+            passphraseEncryptionProvider = PassphraseEncryptionProvider(passphraseSettings("test-passphrase")),
+            RSAEncryptionProvider = RSAEncryptionProvider(e2eKeyService()),
+        )
+
+    /**
+     * Mirrors the production passphrase payload format:
+     * $aes-256-cbc/pbkdf2-sha1$i=1000$b64(salt)$b64(ciphertext)
+     */
+    private fun buildPassphrasePayload(passphrase: String, plaintext: String): String {
+        val salt = ByteArray(16).also { SecureRandom().nextBytes(it) }
+        val keySpec = PBEKeySpec(passphrase.toCharArray(), salt, 1_000, 256)
+        val keyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")
+        val key = SecretKeySpec(keyFactory.generateSecret(keySpec).encoded, "AES")
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        cipher.init(Cipher.ENCRYPT_MODE, key, IvParameterSpec(salt))
+        val ciphertext = cipher.doFinal(plaintext.toByteArray())
+        return listOf(
+            "",
+            PassphraseEncryptionProvider.PASSPHRASE_FORMAT,
+            "i=1000",
+            Base64.getEncoder().encodeToString(salt),
+            Base64.getEncoder().encodeToString(ciphertext),
+        ).joinToString("$")
+    }
+
+    /**
+     * Mirrors the production E2E payload format:
+     * $rsa-oaep-aes-256-gcm$v=1$k=1$b64(rsaEncAesKey)$b64(iv)$b64(ct+tag)
+     */
+    private fun buildE2EPayload(publicKey: PublicKey, plaintext: String): String {
+        val aesKey = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        val rsaCipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding")
+        rsaCipher.init(
+            Cipher.ENCRYPT_MODE,
+            publicKey,
+            OAEPParameterSpec(
+                "SHA-256",
+                "MGF1",
+                MGF1ParameterSpec.SHA256,
+                PSource.PSpecified.DEFAULT,
+            ),
+        )
+        val encryptedAesKey = rsaCipher.doFinal(aesKey)
+        val iv = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        val aesCipher = Cipher.getInstance("AES/GCM/NoPadding")
+        aesCipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(aesKey, "AES"), GCMParameterSpec(128, iv))
+        val ciphertext = aesCipher.doFinal(plaintext.toByteArray())
+        return listOf(
+            "",
+            RSAEncryptionProvider.E2E_FORMAT,
+            "v=1",
+            "k=1",
+            Base64.getEncoder().encodeToString(encryptedAesKey),
+            Base64.getEncoder().encodeToString(iv),
+            Base64.getEncoder().encodeToString(ciphertext),
+        ).joinToString("$")
+    }
+
+    // region error paths
+
+    @Test
+    fun decrypt_lessThanThreeChunks_throwsExactMessage() = runBlocking {
+        val payloads = listOf(
+            "",
+            "single",
+            "two\$chunks",
+        )
+        for (payload in payloads) {
+            try {
+                service().decrypt(payload)
+                fail("expected RuntimeException for: $payload")
+            } catch (e: RuntimeException) {
+                assertEquals("Invalid encrypted data format", e.message)
+            }
+        }
+    }
+
+    @Test
+    fun decrypt_unknownAlgorithm_throwsExactMessage() = runBlocking {
+        val payloads = listOf(
+            "\$unknown-algo\$a\$b",
+            "\$aes-128-cbc/pbkdf2-sha1\$a\$b",
+            "\$rot13\$a\$b",
+        )
+        val expectedMessages = listOf(
+            "Unsupported algorithm: unknown-algo",
+            "Unsupported algorithm: aes-128-cbc/pbkdf2-sha1",
+            "Unsupported algorithm: rot13",
+        )
+        for ((payload, expected) in payloads.zip(expectedMessages)) {
+            try {
+                service().decrypt(payload)
+                fail("expected RuntimeException for: $payload")
+            } catch (e: RuntimeException) {
+                assertEquals(expected, e.message)
+            }
+        }
+    }
+
+    // endregion
+
+    // region happy path + routing
+
+    @Test
+    fun decrypt_validPassphrasePayload_roundTrips() = runBlocking {
+        val passphrase = "correct horse battery staple"
+        val facade = EncryptionService(
+            passphraseEncryptionProvider = PassphraseEncryptionProvider(
+                passphraseSettings(
+                    passphrase
+                )
+            ),
+            RSAEncryptionProvider = RSAEncryptionProvider(e2eKeyService()),
+        )
+
+        val plaintexts = listOf(
+            "hello world",
+            "x",
+            "a".repeat(5000),
+            "unicode \u20ac \u4e2d\u6587 \uD83D\uDE00",
+        )
+        for (plaintext in plaintexts) {
+            assertEquals(plaintext, facade.decrypt(buildPassphrasePayload(passphrase, plaintext)))
+        }
+    }
+
+    @Test
+    fun decrypt_validE2EPayload_routesToE2EDecryptor() = runBlocking {
+        val store = FakeEncryptionKeyStore()
+        val keyService = e2eKeyService(store = store)
+        keyService.rotateKey()
+        val publicKey = store.keys.getValue("e2e_key_v1").public
+        val facade = EncryptionService(
+            passphraseEncryptionProvider = PassphraseEncryptionProvider(passphraseSettings("test-passphrase")),
+            RSAEncryptionProvider = RSAEncryptionProvider(keyService),
+        )
+
+        assertEquals(
+            "top-secret message",
+            facade.decrypt(buildE2EPayload(publicKey, "top-secret message"))
+        )
+    }
+
+    @Test
+    fun decrypt_passphraseFormattedPayload_dispatchedToPassphraseDecryptor() = runBlocking {
+        // 3 chunks pass the facade size check; the forwarded decryptor must
+        // reject the truncated payload with ITS error, proving the dispatch.
+        try {
+            service().decrypt("\$aes-256-cbc/pbkdf2-sha1\$a\$b")
+            fail("expected RuntimeException from passphrase decryptor")
+        } catch (e: RuntimeException) {
+            assertEquals("Invalid passphrase encrypted data format", e.message)
+        }
+    }
+
+    @Test
+    fun decrypt_e2eFormattedPayload_dispatchedToE2EDecryptor() = runBlocking {
+        try {
+            service().decrypt("\$rsa-oaep-aes-256-gcm\$a\$b")
+            fail("expected RuntimeException from E2E decryptor")
+        } catch (e: RuntimeException) {
+            assertEquals("Invalid E2E encrypted data format: expected at least 7 chunks", e.message)
+        }
+    }
+
+    // endregion
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/encryption/PassphraseEncryptionProviderTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/encryption/PassphraseEncryptionProviderTest.kt
@@ -1,0 +1,171 @@
+package me.capcom.smsgateway.modules.encryption
+
+import kotlinx.coroutines.runBlocking
+import me.capcom.smsgateway.modules.encryption.providers.PassphraseEncryptionProvider
+import me.capcom.smsgateway.modules.settings.KeyValueStorage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import java.lang.reflect.Type
+import java.security.GeneralSecurityException
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * JVM tests for PassphraseDecryptor. Ciphertext is built in-test with the
+ * same JCA recipe (PBKDF2WithHmacSHA1 + AES/CBC/PKCS5Padding) using the
+ * JVM java.util.Base64; production keeps android.util.Base64 (minSdk 21).
+ */
+class PassphraseEncryptionProviderTest {
+
+    private class FakeStorage : KeyValueStorage {
+        private val values = mutableMapOf<String, Any?>()
+
+        override fun <T> set(key: String, value: T) {
+            values[key] = value
+        }
+
+        override fun <T> get(key: String, typeOfT: Type): T? = values[key] as T?
+
+        override fun remove(key: String) {
+            values.remove(key)
+        }
+    }
+
+    private fun settingsWithPassphrase(passphrase: String): EncryptionSettings =
+        EncryptionSettings(FakeStorage().apply { set("passphrase", passphrase) })
+
+    private fun decryptor(passphrase: String): PassphraseEncryptionProvider =
+        PassphraseEncryptionProvider(settingsWithPassphrase(passphrase))
+
+    /**
+     * Mirrors the production payload format:
+     * $aes-256-cbc/pbkdf2-sha1$i={iterations}$b64(salt)$b64(ciphertext)
+     * The salt doubles as the AES-CBC IV, exactly like the production decryptor.
+     */
+    private fun encrypt(
+        passphrase: String,
+        plaintext: String,
+        iterationCount: Int = 1_000,
+    ): String {
+        val salt = ByteArray(16).also { SecureRandom().nextBytes(it) }
+        val keySpec = PBEKeySpec(passphrase.toCharArray(), salt, iterationCount, 256)
+        val keyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")
+        val key = SecretKeySpec(keyFactory.generateSecret(keySpec).encoded, "AES")
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        cipher.init(Cipher.ENCRYPT_MODE, key, IvParameterSpec(salt))
+        val ciphertext = cipher.doFinal(plaintext.toByteArray())
+        return listOf(
+            "",
+            PassphraseEncryptionProvider.PASSPHRASE_FORMAT,
+            "i=$iterationCount",
+            Base64.getEncoder().encodeToString(salt),
+            Base64.getEncoder().encodeToString(ciphertext),
+        ).joinToString("$")
+    }
+
+    // region happy path + input variation
+
+    @Test
+    fun decrypt_validPayload_roundTrips() = runBlocking {
+        val payload = encrypt("correct horse battery staple", "hello world")
+        assertEquals("hello world", decryptor("correct horse battery staple").decrypt(payload))
+    }
+
+    @Test
+    fun decrypt_varyingPlaintexts_roundTrips() = runBlocking {
+        val passphrase = "p@ssw0rd"
+        val d = decryptor(passphrase)
+        val plaintexts = listOf(
+            "x",
+            "a".repeat(5000),
+            "unicode \u20ac \u4e2d\u6587 \uD83D\uDE00",
+        )
+        for (plaintext in plaintexts) {
+            assertEquals(plaintext, d.decrypt(encrypt(passphrase, plaintext)))
+        }
+    }
+
+    @Test
+    fun decrypt_productionIterationCount_roundTrips() = runBlocking {
+        val passphrase = "production-compat"
+        val payload = encrypt(passphrase, "secret", iterationCount = 300_000)
+        assertEquals("secret", decryptor(passphrase).decrypt(payload))
+    }
+
+    // endregion
+
+    // region error paths
+
+    @Test
+    fun decrypt_missingIterationParam_throws() = runBlocking {
+        val salt = Base64.getEncoder().encodeToString(ByteArray(16))
+        val payload =
+            listOf("", PassphraseEncryptionProvider.PASSPHRASE_FORMAT, "k=1", salt, "dGV4dA==")
+                .joinToString("$")
+
+        try {
+            decryptor("p").decrypt(payload)
+            fail("expected RuntimeException")
+        } catch (e: RuntimeException) {
+            assertEquals("Missing iteration count", e.message)
+        }
+    }
+
+    @Test
+    fun decrypt_shortChunks_throws() = runBlocking {
+        val d = decryptor("p")
+        val payloads = listOf(
+            "no-chunks",
+            "\$aes-256-cbc/pbkdf2-sha1",
+            "\$aes-256-cbc/pbkdf2-sha1\$i=1000",
+            "\$aes-256-cbc/pbkdf2-sha1\$i=1000\$c2FsdA==",
+        )
+        for (payload in payloads) {
+            try {
+                d.decrypt(payload)
+                fail("expected RuntimeException")
+            } catch (e: RuntimeException) {
+                assertEquals("Invalid passphrase encrypted data format", e.message)
+            }
+        }
+    }
+
+    @Test
+    fun decrypt_missingPassphrase_throws() = runBlocking {
+        val settings = EncryptionSettings(FakeStorage())
+        val d = PassphraseEncryptionProvider(settings)
+        val payload = encrypt("irrelevant", "hello")
+
+        try {
+            d.decrypt(payload)
+            fail("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertEquals("Passphrase is not set", e.message)
+        }
+    }
+
+    @Test
+    fun decrypt_wrongPassphrase_failsDecryption() = runBlocking {
+        val payload = encrypt("correct", "hello")
+
+        try {
+            decryptor("wrong").decrypt(payload)
+            fail("expected GeneralSecurityException")
+        } catch (e: GeneralSecurityException) {
+            // expected: PBKDF2 derives a different key, CBC padding check fails
+        }
+    }
+
+    // endregion
+
+    @Test
+    fun algorithmId_isPassphraseFormat() {
+        assertEquals("aes-256-cbc/pbkdf2-sha1", decryptor("p").algorithmId)
+    }
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/encryption/RSAEncryptionProviderTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/encryption/RSAEncryptionProviderTest.kt
@@ -1,0 +1,260 @@
+package me.capcom.smsgateway.modules.encryption
+
+import kotlinx.coroutines.runBlocking
+import me.capcom.smsgateway.modules.encryption.db.EncryptionKey
+import me.capcom.smsgateway.modules.encryption.db.EncryptionKeysDao
+import me.capcom.smsgateway.modules.encryption.providers.RSAEncryptionProvider
+import me.capcom.smsgateway.modules.logs.LogsService
+import me.capcom.smsgateway.modules.logs.LogsSettings
+import me.capcom.smsgateway.modules.logs.db.LogEntriesDao
+import me.capcom.smsgateway.modules.logs.db.LogEntry
+import me.capcom.smsgateway.modules.settings.KeyValueStorage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import java.lang.reflect.Type
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PublicKey
+import java.security.SecureRandom
+import java.security.spec.MGF1ParameterSpec
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.OAEPParameterSpec
+import javax.crypto.spec.PSource
+import javax.crypto.spec.SecretKeySpec
+
+class RSAEncryptionProviderTest {
+
+    // region fakes (mirror E2EKeyServiceTest)
+
+    private class FakeEncryptionKeysDao : EncryptionKeysDao {
+        val rows = mutableListOf<EncryptionKey>()
+        private var idSeq = 1L
+
+        override suspend fun insert(encryptionKey: EncryptionKey): Long {
+            val id = idSeq++
+            rows += encryptionKey.copy(id = id)
+            return id
+        }
+
+        override suspend fun getCurrent(): EncryptionKey? =
+            rows.filter { it.retiredAt == null }.maxByOrNull { it.id }
+
+        override suspend fun getAllActive(): List<EncryptionKey> =
+            rows.filter { it.retiredAt == null }.sortedByDescending { it.id }
+
+        override suspend fun getAll(): List<EncryptionKey> = rows.sortedByDescending { it.id }
+
+        override suspend fun getByKeyVersion(keyVersion: Int): EncryptionKey? =
+            rows.firstOrNull { it.keyVersion == keyVersion }
+
+        override suspend fun retire(keyVersion: Int, retiredAt: Long) {
+            val idx = rows.indexOfFirst { it.keyVersion == keyVersion }
+            if (idx >= 0) rows[idx] = rows[idx].copy(retiredAt = retiredAt)
+        }
+
+        override suspend fun getRetiredOlderThan(cutoffTime: Long): List<EncryptionKey> =
+            rows.filter { it.retiredAt?.let { r -> r < cutoffTime } == true }
+
+        override suspend fun deleteOld(cutoffTime: Long) {
+            rows.removeAll { it.retiredAt?.let { r -> r < cutoffTime } == true }
+        }
+
+        override suspend fun countActive(): Int = rows.count { it.retiredAt == null }
+    }
+
+    private class FakeEncryptionKeyStore : EncryptionKeyStore {
+        val keys = mutableMapOf<String, KeyPair>()
+
+        override fun generateKeyPair(alias: String): KeyPairResult {
+            val kpg = KeyPairGenerator.getInstance("RSA")
+            kpg.initialize(2048)
+            val keyPair = kpg.generateKeyPair()
+            keys[alias] = keyPair
+            return KeyPairResult(
+                keyPair,
+                ByteArray(0),
+                Base64.getEncoder().encodeToString(keyPair.public.encoded)
+            )
+        }
+
+        override fun getPrivateKey(alias: String, persistedBlob: ByteArray): KeyLoadResult? =
+            keys[alias]?.let { KeyLoadResult(it.private) }
+
+        override fun delete(alias: String) {
+            keys.remove(alias)
+        }
+    }
+
+    private class FakeLogEntriesDao : LogEntriesDao {
+        override suspend fun selectByPeriod(from: Long, to: Long): List<LogEntry> = emptyList()
+        override fun selectLast(): androidx.lifecycle.LiveData<List<LogEntry>> =
+            TODO("not used by LogsService in these tests")
+
+        override fun insert(entry: LogEntry) {
+        }
+
+        override suspend fun truncate(until: Long) {
+        }
+    }
+
+    private class FakeKeyValueStorage : KeyValueStorage {
+        val values = mutableMapOf<String, Any?>()
+
+        override fun <T> set(key: String, value: T) {
+            values[key] = value
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> get(key: String, typeOfT: Type): T? = values[key] as T?
+
+        override fun remove(key: String) {
+            values.remove(key)
+        }
+    }
+
+    // endregion
+
+    private fun createService(
+        dao: FakeEncryptionKeysDao = FakeEncryptionKeysDao(),
+        store: FakeEncryptionKeyStore = FakeEncryptionKeyStore(),
+    ): E2EKeyService {
+        val storage = FakeKeyValueStorage()
+        return E2EKeyService(
+            keyStore = store,
+            dao = dao,
+            logsSvc = LogsService(FakeLogEntriesDao(), LogsSettings(storage)),
+            settings = EncryptionSettings(storage),
+        )
+    }
+
+    private fun alias(version: Int): String = "e2e_key_v$version"
+
+    /**
+     * Builds an E2E ciphertext exactly in the production format:
+     * $rsa-oaep-aes-256-gcm$v=1$k={keyVersion}$b64(aesKeyRsaOaep)$b64(iv)$b64(ct+tag)
+     * Mirrors E2EDecryptor.decrypt with a JVM Base64.
+     */
+    private fun buildE2ECiphertext(
+        publicKey: PublicKey,
+        plaintext: String,
+        versionParam: String = "v=1",
+        keyVersionParam: String = "k=1",
+    ): String {
+        val aesKey = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        val rsaCipher = Cipher.getInstance(RSA_OAEP_ALGORITHM)
+        rsaCipher.init(
+            Cipher.ENCRYPT_MODE,
+            publicKey,
+            OAEPParameterSpec(
+                "SHA-256",
+                "MGF1",
+                MGF1ParameterSpec.SHA256,
+                PSource.PSpecified.DEFAULT,
+            ),
+        )
+        val encryptedAesKey = rsaCipher.doFinal(aesKey)
+        val iv = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        val aesCipher = Cipher.getInstance("AES/GCM/NoPadding")
+        aesCipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(aesKey, "AES"), GCMParameterSpec(128, iv))
+        val ciphertext = aesCipher.doFinal(plaintext.toByteArray())
+        return listOf(
+            "",
+            "rsa-oaep-aes-256-gcm",
+            versionParam,
+            keyVersionParam,
+            Base64.getEncoder().encodeToString(encryptedAesKey),
+            Base64.getEncoder().encodeToString(iv),
+            Base64.getEncoder().encodeToString(ciphertext),
+        ).joinToString("$")
+    }
+
+    // region tests
+
+    @Test
+    fun roundTrip_decryptsPayloadEncryptedToCurrentKeyVersion() = runBlocking {
+        val store = FakeEncryptionKeyStore()
+        val service = createService(store = store)
+        val decryptor = RSAEncryptionProvider(service)
+
+        service.rotateKey()
+        val publicKey = store.keys.getValue(alias(1)).public
+        val ciphertext = buildE2ECiphertext(publicKey, "top-secret message")
+
+        assertEquals("top-secret message", decryptor.decrypt(ciphertext))
+    }
+
+    @Test
+    fun unsupportedVersion_throwsExactMessage() = runBlocking {
+        val store = FakeEncryptionKeyStore()
+        val decryptor = RSAEncryptionProvider(createService(store = store))
+
+        store.generateKeyPair(alias(1))
+        val publicKey = store.keys.getValue(alias(1)).public
+        val ciphertext = buildE2ECiphertext(publicKey, "irrelevant", versionParam = "v=2")
+
+        try {
+            decryptor.decrypt(ciphertext)
+            fail("expected RuntimeException for unsupported version")
+        } catch (e: RuntimeException) {
+            assertEquals("Unsupported E2E version: 2", e.message)
+        }
+    }
+
+    @Test
+    fun invalidKeyVersion_throwsExactMessage() = runBlocking {
+        val store = FakeEncryptionKeyStore()
+        val decryptor = RSAEncryptionProvider(createService(store = store))
+
+        store.generateKeyPair(alias(1))
+        val publicKey = store.keys.getValue(alias(1)).public
+        val ciphertext = buildE2ECiphertext(publicKey, "irrelevant", keyVersionParam = "k=abc")
+
+        try {
+            decryptor.decrypt(ciphertext)
+            fail("expected RuntimeException for invalid key version")
+        } catch (e: RuntimeException) {
+            assertEquals("Invalid E2E key version: k=abc", e.message)
+        }
+    }
+
+    @Test
+    fun missingKeyVersion_throwsExactMessage() = runBlocking {
+        // Store has a keypair for building the payload, but the DAO rows omit
+        // that key version: getPrivateKey must miss and the decryptor must fail.
+        val store = FakeEncryptionKeyStore()
+        val dao = FakeEncryptionKeysDao()
+        val decryptor = RSAEncryptionProvider(createService(dao = dao, store = store))
+
+        store.generateKeyPair(alias(1))
+        val publicKey = store.keys.getValue(alias(1)).public
+        val ciphertext = buildE2ECiphertext(publicKey, "irrelevant", keyVersionParam = "k=1")
+
+        try {
+            decryptor.decrypt(ciphertext)
+            fail("expected RuntimeException for missing key version")
+        } catch (e: RuntimeException) {
+            assertEquals("No E2E private key available for version 1", e.message)
+        }
+    }
+
+    @Test
+    fun fewerThanSevenChunks_throwsExactMessage() = runBlocking {
+        val decryptor = RSAEncryptionProvider(createService())
+
+        try {
+            decryptor.decrypt("\$rsa-oaep-aes-256-gcm\$v=1\$k=1\$x")
+            fail("expected RuntimeException for truncated payload")
+        } catch (e: RuntimeException) {
+            assertEquals("Invalid E2E encrypted data format: expected at least 7 chunks", e.message)
+        }
+    }
+
+    // endregion
+
+    private companion object {
+        const val RSA_OAEP_ALGORITHM = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"
+    }
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/encryption/StorageBlobCipherTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/encryption/StorageBlobCipherTest.kt
@@ -1,0 +1,256 @@
+package me.capcom.smsgateway.modules.encryption
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.GeneralSecurityException
+import java.security.MessageDigest
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * JVM tests for the software (API 21-22) E2E key blob codec: versioned blob
+ * format, PBKDF2 KDF, legacy (SHA-256) compat + upgrade, tamper detection.
+ */
+class StorageBlobCipherTest {
+
+    private val material = "some-android-id:me.capcom.smsgateway"
+
+    private fun newCipher(material: String = this.material) = StorageBlobCipher(material)
+
+    private fun privateKeyBytes(): ByteArray {
+        val kpg = java.security.KeyPairGenerator.getInstance("RSA")
+        kpg.initialize(2048)
+        return kpg.generateKeyPair().private.encoded
+    }
+
+    // ---------------------------------------------------------------------
+    // helpers mirroring the documented blob layout
+    // ---------------------------------------------------------------------
+
+    private data class Header(
+        val version: Int,
+        val kdfId: Int,
+        val iterations: Int,
+        val salt: ByteArray,
+        val iv: ByteArray,
+    )
+
+    private fun headerOf(blob: ByteArray): Header = Header(
+        version = blob[4].toInt(),
+        kdfId = blob[5].toInt(),
+        iterations = readInt(blob, 6),
+        salt = blob.copyOfRange(10, 26),
+        iv = blob.copyOfRange(26, 38),
+    )
+
+    private fun readInt(b: ByteArray, off: Int): Int =
+        (b[off].toInt() and 0xFF shl 24) or
+            (b[off + 1].toInt() and 0xFF shl 16) or
+            (b[off + 2].toInt() and 0xFF shl 8) or
+            (b[off + 3].toInt() and 0xFF)
+
+    private fun writeInt(b: ByteArray, off: Int, v: Int) {
+        b[off] = (v ushr 24).toByte()
+        b[off + 1] = (v ushr 16).toByte()
+        b[off + 2] = (v ushr 8).toByte()
+        b[off + 3] = v.toByte()
+    }
+
+    private fun buildV1Blob(
+        version: Int,
+        kdfId: Int,
+        iterations: Int,
+        salt: ByteArray,
+        iv: ByteArray,
+        ciphertext: ByteArray,
+    ): ByteArray {
+        val out = ByteArray(38 + ciphertext.size)
+        byteArrayOf(0x53, 0x4D, 0x53, 0x4B).copyInto(out, 0) // "SMSK"
+        out[4] = version.toByte()
+        out[5] = kdfId.toByte()
+        writeInt(out, 6, iterations)
+        salt.copyInto(out, 10)
+        iv.copyInto(out, 26)
+        ciphertext.copyInto(out, 38)
+        return out
+    }
+
+    /** Mirrors the pre-upgrade production format: iv(12) || AES-GCM(sha256(material)). */
+    private fun buildLegacyBlob(material: String, plaintext: ByteArray): ByteArray {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val key = SecretKeySpec(digest.digest(material.toByteArray()).copyOf(32), "AES")
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, key)
+        val iv = cipher.iv
+        return iv + cipher.doFinal(plaintext)
+    }
+
+    // ---------------------------------------------------------------------
+    // new-format blob (PBKDF2)
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun newBlob_hasPbkdf2HeaderWithSaltAndParams_roundTrips() {
+        val plaintext = privateKeyBytes()
+        val blob = newCipher().encrypt(plaintext)
+
+        assertTrue(blob.size > 38)
+        val header = headerOf(blob)
+        assertEquals("magic must be present", "SMSK", String(blob.copyOfRange(0, 4)))
+        assertEquals(1, header.version)
+        assertEquals(StorageBlobCipher.KDF_ID_PBKDF2, header.kdfId)
+        assertTrue("iterations >= 100k", header.iterations >= 100_000)
+        assertEquals(16, header.salt.size)
+        assertTrue(header.salt.any { it != 0.toByte() })
+        assertEquals(12, header.iv.size)
+
+        val result = newCipher().decrypt(blob)
+        assertArrayEquals(plaintext, result.plaintext)
+        assertNull("current-format blob must not yield an upgrade", result.upgradedBlob)
+    }
+
+    @Test
+    fun newBlob_usesFreshRandomSaltPerEncryption() {
+        val plaintext = privateKeyBytes()
+        val cipher = newCipher()
+        val a = cipher.encrypt(plaintext)
+        val b = cipher.encrypt(plaintext)
+
+        assertNotEquals(headerOf(a).salt.toList(), headerOf(b).salt.toList())
+        assertNotEquals(headerOf(a).iv.toList(), headerOf(b).iv.toList())
+    }
+
+    // ---------------------------------------------------------------------
+    // legacy format compat + upgrade
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun legacyBlob_decryptsAndYieldsUpgradedPbkdf2Blob() {
+        val plaintext = privateKeyBytes()
+        val legacy = buildLegacyBlob(material, plaintext)
+
+        val result = newCipher().decrypt(legacy)
+        assertArrayEquals(plaintext, result.plaintext)
+
+        val upgraded = result.upgradedBlob
+        assertNotNull("legacy blob must be re-encrypted", upgraded)
+        assertEquals("SMSK", String(upgraded!!.copyOfRange(0, 4)))
+        val header = headerOf(upgraded)
+        assertEquals(StorageBlobCipher.KDF_ID_PBKDF2, header.kdfId)
+        assertTrue(header.iterations >= 100_000)
+
+        // upgraded blob is self-contained: decrypts to the same plaintext
+        val redecrypt = newCipher().decrypt(upgraded)
+        assertArrayEquals(plaintext, redecrypt.plaintext)
+        assertNull(redecrypt.upgradedBlob)
+    }
+
+    @Test
+    fun legacyBlob_wrongMaterial_failsDecryption() {
+        val legacy = buildLegacyBlob("different-id:me.capcom.smsgateway", privateKeyBytes())
+
+        assertThrows(GeneralSecurityException::class.java) { newCipher().decrypt(legacy) }
+    }
+
+    // ---------------------------------------------------------------------
+    // tamper detection
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun tamperedSalt_failsDecryption() {
+        val blob = newCipher().encrypt(privateKeyBytes())
+        val tampered = blob.copyOf().also { it[10] = (it[10].toInt() xor 0x01).toByte() }
+
+        assertThrows(GeneralSecurityException::class.java) { newCipher().decrypt(tampered) }
+    }
+
+    @Test
+    fun tamperedIterations_failsDecryption() {
+        val blob = newCipher().encrypt(privateKeyBytes())
+        // flip the low byte: 100_000 -> 100_001 (stays within accepted bounds)
+        val tampered = blob.copyOf().also { it[9] = (it[9].toInt() xor 0x01).toByte() }
+
+        assertThrows(GeneralSecurityException::class.java) { newCipher().decrypt(tampered) }
+    }
+
+    @Test
+    fun tamperedIv_failsDecryption() {
+        val blob = newCipher().encrypt(privateKeyBytes())
+        val tampered = blob.copyOf().also { it[30] = (it[30].toInt() xor 0x01).toByte() }
+
+        assertThrows(GeneralSecurityException::class.java) { newCipher().decrypt(tampered) }
+    }
+
+    @Test
+    fun tamperedCiphertext_failsDecryption() {
+        val blob = newCipher().encrypt(privateKeyBytes())
+        val tampered = blob.copyOf().also {
+            it[it.size - 1] = (it[it.size - 1].toInt() xor 0x01).toByte()
+        }
+
+        assertThrows(GeneralSecurityException::class.java) { newCipher().decrypt(tampered) }
+    }
+
+    // ---------------------------------------------------------------------
+    // malformed / boundary inputs
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun emptyAndTruncatedBlobs_fail() {
+        assertThrows(IllegalArgumentException::class.java) { newCipher().decrypt(ByteArray(0)) }
+        assertThrows(IllegalArgumentException::class.java) { newCipher().decrypt(ByteArray(5)) }
+        // v1 header truncated (magic present but header incomplete)
+        val truncated = ByteArray(6).also { byteArrayOf(0x53, 0x4D, 0x53, 0x4B).copyInto(it, 0) }
+        assertThrows(IllegalArgumentException::class.java) { newCipher().decrypt(truncated) }
+    }
+
+    @Test
+    fun unsupportedVersion_fails() {
+        val blob = buildV1Blob(
+            version = 2,
+            kdfId = StorageBlobCipher.KDF_ID_PBKDF2,
+            iterations = 100_000,
+            salt = ByteArray(16),
+            iv = ByteArray(12),
+            ciphertext = ByteArray(16),
+        )
+
+        assertThrows(IllegalArgumentException::class.java) { newCipher().decrypt(blob) }
+    }
+
+    @Test
+    fun unsupportedKdfId_fails() {
+        val blob = buildV1Blob(
+            version = 1,
+            kdfId = 99,
+            iterations = 100_000,
+            salt = ByteArray(16),
+            iv = ByteArray(12),
+            ciphertext = ByteArray(16),
+        )
+
+        assertThrows(IllegalArgumentException::class.java) { newCipher().decrypt(blob) }
+    }
+
+    // ---------------------------------------------------------------------
+    // input variation
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun roundTrip_varyingPlaintextSizes() {
+        val sizes = intArrayOf(1, 2048, 5000)
+        for (size in sizes) {
+            val data = ByteArray(size).also { SecureRandom().nextBytes(it) }
+            val blob = newCipher().encrypt(data)
+            assertArrayEquals(data, newCipher().decrypt(blob).plaintext)
+        }
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a full E2E key management infrastructure for the Android SMS Gateway: RSA-2048 key pairs are generated on-device (AndroidKeyStore on API 23+, AES-GCM-wrapped software keys on API 21-22), stored in a new `encryption_keys` Room table (DB v24), and exposed via the local-server `GET /device` endpoint. `EncryptionService` gains a second decryption path for the hybrid `rsa-oaep-aes-256-gcm` format alongside the existing passphrase path, with an explicit `OAEPParameterSpec` that fixes the previously-flagged MGF1 hash mismatch.

- **Key lifecycle (`E2EKeyService`)**: key generation with `rotationMutex` to prevent concurrent creation, keystore-orphan cleanup on DB insert failure, and correct `retireKey()` path — all previous review findings are addressed.
- **`EncryptionService`**: algorithm-routing `decrypt()`, correct `OAEPParameterSpec(SHA-256, MGF1-SHA-256)`, and AES-GCM payload decryption.
- **`GatewayService` + `DeviceRoutes`**: public key and key version are now included in device registration, patch, and the local-server device response; the device route is extracted to a new `DeviceRoutes` class and registered under both `/device` and `/devices`.

<h3>Confidence Score: 5/5</h3>

- The local-server E2E path is functionally correct; the cloud-gateway registration sends keys the server currently ignores, but that doesn't break existing behaviour.
- All previously-flagged issues (TOCTOU race, keystore orphan, OAEP MGF1 mismatch, MODULE_NAME visibility, insert-failure cleanup) have been correctly addressed. The two remaining observations are design-level: the AndroidKeyStore entry is deleted immediately on key retirement while the DB record is kept for 7 days (making the retention window ineffective on API 23+ if future rotation is added), and the cloud server has no support for the publicKey/keyVersion fields being sent. Neither breaks the current feature as shipped.
- E2EKeyService.kt warrants attention if key rotation is added in the future — the keystore-deletion-before-DB-cleanup ordering would prevent decryption of in-flight messages encrypted with a recently-retired key on API 23+.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/encryption/E2EKeyService.kt | New service managing RSA-2048 key lifecycle for E2E encryption. Addresses previous review issues (TOCTOU via mutex, keystore orphan cleanup on insert failure, correct retireKey path). Remaining concern: retireKey() deletes the AndroidKeyStore entry immediately, which defeats the intended 7-day DB retention window for decrypting in-flight messages with retired keys. |
| app/src/main/java/me/capcom/smsgateway/modules/encryption/EncryptionService.kt | Adds E2E decryption path alongside existing passphrase path. Uses explicit OAEPParameterSpec with MGF1ParameterSpec.SHA256 (addressing previous OAEP MGF1 hash mismatch), correct AES-GCM decryption, and proper format routing. Code is correct and well-structured. |
| app/src/main/java/me/capcom/smsgateway/modules/encryption/db/EncryptionKey.kt | New Room entity for E2E key storage with unique index on key_version and index on retired_at. Custom equals/hashCode based on id only avoids ByteArray comparison issues. Looks correct. |
| app/src/main/java/me/capcom/smsgateway/modules/encryption/db/EncryptionKeysDao.kt | Clean DAO with appropriate queries. getCurrent and getAllActive use correct retired_at IS NULL filter. deleteOld correctly uses cutoff time. No issues found. |
| app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt | Now calls ensureKey() during registration and device patch to include the public key. The cloud server silently ignores publicKey/keyVersion (server has no support for these fields), making E2E for cloud-gateway mode incomplete. Local server mode is unaffected. |
| app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/DeviceRoutes.kt | New route class handling GET /device and /devices. Correctly includes E2E public key in the response by calling ensureKey(). Extraction from WebService is clean; no issues found. |
| app/src/main/java/me/capcom/smsgateway/data/AppDatabase.kt | Adds EncryptionKey entity, bumps DB version to 24, registers AutoMigration from 23→24, and exposes e2eKeysDao(). Standard Room migration pattern, correct. |
| app/src/main/java/me/capcom/smsgateway/modules/localserver/WebService.kt | Extracts device route logic to DeviceRoutes class and registers both /device and /devices paths for backward compatibility. Clean refactor, no issues. |
| app/src/main/java/me/capcom/smsgateway/modules/encryption/Module.kt | Wires E2EKeyService and updated EncryptionService in Koin. MODULE_NAME now correctly declared internal const val. |
| app/src/main/java/me/capcom/smsgateway/modules/health/Module.kt | Package declaration added, fixing the missing-package bug that previously caused an implicit default package import. No logic changes. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client (Local API)
    participant WS as WebService / DeviceRoutes
    participant E2E as E2EKeyService
    participant KS as AndroidKeyStore (API 23+)
    participant DB as Room DB (encryption_keys)
    participant ES as EncryptionService

    Note over E2E,DB: Key Provisioning
    C->>WS: GET /device
    WS->>E2E: ensureKey()
    E2E->>E2E: rotationMutex.withLock
    E2E->>DB: dao.getCurrent()
    alt No active key
        E2E->>KS: generateKeyPairInKeystore(alias)
        E2E->>DB: dao.insert(EncryptionKey)
        E2E->>E2E: enforceKeyLimit()
    end
    E2E-->>WS: EncryptionKey (publicKey, keyVersion)
    WS-->>C: "Device { publicKey, keyVersion, ... }"

    Note over C,ES: E2E Message Encryption / Decryption
    C->>C: Encrypt AES key with RSA-OAEP (SHA-256 / MGF1-SHA-256)
    C->>C: Encrypt payload with AES-256-GCM
    C->>WS: "POST /message (encrypted payload: $rsa-oaep-aes-256-gcm$v=1$k=N$...)"
    WS->>ES: decrypt(encryptedText)
    ES->>ES: "route on algorithm = "rsa-oaep-aes-256-gcm""
    ES->>E2E: "getPrivateKey(keyVersion=N)"
    E2E->>DB: dao.getByKeyVersion(N)
    E2E->>KS: getKeyFromKeystore(alias)
    KS-->>E2E: PrivateKey
    E2E-->>ES: PrivateKey
    ES->>ES: RSA-OAEP decrypt → AES key
    ES->>ES: AES-GCM decrypt → plaintext
    ES-->>WS: plaintext message
```
</details>

<sub>Reviews (5): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/capcom6/android-sms-gateway/commit/21d5fa9ed896851aa3c29b34381b1f9828d3894c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49402835)</sub>

<!-- /greptile_comment -->