### PR TITLE
[messages] fix queue stuck when there is a scheduled message

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -143,20 +143,13 @@ class MessagesService(
         val startTime = when {
             workHoursStart != null && workHoursStart < (nextScheduled ?: 0) -> workHoursStart
             scheduleAt != null
-                && scheduleAt > System.currentTimeMillis()
-                && scheduleAt < (nextScheduled ?: 0) -> scheduleAt
+                    && scheduleAt > System.currentTimeMillis()
+                    && scheduleAt < (nextScheduled ?: 0) -> scheduleAt
+
             else -> SendMessagesWorker.IMMEDIATE
         }
 
-        if (startTime == SendMessagesWorker.IMMEDIATE) {
-            SendMessagesWorker.start(
-                context,
-                nextScheduled == null || priority >= Message.PRIORITY_EXPEDITED,
-                SendMessagesWorker.IMMEDIATE
-            )
-        } else {
-            SendMessagesWorker.start(context, true, startTime)
-        }
+        SendMessagesWorker.start(context, true, startTime)
 
         return message
     }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where enqueueing an immediate (non-scheduled) message while a future-scheduled message was already in the queue caused the immediate message to be stuck until the scheduled message's time arrived.

- The root cause was that the old code passed `force=false` to `SendMessagesWorker.start()` (→ `ExistingWorkPolicy.KEEP`) whenever a scheduled message existed in the queue and the new message was non-expedited, so the delayed worker was never replaced by an immediate one.
- The fix always passes `force=true` (→ `ExistingWorkPolicy.REPLACE`), ensuring an immediate message always displaces any pending scheduled worker; the existing `finally` block in `sendPendingMessages` already re-registers the next scheduled time after processing, so no scheduled messages are lost.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the change is a well-targeted, minimal fix with no new logic paths introduced.
- The single-line change removes an incorrect conditional that caused immediate messages to be ignored when a scheduled message occupied the WorkManager slot. The safety net for scheduled messages (the `finally` block in `sendPendingMessages` that re-registers the next scheduled time) was already in place and is unaffected by this change. The simplification also reduces the surface area for future scheduling bugs.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt | Simplifies worker scheduling in `enqueueMessage` — always uses `ExistingWorkPolicy.REPLACE` (`force=true`) instead of conditionally using `KEEP` when a scheduled message existed in the queue. Correctly fixes the stuck-queue bug; scheduled messages are protected by the `finally` block in `sendPendingMessages` that re-registers the next scheduled time after processing. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Caller
    participant MS as MessagesService
    participant DB as MessagesDao
    participant SMW as SendMessagesWorker (WorkManager)

    Note over C,SMW: Scenario: Scheduled message M1 already in queue, new immediate message M2 arrives

    C->>MS: enqueueMessage(M2, immediate)
    MS->>DB: nextScheduledTime() → T+1hr (from M1)
    MS->>DB: enqueue(M2)
    Note over MS: startTime = IMMEDIATE (scheduleAt=null → else branch)

    Note over MS: OLD CODE (buggy path)
    MS-->>SMW: "start(force=false, IMMEDIATE) [ExistingWorkPolicy.KEEP]"
    Note over SMW: Existing worker scheduled at T+1hr is KEPT → M2 stuck!

    Note over MS: NEW CODE (fixed path)
    MS->>SMW: "start(force=true, IMMEDIATE) [ExistingWorkPolicy.REPLACE]"
    SMW->>MS: doWork() → sendPendingMessages()
    MS->>DB: getPending() → M2
    MS-->>C: M2 sent immediately ✓

    Note over SMW: finally block in sendPendingMessages
    SMW->>DB: nextScheduledTime() → T+1hr (M1 still pending)
    SMW->>SMW: "start(force=true, T+1hr) — M1 re-scheduled ✓"
```
</details>

<sub>Reviews (5): Last reviewed commit: ["\[messages\] fix queue stuck when there is..."](https://github.com/capcom6/android-sms-gateway/commit/23c092814914cb0123bb2f30159fefd07d504a6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49578063)</sub>

<!-- /greptile_comment -->