### PR TITLE
[webhooks] queue UI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,6 +128,7 @@ dependencies {
     implementation "io.insert-koin:koin-android:$koin_version"
 
     testImplementation("junit:junit:4.13.2")
+    testImplementation("androidx.arch.core:core-testing:2.1.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/notifications/NotificationsService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/notifications/NotificationsService.kt
@@ -66,7 +66,7 @@ class NotificationsService(
         contentIntent: PendingIntent? = null
     ): Notification {
         return NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
-            .setContentTitle(context.getText(R.string.notification_title))
+            .setContentTitle(context.getText(R.string.sms_gateway))
             .setContentText(contentText)
             .setSmallIcon(icons[id] ?: R.drawable.ic_sms)
             .setContentIntent(

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/Module.kt
@@ -1,6 +1,8 @@
 package me.capcom.smsgateway.modules.webhooks
 
 import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueRepository
+import me.capcom.smsgateway.modules.webhooks.vm.WebhookQueueViewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
@@ -8,6 +10,7 @@ val webhooksModule = module {
     singleOf(::WebHooksService)
     singleOf(::WebhookQueueRepository)
     singleOf(::WebhookPayloadStorage)
+    viewModelOf(::WebhookQueueViewModel)
 }
 
 val NAME = "webhooks"

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueDao.kt
@@ -1,5 +1,6 @@
 package me.capcom.smsgateway.modules.webhooks.db
 
+import androidx.lifecycle.LiveData
 import androidx.room.*
 
 /**
@@ -109,6 +110,16 @@ interface WebhookQueueDao {
         id: String,
         error: String,
     )
+
+    /**
+     * Get the most recent webhook queue entries for a single status (or all when null),
+     * bounded by limit. Filtering happens at the SQL level; no unbounded query.
+     */
+    @Query(
+        "SELECT * FROM webhook_queue WHERE (:status IS NULL OR status = :status) " +
+            "ORDER BY created_at DESC LIMIT :limit"
+    )
+    fun selectLastFiltered(limit: Int, status: String? = null): LiveData<List<WebhookQueueEntity>>
 
     /**
      * Get queue statistics.

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueRepository.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueRepository.kt
@@ -1,6 +1,10 @@
 package me.capcom.smsgateway.modules.webhooks.db
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.distinctUntilChanged
 import com.aventrix.jnanoid.jnanoid.NanoIdUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import me.capcom.smsgateway.modules.webhooks.WebhookPayloadStorage
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -13,6 +17,22 @@ class WebhookQueueRepository(
     private val dao: WebhookQueueDao,
 ) : KoinComponent {
     private val payloadStorage: WebhookPayloadStorage by inject()
+
+    /**
+     * The most recent webhook queue entries, optionally filtered by status at the SQL level.
+     * Bounded by limit; distinct repeated emissions.
+     */
+    fun selectLast(limit: Int, status: WebhookStatus? = null) =
+        dao.selectLastFiltered(limit, status?.value).distinctUntilChanged()
+
+    /**
+     * Get queue statistics summary. Full-table aggregate, runs off the main thread.
+     */
+    suspend fun getQueueStatistics(): WebhookQueueStatistics {
+        return withContext(Dispatchers.IO) {
+            dao.getQueueStatistics()
+        }
+    }
 
     /**
      * Enqueue a new webhook event for processing.

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/vm/WebhookQueueViewModel.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/vm/WebhookQueueViewModel.kt
@@ -1,0 +1,53 @@
+package me.capcom.smsgateway.modules.webhooks.vm
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
+import androidx.lifecycle.switchMap
+import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueEntity
+import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueRepository
+import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueStatistics
+import me.capcom.smsgateway.modules.webhooks.db.WebhookStatus
+
+class WebhookQueueViewModel(
+    private val repository: WebhookQueueRepository
+) : ViewModel() {
+
+    private val _queryParams = MutableLiveData<Pair<Int, WebhookStatus?>>(CHUNK_SIZE to null)
+    val filter: LiveData<WebhookStatus?> = _queryParams.map { it.second }
+
+    private val _filteredEntries = MediatorLiveData<List<WebhookQueueEntity>>()
+    val filteredEntries: LiveData<List<WebhookQueueEntity>> = _filteredEntries
+
+    private val _queueStatistics = MutableLiveData<WebhookQueueStatistics?>(null)
+    val queueStatistics: LiveData<WebhookQueueStatistics?> = _queueStatistics
+
+    init {
+        _filteredEntries.addSource(_queryParams.switchMap { (limit, status) ->
+            repository.selectLast(limit, status)
+        }) {
+            _filteredEntries.value = it
+        }
+    }
+
+    /**
+     * Apply a status filter. Null selects the "All" filter.
+     * Resets the list back to the bounded limit.
+     */
+    fun setFilter(status: WebhookStatus?) {
+        _queryParams.value = CHUNK_SIZE to status
+    }
+
+    /**
+     * Load the queue statistics summary. Called from the fragment lifecycle.
+     */
+    suspend fun refreshStatistics() {
+        _queueStatistics.value = repository.getQueueStatistics()
+    }
+
+    companion object {
+        private const val CHUNK_SIZE = 100
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/HomeFragment.kt
@@ -253,7 +253,7 @@ class HomeFragment : Fragment() {
                         )
                     )
 
-                } ?: getString(R.string.settings_local_address_not_found)
+                } ?: getString(R.string.not_available)
 
                 binding.textPublicIP.text = event.publicIP?.let {
                     makeCopyableLink(
@@ -265,7 +265,7 @@ class HomeFragment : Fragment() {
                             )
                         )
                     )
-                } ?: getString(R.string.settings_public_address_not_found)
+                } ?: getString(R.string.not_available)
 
                 // Set Local Server Device ID
                 binding.textLocalDeviceId.text = localServerSettings.deviceId?.let {

--- a/app/src/main/java/me/capcom/smsgateway/ui/adapters/WebhookQueueAdapter.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/adapters/WebhookQueueAdapter.kt
@@ -1,0 +1,75 @@
+package me.capcom.smsgateway.ui.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import me.capcom.smsgateway.R
+import me.capcom.smsgateway.databinding.ItemWebhookQueueBinding
+import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueEntity
+import java.text.DateFormat
+import java.util.Date
+
+class WebhookQueueAdapter(
+    private val onItemClickListener: OnItemClickListener<WebhookQueueEntity>
+) :
+    ListAdapter<WebhookQueueEntity, WebhookQueueAdapter.ViewHolder>(WebhookQueueDiffCallback()) {
+
+    class ViewHolder(private val binding: ItemWebhookQueueBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: WebhookQueueEntity) {
+            binding.apply {
+                statusText.text = item.status.displayName
+                urlText.text = item.url
+                retryText.text = binding.root.context.getString(
+                    R.string.webhook_queue_retry_count_format,
+                    item.retryCount
+                )
+                createdAtText.text =
+                    DateFormat.getDateTimeInstance().format(Date(item.createdAt))
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return ViewHolder(
+            ItemWebhookQueueBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        ).also { holder ->
+            holder.itemView.setOnClickListener {
+                val position = holder.adapterPosition
+                if (position != RecyclerView.NO_POSITION) {
+                    onItemClickListener.onItemClick(getItem(position))
+                }
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class WebhookQueueDiffCallback : DiffUtil.ItemCallback<WebhookQueueEntity>() {
+        override fun areItemsTheSame(
+            oldItem: WebhookQueueEntity,
+            newItem: WebhookQueueEntity
+        ): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(
+            oldItem: WebhookQueueEntity,
+            newItem: WebhookQueueEntity
+        ): Boolean {
+            return oldItem == newItem
+        }
+    }
+
+    interface OnItemClickListener<T> {
+        fun onItemClick(item: T)
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/ui/dialogs/PasswordPromptDialogFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/dialogs/PasswordPromptDialogFragment.kt
@@ -25,7 +25,7 @@ class PasswordPromptDialogFragment : DialogFragment() {
             .apply {
                 setView(binding.root)
                 setPositiveButton(R.string.btn_continue, null)
-                setNegativeButton(R.string.btn_cancel) { _, _ ->
+                setNegativeButton(R.string.cancel) { _, _ ->
                     sendCanceledResult()
                 }
             }

--- a/app/src/main/java/me/capcom/smsgateway/ui/settings/WebhookQueueDetailFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/settings/WebhookQueueDetailFragment.kt
@@ -1,0 +1,117 @@
+package me.capcom.smsgateway.ui.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import me.capcom.smsgateway.R
+import me.capcom.smsgateway.databinding.FragmentWebhookQueueDetailBinding
+import me.capcom.smsgateway.modules.webhooks.WebhookPayloadStorage
+import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueDao
+import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueEntity
+import org.koin.android.ext.android.inject
+import java.text.DateFormat
+import java.util.Date
+
+class WebhookQueueDetailFragment : Fragment() {
+    private val dao: WebhookQueueDao by inject()
+    private val payloadStorage: WebhookPayloadStorage by inject()
+
+    private var _binding: FragmentWebhookQueueDetailBinding? = null
+    private val binding get() = _binding!!
+
+    private val webhookId: String
+        get() = requireNotNull(requireArguments().getString(ARG_ID)) { "id is null" }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentWebhookQueueDetailBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            val entity = findEntity(webhookId)
+            val currentBinding = _binding ?: return@launch
+            if (entity == null) {
+                currentBinding.detailLayout.isVisible = false
+                currentBinding.notFoundLayout.isVisible = true
+                return@launch
+            }
+            bindEntity(currentBinding, entity)
+        }
+    }
+
+    private suspend fun bindEntity(
+        binding: FragmentWebhookQueueDetailBinding,
+        entity: WebhookQueueEntity
+    ) {
+        binding.apply {
+            textWebhookId.text = getString(R.string.webhook_id_format, entity.id)
+            textUrl.text = entity.url
+            textStatus.text = entity.status.displayName
+            textRetryCount.text = getString(R.string.webhook_queue_retry_count_format, entity.retryCount)
+            textLastError.text = entity.lastError ?: getString(R.string.webhook_queue_no_error)
+            textCreatedAt.text = formatTimestamp(entity.createdAt)
+            textNextAttempt.text = formatTimestamp(entity.nextAttempt)
+        }
+
+        val payload = readPayload(entity.payload)
+        val currentBinding = _binding ?: return
+        currentBinding.textPayload.text =
+            payload ?: getString(R.string.webhook_queue_payload_unavailable)
+    }
+
+    private suspend fun findEntity(id: String): WebhookQueueEntity? = withContext(Dispatchers.IO) {
+        try {
+            dao.getById(id)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Row may be deleted by cleanupOldEntries between list render and detail open.
+            null
+        }
+    }
+
+    private suspend fun readPayload(payloadRef: String): String? = withContext(Dispatchers.IO) {
+        try {
+            payloadStorage.read(payloadRef)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Payload file may already be deleted for terminal statuses.
+            null
+        }
+    }
+
+    private fun formatTimestamp(timestamp: Long): String {
+        return DateFormat.getDateTimeInstance().format(Date(timestamp))
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        private const val ARG_ID = "id"
+        fun newInstance(id: String) =
+            WebhookQueueDetailFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_ID, id)
+                }
+            }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/ui/settings/WebhookQueueListFragment.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/settings/WebhookQueueListFragment.kt
@@ -1,0 +1,169 @@
+package me.capcom.smsgateway.ui.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import kotlinx.coroutines.launch
+import me.capcom.smsgateway.R
+import me.capcom.smsgateway.databinding.FragmentWebhookQueueListBinding
+import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueEntity
+import me.capcom.smsgateway.modules.webhooks.db.WebhookStatus
+import me.capcom.smsgateway.modules.webhooks.vm.WebhookQueueViewModel
+import me.capcom.smsgateway.ui.adapters.WebhookQueueAdapter
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class WebhookQueueListFragment : Fragment(),
+    WebhookQueueAdapter.OnItemClickListener<WebhookQueueEntity> {
+    private val viewModel: WebhookQueueViewModel by viewModel()
+    private val adapter: WebhookQueueAdapter = WebhookQueueAdapter(this)
+
+    private var _binding: FragmentWebhookQueueListBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentWebhookQueueListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
+        setupFilterChips()
+        binding.filterAll.isChecked = true
+
+        viewModel.filteredEntries.observe(viewLifecycleOwner) { entries ->
+            adapter.submitList(entries)
+            val isEmpty = entries.isEmpty()
+            binding.emptyState.isVisible = isEmpty
+            binding.webhookQueueList.isVisible = !isEmpty
+            if (isEmpty) {
+                val filterActive = viewModel.filter.value != null
+                binding.emptyFilterMessage.isVisible = filterActive
+                binding.emptyStateMessage.isVisible = !filterActive
+                if (filterActive) {
+                    binding.emptyFilterMessage.text = getString(
+                        R.string.webhook_queue_empty_filter,
+                        requireNotNull(viewModel.filter.value).displayName
+                    )
+                }
+            }
+            viewLifecycleOwner.lifecycleScope.launch { viewModel.refreshStatistics() }
+        }
+
+        viewModel.queueStatistics.observe(viewLifecycleOwner) { stats ->
+            if (stats != null) {
+                binding.filterAll.text = getString(R.string.filter_all_count, stats.total)
+                binding.filterPending.text = getString(R.string.filter_pending_count, stats.pending)
+                binding.filterProcessing.text =
+                    getString(R.string.filter_processing_count, stats.processing)
+                binding.filterCompleted.text =
+                    getString(R.string.filter_completed_count, stats.completed)
+                binding.filterFailed.text = getString(R.string.filter_failed_count, stats.failed)
+                binding.filterPermanentlyFailed.text = getString(
+                    R.string.filter_permanently_failed_count,
+                    stats.permanentlyFailed
+                )
+
+                binding.filterPending.visibility = if (stats.pending > 0) View.VISIBLE else View.GONE
+                binding.filterProcessing.visibility =
+                    if (stats.processing > 0) View.VISIBLE else View.GONE
+                binding.filterCompleted.visibility =
+                    if (stats.completed > 0) View.VISIBLE else View.GONE
+                binding.filterFailed.visibility = if (stats.failed > 0) View.VISIBLE else View.GONE
+                binding.filterPermanentlyFailed.visibility =
+                    if (stats.permanentlyFailed > 0) View.VISIBLE else View.GONE
+
+                if (viewModel.filter.value != null) {
+                    val activeVisible = when (viewModel.filter.value) {
+                        WebhookStatus.PENDING -> stats.pending > 0
+                        WebhookStatus.PROCESSING -> stats.processing > 0
+                        WebhookStatus.COMPLETED -> stats.completed > 0
+                        WebhookStatus.FAILED -> stats.failed > 0
+                        WebhookStatus.PERMANENTLY_FAILED -> stats.permanentlyFailed > 0
+                        else -> true
+                    }
+                    if (!activeVisible) viewModel.setFilter(null)
+                }
+            }
+        }
+
+        viewModel.filter.observe(viewLifecycleOwner) { status ->
+            when (status) {
+                null -> {
+                    if (!binding.filterAll.isChecked) binding.filterAll.isChecked = true
+                }
+                WebhookStatus.PENDING -> {
+                    if (!binding.filterPending.isChecked) binding.filterPending.isChecked = true
+                }
+                WebhookStatus.PROCESSING -> {
+                    if (!binding.filterProcessing.isChecked) binding.filterProcessing.isChecked = true
+                }
+                WebhookStatus.COMPLETED -> {
+                    if (!binding.filterCompleted.isChecked) binding.filterCompleted.isChecked = true
+                }
+                WebhookStatus.FAILED -> {
+                    if (!binding.filterFailed.isChecked) binding.filterFailed.isChecked = true
+                }
+                WebhookStatus.PERMANENTLY_FAILED -> {
+                    if (!binding.filterPermanentlyFailed.isChecked) {
+                        binding.filterPermanentlyFailed.isChecked = true
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.refreshStatistics()
+        }
+    }
+
+    private fun setupFilterChips() {
+        binding.filterChipGroup.setOnCheckedStateChangeListener { _, checkedIds ->
+            when (checkedIds.firstOrNull()) {
+                R.id.filterAll -> viewModel.setFilter(null)
+                R.id.filterPending -> viewModel.setFilter(WebhookStatus.PENDING)
+                R.id.filterProcessing -> viewModel.setFilter(WebhookStatus.PROCESSING)
+                R.id.filterCompleted -> viewModel.setFilter(WebhookStatus.COMPLETED)
+                R.id.filterFailed -> viewModel.setFilter(WebhookStatus.FAILED)
+                R.id.filterPermanentlyFailed -> viewModel.setFilter(WebhookStatus.PERMANENTLY_FAILED)
+                else -> viewModel.setFilter(null)
+            }
+        }
+    }
+
+    private fun setupRecyclerView() {
+        binding.webhookQueueList.apply {
+            layoutManager = LinearLayoutManager(context)
+            adapter = this@WebhookQueueListFragment.adapter
+            addItemDecoration(
+                DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
+            )
+        }
+    }
+
+    override fun onItemClick(item: WebhookQueueEntity) {
+        val containerId = (requireView().parent as? View)?.id
+            ?.takeIf { it != View.NO_ID }
+            ?: return
+        parentFragmentManager.commit {
+            replace(containerId, WebhookQueueDetailFragment.newInstance(item.id))
+            addToBackStack(null)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/dialog_first_start.xml
+++ b/app/src/main/res/layout/dialog_first_start.xml
@@ -142,7 +142,7 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="4dp"
             android:layout_weight="1"
-            android:text="@string/btn_cancel" />
+            android:text="@string/cancel" />
 
         <Button
             android:id="@+id/buttonContinue"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -109,7 +109,7 @@
 
                         <TextView
                             style="@style/HomeCardLabel"
-                            android:text="@string/label_username" />
+                            android:text="@string/username" />
 
                         <TextView
                             android:id="@+id/textLocalUsername"
@@ -118,7 +118,7 @@
 
                         <TextView
                             style="@style/HomeCardLabel"
-                            android:text="@string/label_password" />
+                            android:text="@string/password" />
 
                         <TextView
                             android:id="@+id/textLocalPassword"
@@ -207,7 +207,7 @@
 
                         <TextView
                             style="@style/HomeCardLabel"
-                            android:text="@string/label_username" />
+                            android:text="@string/username" />
 
                         <TextView
                             android:id="@+id/textRemoteUsername"
@@ -216,7 +216,7 @@
 
                         <TextView
                             style="@style/HomeCardLabel"
-                            android:text="@string/label_password" />
+                            android:text="@string/password" />
 
                         <TextView
                             android:id="@+id/textRemotePassword"

--- a/app/src/main/res/layout/fragment_webhook_queue_detail.xml
+++ b/app/src/main/res/layout/fragment_webhook_queue_detail.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/textTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:text="@string/webhook_queue_detail_title"
+            android:textAppearance="@style/TextAppearance.AppCompat.Title"
+            tools:ignore="UnusedAttribute" />
+
+        <LinearLayout
+            android:id="@+id/notFoundLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="48dp"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:id="@+id/notFoundText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/webhook_queue_entry_not_found"
+                android:textAppearance="?attr/textAppearanceBody1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/detailLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/textWebhookId"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                android:textStyle="bold"
+                tools:text="ID: abc123" />
+
+            <TextView
+                android:id="@+id/labelUrl"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/webhook_queue_label_url"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+            <TextView
+                android:id="@+id/textUrl"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                tools:text="https://example.com/webhook" />
+
+            <TextView
+                android:id="@+id/labelStatus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/webhook_queue_label_status"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+            <TextView
+                android:id="@+id/textStatus"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                tools:text="Failed" />
+
+            <TextView
+                android:id="@+id/labelRetryCount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/webhook_queue_label_retry_count"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+            <TextView
+                android:id="@+id/textRetryCount"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                tools:text="2" />
+
+            <TextView
+                android:id="@+id/labelLastError"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/webhook_queue_label_last_error"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+            <TextView
+                android:id="@+id/textLastError"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                tools:text="Connection refused" />
+
+            <TextView
+                android:id="@+id/labelCreatedAt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/webhook_queue_label_created_at"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+            <TextView
+                android:id="@+id/textCreatedAt"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                tools:text="2026-08-03 12:00" />
+
+            <TextView
+                android:id="@+id/labelNextAttempt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/webhook_queue_label_next_attempt"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+            <TextView
+                android:id="@+id/textNextAttempt"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                tools:text="2026-08-03 12:05" />
+
+            <TextView
+                android:id="@+id/labelPayload"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/webhook_queue_label_payload"
+                android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+            <TextView
+                android:id="@+id/textPayload"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                tools:text='{"event":"message","from":"+1234567890"}' />
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_webhook_queue_list.xml
+++ b/app/src/main/res/layout/fragment_webhook_queue_list.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground"
+    android:clickable="true"
+    android:orientation="vertical">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/statisticsCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="4dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="12dp"
+            android:paddingVertical="6dp">
+
+            <TextView
+                android:id="@+id/queueTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:text="@string/queue_status"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/filterChipGroup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:chipSpacingHorizontal="4dp"
+                app:chipSpacingVertical="0dp"
+                app:singleSelection="true"
+                app:selectionRequired="true">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/filterAll"
+                    style="@style/CompactFilterChip"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="All (0)" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/filterPending"
+                    style="@style/CompactFilterChip"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="Pending (0)" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/filterProcessing"
+                    style="@style/CompactFilterChip"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="Processing (0)" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/filterCompleted"
+                    style="@style/CompactFilterChip"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="Completed (0)" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/filterFailed"
+                    style="@style/CompactFilterChip"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="Failed (0)" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/filterPermanentlyFailed"
+                    style="@style/CompactFilterChip"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="Permanently Failed (0)" />
+
+            </com.google.android.material.chip.ChipGroup>
+
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/webhookQueueList"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:padding="8dp"
+            tools:listitem="@layout/item_webhook_queue" />
+
+        <LinearLayout
+            android:id="@+id/emptyState"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <ImageView
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:src="@drawable/ic_webhook" />
+
+            <TextView
+                android:id="@+id/emptyStateMessage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/webhook_queue_empty"
+                android:textAppearance="?attr/textAppearanceCaption" />
+
+            <TextView
+                android:id="@+id/emptyFilterMessage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:textAppearance="?attr/textAppearanceCaption"
+                android:visibility="gone"
+                tools:text="No Failed entries" />
+        </LinearLayout>
+    </FrameLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/item_webhook_queue.xml
+++ b/app/src/main/res/layout/item_webhook_queue.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/statusText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+            tools:text="Pending" />
+
+        <TextView
+            android:id="@+id/createdAtText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+            tools:text="2026-08-03 12:00" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/urlText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        tools:text="https://example.com/webhook" />
+
+    <TextView
+        android:id="@+id/retryText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+        tools:text="Retries: 2" />
+</LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -8,7 +8,6 @@
     <string name="battery_optimization_is_not_supported_on_this_device">تحسين البطارية غير مدعوم على
         هذا الجهاز</string>
     <string name="battery_optimization">تحسين البطارية</string>
-    <string name="btn_cancel">إلغاء</string>
     <string name="btn_continue">استمرار</string>
     <string name="by_code">بواسطة الكود</string>
     <string name="can_affect_battery_life">يمكن أن يؤثر على عمر البطارية</string>
@@ -42,8 +41,6 @@
     <string name="invalid_url">رابط غير صحيح</string>
     <string name="is_not_a_valid_port_must_be_between_1024_and_65535">%1$s ليس منفذًا صالحًا. يجب أن
         يكون بين 1024 و 65535.</string>
-    <string name="label_password">كلمة المرور</string>
-    <string name="label_username">اسم المستخدم</string>
     <string name="limits">الحدود</string>
     <string name="list_of_last_50_log_entries">قائمة آخر 50 إدخال سجل</string>
     <string name="listening_to_the_server_events">الاستماع لأحداث الخادم…</string>
@@ -64,7 +61,6 @@
     <string name="no_webhooks_found">لم يتم تكوين ويب هوك</string>
     <string name="not_registered">غير مسجل</string>
     <string name="not_set">لم يحدد</string>
-    <string name="notification_title">SMSGate</string>
     <string name="notification_channel">قناة الإشعارات</string>
     <string name="online_status_at_the_cost_of_battery_life">حالة الاتصال بالإنترنت على حساب عمر
         البطارية</string>
@@ -96,9 +92,8 @@
     <string name="set_maximum_value_to_activate">حدد القيمة القصوى للتفعيل</string>
     <string name="settings_changed_via_api_restart_the_app_to_apply_changes">تم تغيير الإعدادات عبر
         API. أعد تشغيل التطبيق لتطبيق التغييرات.</string>
-    <string name="settings_local_address_not_found">غير متاح</string>
+    <string name="not_available">غير متاح</string>
     <string name="settings_local_server">الخادم المحلي</string>
-    <string name="settings_public_address_not_found">غير متاح</string>
     <string name="settings_start_on_boot">بدء التشغيل عند إقلاع النظام</string>
     <string name="sign_in">تسجيل الدخول</string>
     <string name="sign_up">إنشاء حساب</string>
@@ -184,4 +179,22 @@
     <string name="filter_sms_count">SMS (%1$d)</string>
     <string name="filter_data_sms_count">SMS بيانات (%1$d)</string>
     <string name="filter_mms_count">MMS (%1$d)</string>
+    <string name="webhook_queue_empty">لا توجد إدخالات في طابور الويب هوك</string>
+    <string name="webhook_queue_empty_filter">لا توجد إدخالات %1$s</string>
+    <string name="filter_processing_count">قيد المعالجة (%1$d)</string>
+    <string name="filter_completed_count">مكتمل (%1$d)</string>
+    <string name="filter_permanently_failed_count">فشل نهائي (%1$d)</string>
+    <string name="webhook_queue_summary">عرض إدخالات طابور الويب هوك الأخيرة</string>
+    <string name="webhook_queue_title">طابور الويب هوك</string>
+    <string name="webhook_queue_detail_title">إدخال طابور الويب هوك</string>
+    <string name="webhook_queue_entry_not_found">إدخال الويب هوك غير موجود</string>
+    <string name="webhook_queue_label_url">URL</string>
+    <string name="webhook_queue_label_status">الحالة</string>
+    <string name="webhook_queue_label_last_error">آخر خطأ</string>
+    <string name="webhook_queue_label_created_at">تم الإنشاء</string>
+    <string name="webhook_queue_label_next_attempt">المحاولة التالية</string>
+    <string name="webhook_queue_label_retry_count">المحاولات</string>
+    <string name="webhook_queue_label_payload">الحمولة</string>
+    <string name="webhook_queue_payload_unavailable">الحمولة غير متاحة</string>
+    <string name="webhook_queue_no_error">لا يوجد</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -8,7 +8,6 @@
     <string name="battery_optimization_is_not_supported_on_this_device">Оптимизация батареи не
         поддерживается на этом устройстве</string>
     <string name="battery_optimization">Оптимизация батареи</string>
-    <string name="btn_cancel">Отмена</string>
     <string name="btn_continue">Продолжить</string>
     <string name="by_code">По коду</string>
     <string name="can_affect_battery_life">может влиять на время работы батареи</string>
@@ -44,8 +43,6 @@
     <string name="invalid_url">Неверный URL</string>
     <string name="is_not_a_valid_port_must_be_between_1024_and_65535">%1$s не является допустимым
         портом. Должен быть между 1024 и 65535</string>
-    <string name="label_password">Пароль</string>
-    <string name="label_username">Имя пользователя</string>
     <string name="limits">Ограничения</string>
     <string name="list_of_last_50_log_entries">Список последних 50 записей лога</string>
     <string name="listening_to_the_server_events">Прослушивание событий сервера…</string>
@@ -67,7 +64,6 @@
     <string name="no_webhooks_found">Вебхуки не настроены</string>
     <string name="not_registered">не зарегистрировано</string>
     <string name="not_set">Не задано</string>
-    <string name="notification_title">SMSGate</string>
     <string name="notification_channel">Канал уведомлений</string>
     <string name="online_status_at_the_cost_of_battery_life">Время автономной работы может быть
         снижено</string>
@@ -97,9 +93,8 @@
     <string name="set_maximum_value_to_activate">Установите максимальное значение для активации</string>
     <string name="settings_changed_via_api_restart_the_app_to_apply_changes">Настройки изменены
         через API. Перезапустите приложение для применения изменений.</string>
-    <string name="settings_local_address_not_found">Недоступно</string>
+    <string name="not_available">Недоступно</string>
     <string name="settings_local_server">Локальный сервер</string>
-    <string name="settings_public_address_not_found">Недоступно</string>
     <string name="settings_start_on_boot">Автозапуск</string>
     <string name="sign_in">Войти</string>
     <string name="sign_up">Зарегистрироваться</string>
@@ -161,7 +156,6 @@
     <string name="clear_password">Очистить пароль</string>
     <string name="password_cleared">Пароль очищен</string>
     <string name="password_must_not_be_empty">Пароль не может быть пустым</string>
-    <string name="password_hidden">Пароль скрыт</string>
     <string name="button_start_service">Запустить</string>
     <string name="button_stop_service">Остановить</string>
     <string name="receiver_content_provider_monitoring">Мониторинг контент-провайдера</string>
@@ -184,4 +178,22 @@
     <string name="filter_sms_count">SMS (%1$d)</string>
     <string name="filter_data_sms_count">Data SMS (%1$d)</string>
     <string name="filter_mms_count">MMS (%1$d)</string>
+    <string name="webhook_queue_empty">Нет записей очереди веб-хуков</string>
+    <string name="webhook_queue_empty_filter">Нет записей %1$s</string>
+    <string name="filter_processing_count">Обработка (%1$d)</string>
+    <string name="filter_completed_count">Завершено (%1$d)</string>
+    <string name="filter_permanently_failed_count">Окончательно не удалось (%1$d)</string>
+    <string name="webhook_queue_summary">Просмотр последних записей очереди веб-хуков</string>
+    <string name="webhook_queue_title">Очередь веб-хуков</string>
+    <string name="webhook_queue_detail_title">Запись очереди веб-хуков</string>
+    <string name="webhook_queue_entry_not_found">Запись веб-хука не найдена</string>
+    <string name="webhook_queue_label_url">URL</string>
+    <string name="webhook_queue_label_status">Статус</string>
+    <string name="webhook_queue_label_last_error">Последняя ошибка</string>
+    <string name="webhook_queue_label_created_at">Создано</string>
+    <string name="webhook_queue_label_next_attempt">Следующая попытка</string>
+    <string name="webhook_queue_label_retry_count">Повторы</string>
+    <string name="webhook_queue_label_payload">Полезная нагрузка</string>
+    <string name="webhook_queue_payload_unavailable">Полезная нагрузка недоступна</string>
+    <string name="webhook_queue_no_error">Нет</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -6,7 +6,6 @@
     <string name="battery_optimization_already_disabled">电池优化已禁用</string>
     <string name="battery_optimization_is_not_supported_on_this_device">此设备不支持电池优化</string>
     <string name="battery_optimization">电池优化</string>
-    <string name="btn_cancel">取消</string>
     <string name="btn_continue">继续</string>
     <string name="by_code">通过验证码</string>
     <string name="can_affect_battery_life">可能影响电池寿命</string>
@@ -38,8 +37,6 @@
     <string name="interval_seconds">间隔（秒）</string>
     <string name="invalid_url">无效的 URL</string>
     <string name="is_not_a_valid_port_must_be_between_1024_and_65535">%1$s 不是有效端口。必须在 1024-65535 之间</string>
-    <string name="label_password">密码</string>
-    <string name="label_username">用户名</string>
     <string name="limits">限制</string>
     <string name="list_of_last_50_log_entries">最近 50 条日志记录</string>
     <string name="listening_to_the_server_events">正在监听服务器事件…</string>
@@ -60,7 +57,6 @@
     <string name="no_webhooks_found">未配置 Webhook</string>
     <string name="not_registered">未注册</string>
     <string name="not_set">未设置</string>
-    <string name="notification_title">短信网关</string>
     <string name="notification_channel">通知渠道</string>
     <string name="online_status_at_the_cost_of_battery_life">保持在线状态（可能消耗更多电量）</string>
     <string name="passphrase">密码短语</string>
@@ -88,9 +84,8 @@
     <string name="server">服务器</string>
     <string name="set_maximum_value_to_activate">设置最大值以激活</string>
     <string name="settings_changed_via_api_restart_the_app_to_apply_changes">设置已通过 API 修改，重启应用以生效。</string>
-    <string name="settings_local_address_not_found">不可用</string>
+    <string name="not_available">不可用</string>
     <string name="settings_local_server">本地服务器</string>
-    <string name="settings_public_address_not_found">不可用</string>
     <string name="settings_start_on_boot">开机启动</string>
     <string name="sign_in">登录</string>
     <string name="sign_up">注册</string>
@@ -139,7 +134,6 @@
     <string name="clear_password">清除密码</string>
     <string name="password_cleared">密码已清除</string>
     <string name="password_must_not_be_empty">密码不能为空</string>
-    <string name="password_hidden">密码已隐藏</string>
     <string name="button_start_service">启动服务</string>
     <string name="button_stop_service">停止服务</string>
     <string name="receiver_content_provider_monitoring">内容提供程序监控</string>
@@ -161,4 +155,22 @@
     <string name="filter_sms_count">短信 (%1$d)</string>
     <string name="filter_data_sms_count">数据短信 (%1$d)</string>
     <string name="filter_mms_count">彩信 (%1$d)</string>
+    <string name="webhook_queue_empty">暂无 Webhook 队列条目</string>
+    <string name="webhook_queue_empty_filter">暂无 %1$s 条目</string>
+    <string name="filter_processing_count">处理中 (%1$d)</string>
+    <string name="filter_completed_count">已完成 (%1$d)</string>
+    <string name="filter_permanently_failed_count">永久失败 (%1$d)</string>
+    <string name="webhook_queue_summary">查看最近的 Webhook 队列条目</string>
+    <string name="webhook_queue_title">Webhook 队列</string>
+    <string name="webhook_queue_detail_title">Webhook 队列条目</string>
+    <string name="webhook_queue_entry_not_found">未找到 Webhook 条目</string>
+    <string name="webhook_queue_label_url">URL</string>
+    <string name="webhook_queue_label_status">状态</string>
+    <string name="webhook_queue_label_last_error">最后错误</string>
+    <string name="webhook_queue_label_created_at">创建时间</string>
+    <string name="webhook_queue_label_next_attempt">下次尝试</string>
+    <string name="webhook_queue_label_retry_count">重试次数</string>
+    <string name="webhook_queue_label_payload">负载</string>
+    <string name="webhook_queue_payload_unavailable">负载不可用</string>
+    <string name="webhook_queue_no_error">无</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,28 @@
     <string name="webhook_id_format" translatable="false">ID: %1$s</string>
     <string name="webhook_list_summary">View registered webhooks</string>
     <string name="webhook_list_title">Registered Webhooks</string>
+    <string name="webhook_queue_empty">No webhook queue entries</string>
+    <string name="webhook_queue_empty_filter">No %1$s entries</string>
+    <string name="filter_all_count">All (%1$d)</string>
+    <string name="filter_pending_count">Pending (%1$d)</string>
+    <string name="filter_processing_count">Processing (%1$d)</string>
+    <string name="filter_completed_count">Completed (%1$d)</string>
+    <string name="filter_failed_count">Failed (%1$d)</string>
+    <string name="filter_permanently_failed_count">Permanently Failed (%1$d)</string>
+    <string name="webhook_queue_retry_count_format" translatable="false">Retries: %1$d</string>
+    <string name="webhook_queue_summary">View recent webhook queue entries</string>
+    <string name="webhook_queue_title">Webhook Queue</string>
+    <string name="webhook_queue_detail_title">Webhook Queue Entry</string>
+    <string name="webhook_queue_entry_not_found">Webhook entry not found</string>
+    <string name="webhook_queue_label_url">URL</string>
+    <string name="webhook_queue_label_status">Status</string>
+    <string name="webhook_queue_label_last_error">Last error</string>
+    <string name="webhook_queue_label_created_at">Created</string>
+    <string name="webhook_queue_label_next_attempt">Next attempt</string>
+    <string name="webhook_queue_label_retry_count">Retries</string>
+    <string name="webhook_queue_label_payload">Payload</string>
+    <string name="webhook_queue_payload_unavailable">Payload unavailable</string>
+    <string name="webhook_queue_no_error">None</string>
     <string name="webhooks_dotdotdot">Webhooks…</string>
     <string name="webhooks">Webhooks</string>
     <plurals name="review_incoming_sms_webhooks">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,6 @@
     <string name="battery_optimization_is_not_supported_on_this_device">Battery optimization is not
         supported on this device</string>
     <string name="battery_optimization">Battery optimization</string>
-    <string name="btn_cancel">Cancel</string>
     <string name="btn_continue">Continue</string>
     <string name="by_code">By Code</string>
     <string name="can_affect_battery_life">can affect battery life</string>
@@ -44,8 +43,6 @@
     <string name="invalid_url">Invalid URL</string>
     <string name="is_not_a_valid_port_must_be_between_1024_and_65535">%1$s is not a valid port. Must
         be between 1024 and 65535.</string>
-    <string name="label_password">Password</string>
-    <string name="label_username">Username</string>
     <string name="limits">Limits</string>
     <string name="list_of_last_50_log_entries">List of last 50 log entries</string>
     <string name="listening_to_the_server_events">Listening to server events…</string>
@@ -66,7 +63,6 @@
     <string name="no_webhooks_found">No webhooks configured</string>
     <string name="not_registered">not registered</string>
     <string name="not_set">Not set</string>
-    <string name="notification_title">SMSGate</string>
     <string name="notification_channel">Notification channel</string>
     <string name="online_status_at_the_cost_of_battery_life">Online status at the cost of battery
         life</string>
@@ -99,12 +95,11 @@
     <string name="settings_changed_via_api_restart_the_app_to_apply_changes">Settings changed via
         API. Restart the app to apply changes.</string>
     <string name="settings_local_address_is" translatable="false">&lt;a href>%1$s:%2$d&lt;/a></string>
-    <string name="settings_local_address_not_found">Not available</string>
+    <string name="not_available">Not available</string>
     <string name="settings_local_server">Local server</string>
     <string name="button_start_service">Start Service</string>
     <string name="button_stop_service">Stop Service</string>
     <string name="settings_public_address_is" translatable="false">&lt;a href>%1$s:%2$d&lt;/a></string>
-    <string name="settings_public_address_not_found">Not available</string>
     <string name="settings_start_on_boot">Start on boot</string>
     <string name="sign_in">Sign In</string>
     <string name="sign_up">Sign Up</string>
@@ -199,11 +194,8 @@
     <string name="inbox_dotdotdot">Inbox…</string>
     <string name="inbox_settings_summary">Content provider monitoring, retention, etc.</string>
     <string name="inbox">Inbox</string>
-    <string name="filter_all_count">All (%1$d)</string>
-    <string name="filter_pending_count">Pending (%1$d)</string>
     <string name="filter_sent_count">Sent (%1$d)</string>
     <string name="filter_delivered_count">Delivered (%1$d)</string>
-    <string name="filter_failed_count">Failed (%1$d)</string>
     <string name="filter_cancelled_count">Cancelled (%1$d)</string>
     <string name="filter_sms_count">SMS (%1$d)</string>
     <string name="filter_data_sms_count">Data SMS (%1$d)</string>

--- a/app/src/main/res/xml/webhooks_preferences.xml
+++ b/app/src/main/res/xml/webhooks_preferences.xml
@@ -27,4 +27,9 @@
         app:fragment="me.capcom.smsgateway.ui.settings.WebhooksListFragment"
         app:summary="@string/webhook_list_summary"
         app:title="@string/webhook_list_title" />
+    <Preference
+        android:icon="@drawable/ic_webhook"
+        app:fragment="me.capcom.smsgateway.ui.settings.WebhookQueueListFragment"
+        app:summary="@string/webhook_queue_summary"
+        app:title="@string/webhook_queue_title" />
 </androidx.preference.PreferenceScreen>

--- a/app/src/test/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueRepositoryTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueRepositoryTest.kt
@@ -1,0 +1,166 @@
+package me.capcom.smsgateway.modules.webhooks.db
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class WebhookQueueRepositoryTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private class FakeWebhookQueueDao : WebhookQueueDao {
+        val allEntries = mutableListOf<WebhookQueueEntity>()
+        val filteredLiveData = MutableLiveData<List<WebhookQueueEntity>>(emptyList())
+        var statisticsResult = WebhookQueueStatistics(0, 0, 0, 0, 0, 0)
+        var lastFilteredStatus: String? = null
+        var lastFilteredLimit: Int = 0
+
+        override fun selectLastFiltered(
+            limit: Int,
+            status: String?
+        ): LiveData<List<WebhookQueueEntity>> {
+            lastFilteredStatus = status
+            lastFilteredLimit = limit
+            val filtered = if (status == null) allEntries else allEntries.filter { it.status.value == status }
+            filteredLiveData.value = filtered.take(limit)
+            return filteredLiveData
+        }
+
+        override suspend fun getQueueStatistics(): WebhookQueueStatistics {
+            return statisticsResult
+        }
+
+        override suspend fun insertWebhook(webhook: WebhookQueueEntity) = TODO()
+        override suspend fun getById(id: String): WebhookQueueEntity = TODO()
+        override suspend fun dueWebhooksCount(currentTime: Long): Long = TODO()
+        override suspend fun getNextAttemptTime(): Long? = TODO()
+        override suspend fun getPendingWebhooks(
+            currentTime: Long,
+            limit: Int
+        ): List<WebhookQueueEntity> = TODO()
+
+        override suspend fun markAsProcessing(id: String) = TODO()
+        override suspend fun markAsFailed(id: String, nextAttempt: Long, error: String?) = TODO()
+        override suspend fun markAsCompleted(id: String) = TODO()
+        override suspend fun markAsPermanentlyFailed(id: String, error: String) = TODO()
+        override suspend fun getOldEntryIds(cutoffTime: Long): List<String> = TODO()
+        override suspend fun cleanupOldEntries(ids: List<String>) = TODO()
+        override suspend fun recoverStuckProcessingWebhooks(timeoutThreshold: Long) = TODO()
+    }
+
+    @Test
+    fun selectLast_passesStatusValueAndBoundedLimit() {
+        val dao = FakeWebhookQueueDao()
+        dao.allEntries.addAll(
+            listOf(
+                WebhookQueueEntity(id = "1", url = "u", payload = "p", status = WebhookStatus.FAILED),
+                WebhookQueueEntity(id = "2", url = "u", payload = "p", status = WebhookStatus.PENDING)
+            )
+        )
+        val repository = WebhookQueueRepository(dao)
+
+        repository.selectLast(50, WebhookStatus.FAILED)
+
+        assertEquals("failed", dao.lastFilteredStatus)
+        assertEquals(50, dao.lastFilteredLimit)
+    }
+
+    @Test
+    fun selectLast_nullStatus_passesNullToDao() {
+        val dao = FakeWebhookQueueDao()
+        val repository = WebhookQueueRepository(dao)
+
+        repository.selectLast(100, null)
+
+        assertNull(dao.lastFilteredStatus)
+    }
+
+    @Test
+    fun getQueueStatistics_delegatesToDao() = runBlocking {
+        val dao = FakeWebhookQueueDao()
+        val expected = WebhookQueueStatistics(
+            total = 10,
+            pending = 2,
+            processing = 1,
+            failed = 3,
+            permanentlyFailed = 1,
+            completed = 3
+        )
+        dao.statisticsResult = expected
+        val repository = WebhookQueueRepository(dao)
+
+        assertEquals(expected, repository.getQueueStatistics())
+    }
+
+    @Test
+    fun canRetry_allowsBelowMaxRetries() {
+        val entity = WebhookQueueEntity(
+            id = "1",
+            url = "https://example.com",
+            payload = "file:1",
+            retryCount = 2,
+            status = WebhookStatus.FAILED
+        )
+
+        assertTrue(entity.canRetry(maxRetries = 3))
+    }
+
+    @Test
+    fun canRetry_deniesAtMaxRetries() {
+        val entity = WebhookQueueEntity(
+            id = "1",
+            url = "https://example.com",
+            payload = "file:1",
+            retryCount = 3,
+            status = WebhookStatus.FAILED
+        )
+
+        assertFalse(entity.canRetry(maxRetries = 3))
+    }
+
+    @Test
+    fun canRetry_deniesPermanentlyFailed() {
+        val entity = WebhookQueueEntity(
+            id = "1",
+            url = "https://example.com",
+            payload = "file:1",
+            retryCount = 0,
+            status = WebhookStatus.PERMANENTLY_FAILED
+        )
+
+        assertFalse(entity.canRetry(maxRetries = 3))
+    }
+
+    @Test
+    fun canRetry_defaultsToThreeMaxRetries() {
+        val entity = WebhookQueueEntity(
+            id = "1",
+            url = "https://example.com",
+            payload = "file:1",
+            retryCount = 3,
+            status = WebhookStatus.FAILED
+        )
+
+        assertFalse(entity.canRetry())
+
+        val entityBelowDefault = entity.copy(retryCount = 2)
+        assertTrue(entityBelowDefault.canRetry())
+    }
+
+    @Test
+    fun statusDisplayName_mapsAllStatuses() {
+        assertEquals("Pending", WebhookStatus.PENDING.displayName)
+        assertEquals("Processing", WebhookStatus.PROCESSING.displayName)
+        assertEquals("Completed", WebhookStatus.COMPLETED.displayName)
+        assertEquals("Failed", WebhookStatus.FAILED.displayName)
+        assertEquals("Permanently Failed", WebhookStatus.PERMANENTLY_FAILED.displayName)
+    }
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/webhooks/vm/WebhookQueueViewModelTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/webhooks/vm/WebhookQueueViewModelTest.kt
@@ -1,0 +1,178 @@
+package me.capcom.smsgateway.modules.webhooks.vm
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueDao
+import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueEntity
+import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueRepository
+import me.capcom.smsgateway.modules.webhooks.db.WebhookQueueStatistics
+import me.capcom.smsgateway.modules.webhooks.db.WebhookStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class WebhookQueueViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private class FakeWebhookQueueDao : WebhookQueueDao {
+        val entries = mutableListOf<WebhookQueueEntity>()
+        val filteredLiveData = MutableLiveData<List<WebhookQueueEntity>>(emptyList())
+        var statisticsResult = WebhookQueueStatistics(0, 0, 0, 0, 0, 0)
+        var lastFilteredStatus: String? = null
+        var lastFilteredLimit: Int = 0
+
+        override fun selectLastFiltered(
+            limit: Int,
+            status: String?
+        ): LiveData<List<WebhookQueueEntity>> {
+            lastFilteredStatus = status
+            lastFilteredLimit = limit
+            val filtered = if (status == null) entries else entries.filter { it.status.value == status }
+            filteredLiveData.value = filtered.take(limit)
+            return filteredLiveData
+        }
+
+        override suspend fun getQueueStatistics(): WebhookQueueStatistics {
+            return statisticsResult
+        }
+
+        override suspend fun insertWebhook(webhook: WebhookQueueEntity) = TODO()
+        override suspend fun getById(id: String): WebhookQueueEntity = TODO()
+        override suspend fun dueWebhooksCount(currentTime: Long): Long = TODO()
+        override suspend fun getNextAttemptTime(): Long? = TODO()
+        override suspend fun getPendingWebhooks(
+            currentTime: Long,
+            limit: Int
+        ): List<WebhookQueueEntity> = TODO()
+        override suspend fun markAsProcessing(id: String) = TODO()
+        override suspend fun markAsFailed(id: String, nextAttempt: Long, error: String?) = TODO()
+        override suspend fun markAsCompleted(id: String) = TODO()
+        override suspend fun markAsPermanentlyFailed(id: String, error: String) = TODO()
+        override suspend fun getOldEntryIds(cutoffTime: Long): List<String> = TODO()
+        override suspend fun cleanupOldEntries(ids: List<String>) = TODO()
+        override suspend fun recoverStuckProcessingWebhooks(timeoutThreshold: Long) = TODO()
+    }
+
+    private fun entity(id: String, status: WebhookStatus) = WebhookQueueEntity(
+        id = id,
+        url = "https://example.com/$id",
+        payload = "file:$id",
+        status = status
+    )
+
+    private val sampleEntries = listOf(
+        entity("1", WebhookStatus.PENDING),
+        entity("2", WebhookStatus.FAILED),
+        entity("3", WebhookStatus.COMPLETED),
+        entity("4", WebhookStatus.PROCESSING),
+        entity("5", WebhookStatus.PERMANENTLY_FAILED)
+    )
+
+    private fun viewModel(entries: List<WebhookQueueEntity>): WebhookQueueViewModel {
+        val dao = FakeWebhookQueueDao()
+        dao.entries.addAll(entries)
+        return WebhookQueueViewModel(WebhookQueueRepository(dao))
+    }
+
+    private fun observeEntries(vm: WebhookQueueViewModel): MutableList<List<WebhookQueueEntity>> {
+        val observed = mutableListOf<List<WebhookQueueEntity>>()
+        vm.filteredEntries.observeForever { observed.add(it) }
+        return observed
+    }
+
+    @Test
+    fun filter_initialNull() {
+        val vm = viewModel(sampleEntries)
+        assertNull(vm.filter.value)
+    }
+
+    @Test
+    fun filteredEntries_initialAll_returnsAllEntries() {
+        val vm = viewModel(sampleEntries)
+
+        val observed = observeEntries(vm)
+
+        assertEquals(sampleEntries.map { it.id }, observed.last().map { it.id })
+    }
+
+    @Test
+    fun filteredEntries_selectStatus_returnsMatchingRowsOnly() {
+        val vm = viewModel(sampleEntries)
+        observeEntries(vm)
+
+        vm.setFilter(WebhookStatus.FAILED)
+
+        assertEquals(listOf("2"), vm.filteredEntries.value.orEmpty().map { it.id })
+    }
+
+    @Test
+    fun filteredEntries_selectStatusWithoutMatches_returnsEmpty() {
+        val vm = viewModel(
+            listOf(
+                entity("1", WebhookStatus.PENDING),
+                entity("2", WebhookStatus.COMPLETED)
+            )
+        )
+        observeEntries(vm)
+
+        vm.setFilter(WebhookStatus.PERMANENTLY_FAILED)
+
+        assertTrue(vm.filteredEntries.value.orEmpty().isEmpty())
+    }
+
+    @Test
+    fun filteredEntries_reselectAll_restoresAllEntries() {
+        val vm = viewModel(sampleEntries)
+        observeEntries(vm)
+
+        vm.setFilter(WebhookStatus.PROCESSING)
+        vm.setFilter(null)
+
+        assertEquals(
+            sampleEntries.map { it.id },
+            vm.filteredEntries.value.orEmpty().map { it.id }
+        )
+    }
+
+    @Test
+    fun setFilter_exposesFilterLiveData() {
+        val vm = viewModel(sampleEntries)
+        observeEntries(vm)
+        vm.filter.observeForever { }
+
+        vm.setFilter(WebhookStatus.COMPLETED)
+
+        assertEquals(WebhookStatus.COMPLETED, vm.filter.value)
+    }
+
+    @Test
+    fun setFilter_resetsToBoundedLimitAndStatusValue() {
+        val dao = FakeWebhookQueueDao()
+        dao.entries.addAll(sampleEntries)
+        val vm = WebhookQueueViewModel(WebhookQueueRepository(dao))
+        observeEntries(vm)
+
+        vm.setFilter(WebhookStatus.FAILED)
+
+        assertEquals(100, dao.lastFilteredLimit)
+        assertEquals("failed", dao.lastFilteredStatus)
+    }
+
+    @Test
+    fun setFilter_nullPassesNullToDao() {
+        val dao = FakeWebhookQueueDao()
+        dao.entries.addAll(sampleEntries)
+        val vm = WebhookQueueViewModel(WebhookQueueRepository(dao))
+        observeEntries(vm)
+
+        vm.setFilter(WebhookStatus.FAILED)
+        vm.setFilter(null)
+
+        assertNull(dao.lastFilteredStatus)
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a webhook queue UI — a list screen with status-filter chips and a detail screen — wired to a new `WebhookQueueViewModel` backed by Room LiveData. It also consolidates several duplicated string resources (`btn_cancel` → `cancel`, `label_username/password` → `username/password`, `notification_title` → `sms_gateway`, `settings_*_not_found` → `not_available`), all of which already have matching translations in every locale file.

- **New UI layer**: `WebhookQueueListFragment` (filterable list with real-time stats chips) + `WebhookQueueDetailFragment` (async entity + payload display) + `WebhookQueueAdapter` (DiffUtil ListAdapter), registered in the webhooks preference screen.
- **ViewModel & data layer**: `WebhookQueueViewModel` drives filtering via `MediatorLiveData`/`switchMap`; `WebhookQueueRepository` gains `selectLast` and `getQueueStatistics`; `WebhookQueueDao` gains `selectLastFiltered` with a bounded SQL query.
- **Tests**: `WebhookQueueRepositoryTest` and `WebhookQueueViewModelTest` with properly implemented fake DAOs, fixing the interface-mismatch compile errors noted in the previous review.

<h3>Confidence Score: 5/5</h3>

- Safe to merge. The change is additive UI plumbing that reads local Room data; no writes, no network paths, and no authentication changes are involved.
- The new screens and ViewModel are correctly wired to existing Room infrastructure, the fake DAO in both test files now implements the full interface (fixing the previous compile errors), and the string consolidation is clean across all four locale files. The one flagged concern — that `refreshStatistics()` calls `_queueStatistics.value` without dispatcher enforcement — is a fragility for future callers, not a defect in the current code paths.
- No files require special attention. The ViewModel's `refreshStatistics` function is worth a second look if it ever gains additional callers from non-Main coroutine scopes.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/webhooks/vm/WebhookQueueViewModel.kt | New ViewModel for the webhook queue screen. Filter + statistics LiveData wiring is solid. `refreshStatistics()` is a suspend function that calls `_queueStatistics.value`, which is safe only when invoked from a Main-thread coroutine; the current callers (fragment's lifecycleScope) satisfy that constraint, but the public API gives no guarantee. |
| app/src/main/java/me/capcom/smsgateway/ui/settings/WebhookQueueListFragment.kt | List fragment with chip-based filtering and reactive empty-state handling. Each filteredEntries emission launches a new stats coroutine (addressing the previously noted stale-chip issue). Container-ID navigation pattern and stale chip count were flagged in previous review rounds. Overall logic is consistent and correct for the common case. |
| app/src/main/java/me/capcom/smsgateway/ui/settings/WebhookQueueDetailFragment.kt | Detail fragment with async entity and payload loading; guards against null binding after suspension correctly. Direct DAO injection (bypassing repository) was noted in a previous review. Lifecycle safety pattern with `_binding ?: return` is properly applied in both coroutine chains. |
| app/src/main/java/me/capcom/smsgateway/ui/adapters/WebhookQueueAdapter.kt | New ListAdapter using DiffUtil. Uses deprecated `adapterPosition` instead of `bindingAdapterPosition` (flagged in previous review). DiffCallback using data-class equality is correct. |
| app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueDao.kt | Added `selectLastFiltered` LiveData query with bounded LIMIT and optional nullable status filter. SQL is correct; `:status IS NULL OR status = :status` pattern properly passes through all rows when status is null. |
| app/src/main/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueRepository.kt | Added `selectLast` (delegates to DAO with distinctUntilChanged) and `getQueueStatistics` (explicit IO dispatch). Both additions are clean and follow existing repository conventions. |
| app/src/test/java/me/capcom/smsgateway/modules/webhooks/db/WebhookQueueRepositoryTest.kt | New unit tests for repository filtering, statistics, and canRetry logic. FakeWebhookQueueDao now correctly implements all interface methods (including `dueWebhooksCount` and `getNextAttemptTime`), resolving the compile errors noted in the previous review. |
| app/src/test/java/me/capcom/smsgateway/modules/webhooks/vm/WebhookQueueViewModelTest.kt | New ViewModel unit tests covering filter transitions and DAO interaction. FakeWebhookQueueDao correctly implements the full interface, fixing the mismatch called out in the previous review. Uses InstantTaskExecutorRule appropriately. |
| app/src/main/res/values/strings.xml | String key consolidation (btn_cancel→cancel, label_username/label_password→username/password, notification_title→sms_gateway, settings_*_not_found→not_available) plus new webhook queue strings. All replacement keys pre-exist in locale files; no missing-translation regressions. |
| app/src/main/res/xml/webhooks_preferences.xml | Added Preference entry pointing to WebhookQueueListFragment. Straightforward addition with matching strings and icon. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant WebhookQueueListFragment
    participant WebhookQueueViewModel
    participant WebhookQueueRepository
    participant WebhookQueueDao

    User->>WebhookQueueListFragment: Open screen
    WebhookQueueListFragment->>WebhookQueueViewModel: observe filteredEntries
    WebhookQueueViewModel->>WebhookQueueRepository: selectLast(100, null)
    WebhookQueueRepository->>WebhookQueueDao: selectLastFiltered(100, null)
    WebhookQueueDao-->>WebhookQueueRepository: "LiveData<List>"
    WebhookQueueRepository-->>WebhookQueueViewModel: LiveData (distinctUntilChanged)
    WebhookQueueViewModel-->>WebhookQueueListFragment: filteredEntries emits

    WebhookQueueListFragment->>WebhookQueueViewModel: refreshStatistics()
    WebhookQueueViewModel->>WebhookQueueRepository: getQueueStatistics()
    WebhookQueueRepository->>WebhookQueueDao: getQueueStatistics() [IO]
    WebhookQueueDao-->>WebhookQueueRepository: WebhookQueueStatistics
    WebhookQueueRepository-->>WebhookQueueViewModel: statistics
    WebhookQueueViewModel-->>WebhookQueueListFragment: queueStatistics emits → chip labels updated

    User->>WebhookQueueListFragment: Tap filter chip (e.g. Failed)
    WebhookQueueListFragment->>WebhookQueueViewModel: setFilter(FAILED)
    WebhookQueueViewModel->>WebhookQueueRepository: selectLast(100, FAILED)
    WebhookQueueRepository->>WebhookQueueDao: selectLastFiltered(100, "failed")
    WebhookQueueDao-->>WebhookQueueRepository: filtered LiveData
    WebhookQueueViewModel-->>WebhookQueueListFragment: filteredEntries re-emits

    User->>WebhookQueueListFragment: Tap item
    WebhookQueueListFragment->>WebhookQueueListFragment: onItemClick → replace container with WebhookQueueDetailFragment
    WebhookQueueListFragment->>WebhookQueueDao: getById(id) [IO via DetailFragment]
    WebhookQueueDao-->>WebhookQueueListFragment: WebhookQueueEntity
    WebhookQueueListFragment->>WebhookQueueListFragment: bindEntity + readPayload → show detail
```
</details>

<sub>Reviews (20): Last reviewed commit: ["\[i18n\] update strings"](https://github.com/capcom6/android-sms-gateway/commit/ba63a1fb3e519f305bc2d0d0b9b6e6bf0a761ea5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49918671)</sub>

<!-- /greptile_comment -->