### PR TITLE
[messages] async processing of sent/delivered broadcasts

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/receivers/EventsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/receivers/EventsReceiver.kt
@@ -21,10 +21,12 @@ class EventsReceiver : BroadcastReceiver(), KoinComponent {
     private val logsService: LogsService by inject()
 
     override fun onReceive(context: Context, intent: Intent) {
+        val pendingResult = goAsync()
+        val capturedResultCode = pendingResult.resultCode
+
         scope.launch {
             try {
-                messagesService
-                    .processStateIntent(intent, resultCode)
+                messagesService.processStateIntent(intent, capturedResultCode)
             } catch (e: Throwable) {
                 logsService.insert(
                     LogEntry.Priority.ERROR,
@@ -32,8 +34,9 @@ class EventsReceiver : BroadcastReceiver(), KoinComponent {
                     "Can't process message state intent",
                     intent.toLogContext() + e.toLogContext()
                 )
+            } finally {
+                pendingResult.finish()
             }
-
         }
     }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR keeps sent and delivered broadcasts active while their state updates run asynchronously.
- Acquires a `PendingResult` with `goAsync()`.
- Captures the broadcast result code before launching asynchronous processing.
- Finishes the pending broadcast in a `finally` block.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/receivers/EventsReceiver.kt | Adds the pending-result lifecycle needed to safely process sent and delivered broadcasts after `onReceive` returns. |

</details>

<sub>Reviews (3): Last reviewed commit: ["\[messages\] async processing of sent/deli..."](https://github.com/capcom6/android-sms-gateway/commit/04ff107699b5d3c89ee084ab876a74c7b417ff8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50730555)</sub>

<!-- /greptile_comment -->