### PR TITLE
[mms] sending feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ SMS Gateway turns your Android smartphone into an SMS gateway. It's a lightweigh
 - 🔔 **Real-time incoming message notifications:** Receive instant SMS and MMS notifications via webhooks.
 - 📖 **Read received messages:** Access [previously received messages](https://docs.sms-gate.app/features/reading-messages/) via the same webhooks used for real-time notifications.
 - 📎 **MMS download notifications:** Receive webhook notifications when MMS messages are fully downloaded, including message body and attachments.
+- 📤 **Send MMS messages via API:** Send multimedia messages (images, audio, video, files) with an optional subject and text body.
 - 📦 **Batch webhook events:** Receive batched webhook deliveries when multiple messages arrive at once, reducing the number of requests.
 - 🛑 **Cancel pending messages:** Cancel queued messages before they are sent.
 - ⏳ **Send rate limiting:** Restrict the number of messages sent per period (e.g., per 30 minutes) to avoid operator throttling.
+- 🖼️ **Send and receive MMS with payloads:** Send images, audio, video, and other media as MMS with inline or URL-referenced attachments. Received attachments are persisted locally and exposed via the API. See [`docs/MMS.md`](docs/MMS.md).
 
 🔒 Security and Privacy:
 
@@ -211,6 +213,17 @@ This mode is ideal for sending messages from a local network.
       send --phones '+19162255887,+19162255888' 'Hello, doctors!'
     ```
 
+    To send an MMS message, use the `mmsMessage` field with one or more Base64-encoded attachments:
+
+    ```sh
+    curl -X POST -u <username>:<password> \
+      -H "Content-Type: application/json" \
+      -d '{ "mmsMessage": { "subject": "Hello", "text": "See the photo", "attachments": [ { "contentType": "image/jpeg", "name": "photo.jpg", "data": "<base64-encoded-bytes>" } ] }, "phoneNumbers": ["+19162255887"] }' \
+      http://<device_local_ip>:8080/message
+    ```
+
+    *Note*: The `data` field must contain Base64-encoded bytes. The app must be set as the device's default SMS app for reliable MMS sending on most carriers.
+
 The full API reference is available as interactive Swagger documentation at `http://<device_local_ip>:8080/docs`.
 
 ### Cloud Server
@@ -321,6 +334,7 @@ For cloud mode the process is similar, simply change the URL to https://api.sms-
 - [ ] Implement region-based restrictions to prevent international SMS.
 - [x] Provide an API endpoint to retrieve the list of available SIM cards on the device.
 - [x] Include detailed error messages in responses and logs.
+- [x] Send MMS messages via the API.
 
 See the [open issues](https://github.com/capcom6/android-sms-gateway/issues) for a full list of proposed features (and known issues).
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,7 @@
             <intent-filter>
                 <action android:name="me.capcom.smsgateway.ACTION_SENT" />
                 <action android:name="me.capcom.smsgateway.ACTION_DELIVERED" />
+                <action android:name="me.capcom.smsgateway.ACTION_MMS_SENT" />
             </intent-filter>
         </receiver>
         <receiver

--- a/app/src/main/assets/api/swagger.json
+++ b/app/src/main/assets/api/swagger.json
@@ -35,6 +35,52 @@
         ],
         "type": "object"
       },
+      "smsgateway.MmsMessage": {
+        "description": "MMS payload for POST /message. Requires the app to be the default SMS app for reliable delivery on most carriers.",
+        "properties": {
+          "subject": {
+            "description": "Optional MMS subject line.",
+            "nullable": true,
+            "type": "string"
+          },
+          "text": {
+            "description": "Optional text/plain body to include alongside attachments.",
+            "nullable": true,
+            "type": "string"
+          },
+          "attachments": {
+            "description": "One or more media parts, provided as inline base64 `data`.",
+            "items": {
+              "$ref": "#/components/schemas/smsgateway.MmsAttachment"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "smsgateway.MmsAttachment": {
+        "properties": {
+          "contentType": {
+            "description": "MIME type. Common values: image/jpeg, image/png, image/gif, video/mp4, audio/amr, audio/mpeg, text/plain.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Optional filename for the part (used as Content-Location).",
+            "nullable": true,
+            "type": "string"
+          },
+          "data": {
+            "description": "Base64-encoded bytes.",
+            "format": "byte",
+            "type": "string"
+          }
+        },
+        "required": [
+          "contentType",
+          "data"
+        ],
+        "type": "object"
+      },
       "MmsDownloadedPayload": {
         "allOf": [
           {
@@ -360,6 +406,15 @@
               }
             ],
             "description": "Present only when `includeContent=true` and the message type is data.",
+            "type": "object"
+          },
+          "mmsMessage": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/smsgateway.MmsMessage"
+              }
+            ],
+            "description": "Present only when `includeContent=true` and the message type is MMS.",
             "type": "object"
           },
           "deviceId": {
@@ -810,6 +865,15 @@
             "description": "Data message",
             "type": "object"
           },
+          "mmsMessage": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/smsgateway.MmsMessage"
+              }
+            ],
+            "description": "MMS message (multimedia: images, audio, video, etc.)",
+            "type": "object"
+          },
           "deviceId": {
             "description": "Optional device ID for explicit selection",
             "example": "PyDmBQZZXYmyxMwED8Fzy",
@@ -945,6 +1009,15 @@
               }
             ],
             "description": "Present only when `includeContent=true` and the message type is data.",
+            "type": "object"
+          },
+          "mmsMessage": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/smsgateway.MmsMessage"
+              }
+            ],
+            "description": "Present only when `includeContent=true` and the message type is MMS.",
             "type": "object"
           },
           "deviceId": {

--- a/app/src/main/java/me/capcom/smsgateway/data/Converters.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/Converters.kt
@@ -28,7 +28,18 @@ class Converters {
 
     @TypeConverter
     fun dateFromString(value: String?): Date? {
-        return value?.let { DATE_FORMAT.parse(it) }
+        if (value == null) return null
+        // Try the canonical format first, then a tolerant fallback list.
+        // Never let a ParseException/RuntimeException escape into LiveData.
+        val parsers = listOf(DATE_FORMAT) + FALLBACK_FORMATS
+        for (format in parsers) {
+            try {
+                format.parse(value)?.let { return it }
+            } catch (_: Exception) {
+                // try next format
+            }
+        }
+        return null
     }
 
     @TypeConverter
@@ -46,5 +57,32 @@ class Converters {
             SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
                 timeZone = TimeZone.getTimeZone("GMT")
             }
+
+        // Accepted legacy/alternate formats (all interpreted as GMT to match the
+        // canonical writer). Used only after DATE_FORMAT fails, so new rows keep
+        // the exact .SSS'Z' round-trip while old rows (e.g. produced by MIGRATION_7_8
+        // via strftime without milliseconds) are parsed without crashing.
+        private val FALLBACK_FORMATS = listOf(
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("GMT")
+                isLenient = true
+            },
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("GMT")
+                isLenient = true
+            },
+            SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("GMT")
+                isLenient = true
+            },
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("GMT")
+                isLenient = true
+            },
+            SimpleDateFormat("yyyy-MM-dd", Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("GMT")
+                isLenient = true
+            },
+        )
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/data/entities/Message.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/entities/Message.kt
@@ -12,6 +12,7 @@ import java.util.Date
 enum class MessageType {
     Text,
     Data,
+    Mms,
 }
 
 @Entity(
@@ -80,6 +81,7 @@ data class Message constructor(
         type = when (content) {
             is MessageContent.Text -> MessageType.Text
             is MessageContent.Data -> MessageType.Data
+            is MessageContent.Mms -> MessageType.Mms
         },
         createdAt = createdAt,
     )
@@ -93,6 +95,12 @@ data class Message constructor(
     val dataContent: MessageContent.Data?
         get() = when (type) {
             MessageType.Data -> gson.fromJson(content, MessageContent.Data::class.java)
+            else -> null
+        }
+
+    val mmsContent: MessageContent.Mms?
+        get() = when (type) {
+            MessageType.Mms -> gson.fromJson(content, MessageContent.Mms::class.java)
             else -> null
         }
 

--- a/app/src/main/java/me/capcom/smsgateway/domain/MessageContent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/domain/MessageContent.kt
@@ -12,4 +12,28 @@ sealed class MessageContent {
             return "$data:$port"
         }
     }
+
+    data class Mms(
+        val subject: String?,
+        val text: String?,
+        val attachments: List<Attachment>,
+    ) : MessageContent() {
+        data class Attachment(
+            val contentType: String,
+            val name: String?,
+            val data: String,
+        )
+
+        override fun toString(): String {
+            val lines = mutableListOf<String>()
+
+            subject?.let { lines.add(it) }
+            text?.let { lines.add(it) }
+            if (attachments.isNotEmpty()) {
+                lines.add("Attachments: ${attachments.size}")
+            }
+
+            return lines.joinToString("\r\n")
+        }
+    }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayApi.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayApi.kt
@@ -185,6 +185,25 @@ class GatewayApi(
             val data: String,
             val port: UShort,
         ) : MessageContent()
+
+        class Mms(
+            val subject: String?,
+            val text: String?,
+            // Gson can leave this null when the field is omitted (text-only
+            // MMS), despite the non-null Kotlin type. Normalize via the
+            // public accessor below so callers never see null.
+            @SerializedName("attachments")
+            private val _attachments: List<Attachment>?,
+        ) : MessageContent() {
+            val attachments: List<Attachment>
+                get() = _attachments.orEmpty()
+
+            class Attachment(
+                val contentType: String,
+                val name: String?,
+                val data: String,
+            )
+        }
     }
 
     data class Message(
@@ -193,6 +212,8 @@ class GatewayApi(
         val _textMessage: MessageContent.Text?,
         @SerializedName("dataMessage")
         val _dataMessage: MessageContent.Data?,
+        @SerializedName("mmsMessage")
+        val _mmsMessage: MessageContent.Mms?,
         val phoneNumbers: List<String>,
         val simNumber: Int?,
         val withDeliveryReport: Boolean?,
@@ -209,6 +230,7 @@ class GatewayApi(
         val content: MessageContent
             get() = this._dataMessage
                 ?: this._textMessage
+                ?: this._mmsMessage
                 ?: _message?.let { MessageContent.Text(it) }
                 ?: throw RuntimeException("Invalid message content")
     }

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
@@ -289,6 +289,17 @@ class GatewayService(
                         content.data,
                         content.port
                     )
+                    is GatewayApi.MessageContent.Mms -> MessageContent.Mms(
+                        subject = content.subject,
+                        text = content.text,
+                        attachments = content.attachments.map {
+                            MessageContent.Mms.Attachment(
+                                contentType = it.contentType,
+                                name = it.name,
+                                data = it.data,
+                            )
+                        }
+                    )
                 },
                 message.phoneNumbers,
                 message.isEncrypted ?: false,

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/Message.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/Message.kt
@@ -12,6 +12,7 @@ open class Message(
     val scheduleAt: Date?,
     val textMessage: TextMessage?,
     val dataMessage: DataMessage?,
+    val mmsMessage: MmsMessage?,
     val hashedMessage: HashedMessage?,
     val recipients: List<Recipient>,
     val states: Map<ProcessingState, Date>,

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/MmsMessage.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/MmsMessage.kt
@@ -1,0 +1,22 @@
+package me.capcom.smsgateway.modules.localserver.domain.messages
+
+data class MmsMessage(
+    val subject: String? = null,
+    val text: String? = null,
+    val attachments: List<Attachment> = emptyList(),
+) {
+    data class Attachment(
+        val contentType: String,
+        val data: String,
+        val name: String? = null,
+    ) {
+        fun validate(index: Int) {
+            if (contentType.isBlank()) {
+                throw IllegalArgumentException("Attachment $index: contentType is required")
+            }
+            if (data.isBlank()) {
+                throw IllegalArgumentException("Attachment $index: must provide data")
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/PostMessageRequest.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/PostMessageRequest.kt
@@ -16,6 +16,7 @@ data class PostMessageRequest(
 
     val textMessage: TextMessage? = null,
     val dataMessage: DataMessage? = null,
+    val mmsMessage: MmsMessage? = null,
 
     val deviceId: String? = null,
 
@@ -43,9 +44,9 @@ data class PostMessageRequest(
 
     fun validate(): PostMessageRequest {
         val messageTypes =
-            listOfNotNull(textMessage, dataMessage, message)
+            listOfNotNull(textMessage, dataMessage, mmsMessage, message)
         when {
-            messageTypes.isEmpty() -> throw IllegalArgumentException("Must specify exactly one of: textMessage, dataMessage, or message")
+            messageTypes.isEmpty() -> throw IllegalArgumentException("Must specify exactly one of: textMessage, dataMessage, mmsMessage, or message")
             messageTypes.size > 1 -> throw IllegalArgumentException("Cannot specify multiple message types simultaneously")
         }
 
@@ -70,6 +71,15 @@ data class PostMessageRequest(
         // Validate text message parameters
         if (textMessage?.text?.isEmpty() == true) {
             throw IllegalArgumentException("Text message is empty")
+        }
+
+        mmsMessage?.let { mms ->
+            val hasBody = !mms.text.isNullOrBlank()
+            if (!hasBody && mms.attachments.isEmpty()) {
+                throw IllegalArgumentException("MMS must have text or at least one attachment")
+            }
+
+            mms.attachments.forEachIndexed { i, att -> att.validate(i) }
         }
 
         if (phoneNumbers.isEmpty()) {

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
@@ -25,6 +25,7 @@ import me.capcom.smsgateway.modules.localserver.auth.requireScope
 import me.capcom.smsgateway.modules.localserver.domain.InboxRefreshRequest
 import me.capcom.smsgateway.modules.localserver.domain.messages.DataMessage
 import me.capcom.smsgateway.modules.localserver.domain.messages.MessageSort
+import me.capcom.smsgateway.modules.localserver.domain.messages.MmsMessage
 import me.capcom.smsgateway.modules.localserver.domain.messages.PostMessageRequest
 import me.capcom.smsgateway.modules.localserver.domain.messages.TextMessage
 import me.capcom.smsgateway.modules.messages.MessagesService
@@ -167,6 +168,20 @@ class MessagesRoutes(
                     )
                 }
 
+                request.mmsMessage != null -> {
+                    MessageContent.Mms(
+                        subject = request.mmsMessage.subject,
+                        text = request.mmsMessage.text,
+                        attachments = request.mmsMessage.attachments.map {
+                            MessageContent.Mms.Attachment(
+                                contentType = it.contentType,
+                                name = it.name,
+                                data = it.data,
+                            )
+                        }
+                    )
+                }
+
                 else -> {
                     // This case should be caught by validation, but just in case
                     throw IllegalStateException("Unknown message type")
@@ -306,6 +321,23 @@ class MessagesRoutes(
                     DataMessage(
                         data = it.data,
                         port = it.port.toInt()
+                    )
+                }
+
+                else -> null
+            },
+            mmsMessage = when (includeContent) {
+                true -> message.mmsContent?.let { mms ->
+                    MmsMessage(
+                        subject = mms.subject,
+                        text = mms.text,
+                        attachments = mms.attachments.map {
+                            MmsMessage.Attachment(
+                                contentType = it.contentType,
+                                name = it.name,
+                                data = it.data,
+                            )
+                        }
                     )
                 }
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesRepository.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesRepository.kt
@@ -99,6 +99,11 @@ class MessagesRepository(private val dao: MessagesDao) {
                         message.message.content,
                         MessageContent.Data::class.java
                     )
+
+                    MessageType.Mms -> gson.fromJson(
+                        message.message.content,
+                        MessageContent.Mms::class.java
+                    )
                 },
                 phoneNumbers = message.recipients.filter { it.state == ProcessingState.Pending }
                     .map { it.phoneNumber },

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -40,6 +40,7 @@ import me.capcom.smsgateway.modules.messages.events.MessageStateChangedEvent
 import me.capcom.smsgateway.modules.messages.exceptions.ConflictException
 import me.capcom.smsgateway.modules.messages.workers.LogTruncateWorker
 import me.capcom.smsgateway.modules.messages.workers.SendMessagesWorker
+import me.capcom.smsgateway.modules.mms.MmsSender
 import me.capcom.smsgateway.receivers.EventsReceiver
 import java.util.Date
 import kotlin.coroutines.coroutineContext
@@ -52,6 +53,7 @@ class MessagesService(
     private val encryptionService: EncryptionService,
     private val events: EventBus,
     private val logsService: LogsService,
+    private val mmsSender: MmsSender,
 ) {
     val processingOrder
         get() = settings.processingOrder
@@ -211,6 +213,22 @@ class MessagesService(
                 "pdu" to intent.extras?.getByteArray("pdu")?.joinToString("") { "%02x".format(it) },
             )
         )
+
+        if (intent.action == EventsReceiver.ACTION_MMS_SENT) {
+            val id = intent.getStringExtra(EventsReceiver.EXTRA_MESSAGE_ID) ?: return
+            val (mmsState, mmsError) = if (resultCode == Activity.RESULT_OK) {
+                ProcessingState.Sent to null
+            } else {
+                ProcessingState.Failed to "MMS send result: ${mmsErrorToMessage(resultCode)}"
+            }
+            try {
+                updateState(id, null, mmsState, mmsError)
+            } finally {
+                MmsSender.cleanup(context, id)
+            }
+            return
+        }
+
         val (state, error) = when (intent.action) {
             EventsReceiver.ACTION_SENT -> when {
                 resultCode != Activity.RESULT_OK -> ProcessingState.Failed to "Send result: " + this.resultToErrorMessage(
@@ -349,7 +367,10 @@ class MessagesService(
         }
 
         try {
-            sendSMS(request)
+            when (request.message.content) {
+                is MessageContent.Mms -> sendMMS(request)
+                else -> sendSMS(request)
+            }
             return true
         } catch (e: Exception) {
             e.printStackTrace()
@@ -362,6 +383,61 @@ class MessagesService(
         }
 
         return false
+    }
+
+    private suspend fun sendMMS(request: StoredSendRequest) {
+        val message = request.message
+        val id = message.id
+        val content = message.content as MessageContent.Mms
+
+        val simNumber = selectSimNumber(request.id, request.params)
+        if (request.params.simNumber == null && simNumber != null) {
+            dao.updateSimNumber(id, simNumber + 1)
+        }
+
+        // Resolve a subscription ID + MSISDN from the chosen SIM slot (if any).
+        // Verizon and some other US carriers silently drop MMS whose From
+        // header is the insert-address-token, so we pass an explicit MSISDN
+        // whenever the platform exposes one.
+        val subscriptionId = simNumber?.let { SubscriptionsHelper.getSubscriptionId(context, it) }
+        val fromMsisdn = simNumber?.let { SubscriptionsHelper.getPhoneNumber(context, it) }
+            ?: SubscriptionsHelper.getActiveSimCards(context)?.firstOrNull()?.phoneNumber
+
+        val decryptedContent = if (message.isEncrypted) {
+            MessageContent.Mms(
+                subject = content.subject?.let { encryptionService.decrypt(it) },
+                text = content.text?.let { encryptionService.decrypt(it) },
+                attachments = content.attachments.map {
+                    it.copy(
+                        name = it.name?.let { v -> encryptionService.decrypt(v) },
+                        data = encryptionService.decrypt(it.data)
+                    )
+                }
+            )
+        } else content
+
+        val recipients = message.phoneNumbers.map { source ->
+            decryptAndNormalizePhone(
+                source,
+                message.isEncrypted,
+                request.params.skipPhoneValidation
+            )
+        }
+
+        dao.updatePartsCount(id, 1 + decryptedContent.attachments.size)
+
+        // Don't set fromMsisdn — insert-address-token lets the MMSC fill
+        // the From field, which matches how Google Messages composes its
+        // PDUs and is what Verizon's MMSC expects.
+        mmsSender.send(id, recipients, decryptedContent, subscriptionId, fromMsisdn)
+
+        // Move all recipients out of Pending immediately so the worker loop
+        // does not re-pull this message while we wait for ACTION_MMS_SENT.
+        // State transitions to Sent/Failed are driven by processStateIntent.
+        // Only transition recipients that are still Pending: if the
+        // ACTION_MMS_SENT callback already recorded Sent/Failed, the terminal
+        // state must not be overwritten.
+        updateState(id, null, ProcessingState.Processed)
     }
 
     private suspend fun updateState(
@@ -454,6 +530,9 @@ class MessagesService(
                     }
                 }
 
+                is MessageContent.Mms ->
+                    throw IllegalStateException("MMS content must be handled via sendMMS")
+
                 is MessageContent.Data -> {
                     val data = when (message.isEncrypted) {
                         true -> encryptionService.decrypt(content.data)
@@ -512,14 +591,9 @@ class MessagesService(
                 }
 
                 try {
-                    val phoneNumber = when (message.isEncrypted) {
-                        true -> encryptionService.decrypt(sourcePhoneNumber)
-                        false -> sourcePhoneNumber
-                    }
-                    val normalizedPhoneNumber = when (request.params.skipPhoneValidation) {
-                        true -> phoneNumber.filter { it.isDigit() || it == '+' || it == '*' || it == '#' }
-                        false -> PhoneHelper.filterPhoneNumber(phoneNumber, countryCode ?: "RU")
-                    }
+                    val normalizedPhoneNumber = decryptAndNormalizePhone(
+                        sourcePhoneNumber, message.isEncrypted, request.params.skipPhoneValidation,
+                    )
 
                     sendFn(normalizedPhoneNumber, sentIntent, deliveredIntent)
 
@@ -576,6 +650,34 @@ class MessagesService(
             } else {
                 context.getSystemService(SmsManager::class.java)
             }
+        }
+    }
+
+    private fun mmsErrorToMessage(resultCode: Int): String {
+        return when (resultCode) {
+            Activity.RESULT_OK -> "OK"
+            SmsManager.MMS_ERROR_UNSPECIFIED -> "MMS_ERROR_UNSPECIFIED (An unspecified error occurred)"
+            SmsManager.MMS_ERROR_INVALID_APN -> "MMS_ERROR_INVALID_APN (The APN is invalid)"
+            SmsManager.MMS_ERROR_UNABLE_CONNECT_MMS -> "MMS_ERROR_UNABLE_CONNECT_MMS (Unable to connect to the MMS service)"
+            SmsManager.MMS_ERROR_HTTP_FAILURE -> "MMS_ERROR_HTTP_FAILURE (HTTP failure during MMS transfer)"
+            SmsManager.MMS_ERROR_IO_ERROR -> "MMS_ERROR_IO_ERROR (An I/O error occurred)"
+            SmsManager.MMS_ERROR_RETRY -> "MMS_ERROR_RETRY (The carrier indicated a retry is needed)"
+            SmsManager.MMS_ERROR_CONFIGURATION_ERROR -> "MMS_ERROR_CONFIGURATION_ERROR (MMS configuration error)"
+            SmsManager.MMS_ERROR_NO_DATA_NETWORK -> "MMS_ERROR_NO_DATA_NETWORK (No data network available)"
+            else -> "Unknown MMS error: $resultCode"
+        }
+    }
+
+    private fun decryptAndNormalizePhone(
+        source: String,
+        isEncrypted: Boolean,
+        skipValidation: Boolean,
+    ): String {
+        val phone = if (isEncrypted) encryptionService.decrypt(source) else source
+        return if (skipValidation) {
+            phone.filter { it.isDigit() || it == '+' || it == '*' || it == '#' }
+        } else {
+            PhoneHelper.filterPhoneNumber(phone, countryCode ?: "RU")
         }
     }
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/MmsSender.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/MmsSender.kt
@@ -1,0 +1,202 @@
+package me.capcom.smsgateway.modules.mms
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.telephony.SmsManager
+import android.util.Base64
+import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
+import me.capcom.smsgateway.BuildConfig
+import me.capcom.smsgateway.domain.MessageContent
+import me.capcom.smsgateway.modules.mms.pdu.aosp.CharacterSets
+import me.capcom.smsgateway.modules.mms.pdu.aosp.EncodedStringValue
+import me.capcom.smsgateway.modules.mms.pdu.aosp.PduBody
+import me.capcom.smsgateway.modules.mms.pdu.aosp.PduPart
+import me.capcom.smsgateway.modules.mms.pdu.aosp.SendReq
+import me.capcom.smsgateway.receivers.EventsReceiver
+import java.io.File
+import java.security.MessageDigest
+import me.capcom.smsgateway.modules.mms.pdu.aosp.PduComposer as AospPduComposer
+
+class MmsSender(
+    private val context: Context,
+) {
+    fun send(
+        messageId: String,
+        phoneNumbers: List<String>,
+        mms: MessageContent.Mms,
+        subscriptionId: Int?,
+        fromMsisdn: String? = null,
+    ) {
+        val req = buildSendReq(phoneNumbers, mms, fromMsisdn)
+        val pdu = AospPduComposer(context, req).make()
+            ?: throw RuntimeException("AOSP PduComposer returned null bytes")
+
+        val file = writePduFile(messageId, pdu)
+        val uri = FileProvider.getUriForFile(
+            context,
+            BuildConfig.APPLICATION_ID + ".fileprovider",
+            file
+        )
+
+        context.grantUriPermission(
+            "com.android.phone", uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
+        )
+        context.grantUriPermission(
+            "com.android.mms.service", uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
+        )
+
+        val sentIntent = PendingIntent.getBroadcast(
+            context,
+            messageId.hashCode(),
+            Intent(
+                EventsReceiver.ACTION_MMS_SENT,
+                Uri.parse("mmsgw:$messageId"),
+                context,
+                EventsReceiver::class.java
+            ).apply {
+                putExtra(EventsReceiver.EXTRA_MESSAGE_ID, messageId)
+                putExtra(EventsReceiver.EXTRA_PDU_PATH, file.absolutePath)
+                flags = Intent.FLAG_RECEIVER_FOREGROUND
+            },
+            pendingIntentFlags()
+        )
+
+        val manager = getSmsManager(subscriptionId)
+        try {
+            manager.sendMultimediaMessage(
+                context,
+                uri,
+                null,
+                null,
+                sentIntent
+            )
+        } catch (e: Exception) {
+            file.delete()
+            throw e
+        }
+    }
+
+    private fun buildSendReq(
+        phoneNumbers: List<String>,
+        mms: MessageContent.Mms,
+        fromMsisdn: String?,
+    ): SendReq {
+        val req = SendReq()
+
+        // Recipients
+        req.to = phoneNumbers.map { EncodedStringValue(it) }.toTypedArray()
+
+        // Optional subject
+        mms.subject?.takeIf { it.isNotBlank() }?.let {
+            req.subject = EncodedStringValue(it)
+        }
+
+        // Optional explicit From (Verizon accepts both insert-address-token
+        // default set by SendReq() and an explicit MSISDN).
+        if (!fromMsisdn.isNullOrBlank()) {
+            req.from = EncodedStringValue(fromMsisdn)
+        }
+
+        val body = PduBody()
+        var index = 0
+        mms.text?.takeIf { it.isNotBlank() }?.let { text ->
+            val part = PduPart()
+            part.contentType = "text/plain".toByteArray()
+            part.charset = CharacterSets.UTF_8
+            val name = "text_${index++}.txt"
+            part.contentLocation = name.toByteArray()
+            part.contentId = "<${name}>".toByteArray()
+            part.name = name.toByteArray()
+            part.data = text.toByteArray(Charsets.UTF_8)
+            body.addPart(part)
+        }
+
+        mms.attachments.forEach { att ->
+            val bytes = attachmentBytes(att)
+            val fallbackName = "part_${index++}${extensionFor(att.contentType)}"
+            val name = att.name?.takeIf { it.isNotBlank() } ?: fallbackName
+            val part = PduPart()
+            part.contentType = att.contentType.substringBefore(';').trim().toByteArray()
+            part.contentLocation = name.toByteArray()
+            part.contentId = "<${name}>".toByteArray()
+            part.name = name.toByteArray()
+            part.data = bytes
+            body.addPart(part)
+        }
+
+        require(body.partsNum > 0) { "MMS must contain at least one part" }
+
+        req.body = body
+        // Message size hint for the MMSC (AOSP composes this field optionally).
+        req.messageSize = (0 until body.partsNum)
+            .sumOf { body.getPart(it).dataLength.toLong() }
+        return req
+    }
+
+    private fun attachmentBytes(att: MessageContent.Mms.Attachment): ByteArray {
+        return try {
+            Base64.decode(att.data, Base64.DEFAULT)
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Invalid base64 data for attachment", e)
+        }
+    }
+
+    private fun extensionFor(contentType: String): String {
+        val mime = contentType.substringBefore(';').trim().lowercase()
+        val ext = MimeTypeMap.getSingleton().getExtensionFromMimeType(mime)
+        return if (ext != null) ".$ext" else ".bin"
+    }
+
+    private fun writePduFile(messageId: String, bytes: ByteArray): File {
+        val dir = File(context.filesDir, "mms-out").apply { mkdirs() }
+        val file = File(dir, "${pduFileName(messageId)}.pdu")
+        file.writeBytes(bytes)
+        return file
+    }
+
+    private fun pendingIntentFlags(): Int {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun getSmsManager(subscriptionId: Int?): SmsManager {
+        return when {
+            subscriptionId == null || subscriptionId < 0 -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    context.getSystemService(SmsManager::class.java)
+                } else {
+                    SmsManager.getDefault()
+                }
+            }
+
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
+                context.getSystemService(SmsManager::class.java)
+                    .createForSubscriptionId(subscriptionId)
+
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1 ->
+                SmsManager.getSmsManagerForSubscriptionId(subscriptionId)
+
+            else -> SmsManager.getDefault()
+        }
+    }
+
+    companion object {
+        /** Clean up any stale PDU files for the given message. */
+        fun cleanup(context: Context, messageId: String) {
+            File(File(context.filesDir, "mms-out"), "${pduFileName(messageId)}.pdu").delete()
+        }
+
+        private fun pduFileName(messageId: String): String =
+            MessageDigest.getInstance("SHA-256")
+                .digest(messageId.toByteArray(Charsets.UTF_8))
+                .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/Module.kt
@@ -5,6 +5,7 @@ import org.koin.dsl.module
 
 val mmsModule = module {
     singleOf(::MmsAttachmentStorage)
+    singleOf(::MmsSender)
 }
 
-val MODULE_NAME = "mms"
+internal const val MODULE_NAME = "mms"

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/PduComposer.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/PduComposer.java
@@ -1,0 +1,1216 @@
+/*
+ * Copyright (C) 2007-2008 Esmertec AG.
+ * Copyright (C) 2007-2008 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.text.TextUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class PduComposer {
+    /**
+     * Address regular expression string.
+     */
+    static final String REGEXP_PHONE_NUMBER_ADDRESS_TYPE = "\\+?[0-9|\\.|\\-]+";
+    static final String REGEXP_EMAIL_ADDRESS_TYPE = "[a-zA-Z| ]*\\<{0,1}[a-zA-Z| ]+@{1}" +
+            "[a-zA-Z| ]+\\.{1}[a-zA-Z| ]+\\>{0,1}";
+    static final String REGEXP_IPV6_ADDRESS_TYPE =
+            "[a-fA-F]{4}\\:{1}[a-fA-F0-9]{4}\\:{1}[a-fA-F0-9]{4}\\:{1}" +
+                    "[a-fA-F0-9]{4}\\:{1}[a-fA-F0-9]{4}\\:{1}[a-fA-F0-9]{4}\\:{1}" +
+                    "[a-fA-F0-9]{4}\\:{1}[a-fA-F0-9]{4}";
+    static final String REGEXP_IPV4_ADDRESS_TYPE = "[0-9]{1,3}\\.{1}[0-9]{1,3}\\.{1}" +
+            "[0-9]{1,3}\\.{1}[0-9]{1,3}";
+    /**
+     * The postfix strings of address.
+     */
+    static final String STRING_PHONE_NUMBER_ADDRESS_TYPE = "/TYPE=PLMN";
+    static final String STRING_IPV4_ADDRESS_TYPE = "/TYPE=IPV4";
+    static final String STRING_IPV6_ADDRESS_TYPE = "/TYPE=IPV6";
+    /**
+     * Address type.
+     */
+    static private final int PDU_PHONE_NUMBER_ADDRESS_TYPE = 1;
+    static private final int PDU_EMAIL_ADDRESS_TYPE = 2;
+    static private final int PDU_IPV4_ADDRESS_TYPE = 3;
+    static private final int PDU_IPV6_ADDRESS_TYPE = 4;
+    static private final int PDU_UNKNOWN_ADDRESS_TYPE = 5;
+    /**
+     * Error values.
+     */
+    static private final int PDU_COMPOSE_SUCCESS = 0;
+    static private final int PDU_COMPOSE_CONTENT_ERROR = 1;
+    static private final int PDU_COMPOSE_FIELD_NOT_SET = 2;
+    static private final int PDU_COMPOSE_FIELD_NOT_SUPPORTED = 3;
+
+    /**
+     * WAP values defined in WSP spec.
+     */
+    static private final int QUOTED_STRING_FLAG = 34;
+    static private final int END_STRING_FLAG = 0;
+    static private final int LENGTH_QUOTE = 31;
+    static private final int TEXT_MAX = 127;
+    static private final int SHORT_INTEGER_MAX = 127;
+    static private final int LONG_INTEGER_LENGTH_MAX = 8;
+
+    /**
+     * Block size when read data from InputStream.
+     */
+    static private final int PDU_COMPOSER_BLOCK_SIZE = 1024;
+    /**
+     * Map of all content type
+     */
+    private static HashMap<String, Integer> mContentTypeMap = null;
+
+    static {
+        mContentTypeMap = new HashMap<String, Integer>();
+
+        int i;
+        for (i = 0; i < PduContentTypes.contentTypes.length; i++) {
+            mContentTypeMap.put(PduContentTypes.contentTypes[i], i);
+        }
+    }
+
+    /**
+     * Content resolver.
+     */
+    
+    private final ContentResolver mResolver;
+    /**
+     * The output message.
+     */
+    
+    protected ByteArrayOutputStream mMessage = null;
+    /**
+     * Current visiting position of the mMessage.
+     */
+    
+    protected int mPosition = 0;
+    /**
+     * The PDU.
+     */
+    
+    private GenericPdu mPdu = null;
+    /**
+     * Message compose buffer stack.
+     */
+    
+    private BufferStack mStack = null;
+    /**
+     * Header of this pdu.
+     */
+    
+    private PduHeaders mPduHeader = null;
+
+    /**
+     * Constructor.
+     *
+     * @param context the context
+     * @param pdu     the pdu to be composed
+     */
+    
+    public PduComposer(Context context, GenericPdu pdu) {
+        mPdu = pdu;
+        mResolver = context.getContentResolver();
+        mPduHeader = pdu.getPduHeaders();
+        mStack = new BufferStack();
+        mMessage = new ByteArrayOutputStream();
+        mPosition = 0;
+    }
+
+    /**
+     * Check address type.
+     *
+     * @param address address string without the postfix stinng type,
+     *                such as "/TYPE=PLMN", "/TYPE=IPv6" and "/TYPE=IPv4"
+     * @return PDU_PHONE_NUMBER_ADDRESS_TYPE if it is phone number,
+     * PDU_EMAIL_ADDRESS_TYPE if it is email address,
+     * PDU_IPV4_ADDRESS_TYPE if it is ipv4 address,
+     * PDU_IPV6_ADDRESS_TYPE if it is ipv6 address,
+     * PDU_UNKNOWN_ADDRESS_TYPE if it is unknown.
+     */
+    protected static int checkAddressType(String address) {
+        /*
+         * From OMA-TS-MMS-ENC-V1_3-20050927-C.pdf, section 8.
+         * address = ( e-mail / device-address / alphanum-shortcode / num-shortcode)
+         * e-mail = mailbox; to the definition of mailbox as described in
+         * section 3.4 of [RFC2822], but excluding the
+         * obsolete definitions as indicated by the "obs-" prefix.
+         * device-address = ( global-phone-number "/TYPE=PLMN" )
+         * / ( ipv4 "/TYPE=IPv4" ) / ( ipv6 "/TYPE=IPv6" )
+         * / ( escaped-value "/TYPE=" address-type )
+         *
+         * global-phone-number = ["+"] 1*( DIGIT / written-sep )
+         * written-sep =("-"/".")
+         *
+         * ipv4 = 1*3DIGIT 3( "." 1*3DIGIT ) ; IPv4 address value
+         *
+         * ipv6 = 4HEXDIG 7( ":" 4HEXDIG ) ; IPv6 address per RFC 2373
+         */
+
+        if (null == address) {
+            return PDU_UNKNOWN_ADDRESS_TYPE;
+        }
+
+        if (address.matches(REGEXP_IPV4_ADDRESS_TYPE)) {
+            // Ipv4 address.
+            return PDU_IPV4_ADDRESS_TYPE;
+        } else if (address.matches(REGEXP_PHONE_NUMBER_ADDRESS_TYPE)) {
+            // Phone number.
+            return PDU_PHONE_NUMBER_ADDRESS_TYPE;
+        } else if (address.matches(REGEXP_EMAIL_ADDRESS_TYPE)) {
+            // Email address.
+            return PDU_EMAIL_ADDRESS_TYPE;
+        } else if (address.matches(REGEXP_IPV6_ADDRESS_TYPE)) {
+            // Ipv6 address.
+            return PDU_IPV6_ADDRESS_TYPE;
+        } else {
+            // Unknown address.
+            return PDU_UNKNOWN_ADDRESS_TYPE;
+        }
+    }
+
+    /**
+     * Make the message. No need to check whether mandatory fields are set,
+     * because the constructors of outgoing pdus are taking care of this.
+     *
+     * @return OutputStream of maked message. Return null if
+     * the PDU is invalid.
+     */
+    
+    public byte[] make() {
+        // Get Message-type.
+        int type = mPdu.getMessageType();
+
+        /* make the message */
+        switch (type) {
+            case PduHeaders.MESSAGE_TYPE_SEND_REQ:
+            case PduHeaders.MESSAGE_TYPE_RETRIEVE_CONF:
+                if (makeSendRetrievePdu(type) != PDU_COMPOSE_SUCCESS) {
+                    return null;
+                }
+                break;
+            case PduHeaders.MESSAGE_TYPE_NOTIFYRESP_IND:
+                if (makeNotifyResp() != PDU_COMPOSE_SUCCESS) {
+                    return null;
+                }
+                break;
+            case PduHeaders.MESSAGE_TYPE_ACKNOWLEDGE_IND:
+                if (makeAckInd() != PDU_COMPOSE_SUCCESS) {
+                    return null;
+                }
+                break;
+            case PduHeaders.MESSAGE_TYPE_READ_REC_IND:
+                if (makeReadRecInd() != PDU_COMPOSE_SUCCESS) {
+                    return null;
+                }
+                break;
+            default:
+                return null;
+        }
+
+        return mMessage.toByteArray();
+    }
+
+    /**
+     * Copy buf to mMessage.
+     */
+    
+    protected void arraycopy(byte[] buf, int pos, int length) {
+        mMessage.write(buf, pos, length);
+        mPosition = mPosition + length;
+    }
+
+    /**
+     * Append a byte to mMessage.
+     */
+    protected void append(int value) {
+        mMessage.write(value);
+        mPosition++;
+    }
+
+    /**
+     * Append short integer value to mMessage.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    
+    protected void appendShortInteger(int value) {
+        /*
+         * From WAP-230-WSP-20010705-a:
+         * Short-integer = OCTET
+         * ; Integers in range 0-127 shall be encoded as a one octet value
+         * ; with the most significant bit set to one (1xxx xxxx) and with
+         * ; the value in the remaining least significant bits.
+         * In our implementation, only low 7 bits are stored and otherwise
+         * bits are ignored.
+         */
+        append((value | 0x80) & 0xff);
+    }
+
+    /**
+     * Append an octet number between 128 and 255 into mMessage.
+     * NOTE:
+     * A value between 0 and 127 should be appended by using appendShortInteger.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    
+    protected void appendOctet(int number) {
+        append(number);
+    }
+
+    /**
+     * Append a short length into mMessage.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    protected void appendShortLength(int value) {
+        /*
+         * From WAP-230-WSP-20010705-a:
+         * Short-length = <Any octet 0-30>
+         */
+        append(value);
+    }
+
+    /**
+     * Append long integer into mMessage. it's used for really long integers.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    
+    protected void appendLongInteger(long longInt) {
+        /*
+         * From WAP-230-WSP-20010705-a:
+         * Long-integer = Short-length Multi-octet-integer
+         * ; The Short-length indicates the length of the Multi-octet-integer
+         * Multi-octet-integer = 1*30 OCTET
+         * ; The content octets shall be an unsigned integer value with the
+         * ; most significant octet encoded first (big-endian representation).
+         * ; The minimum number of octets must be used to encode the value.
+         */
+        int size;
+        long temp = longInt;
+
+        // Count the length of the long integer.
+        for (size = 0; (temp != 0) && (size < LONG_INTEGER_LENGTH_MAX); size++) {
+            temp = (temp >>> 8);
+        }
+
+        // Set Length.
+        appendShortLength(size);
+
+        // Count and set the long integer.
+        int i;
+        int shift = (size - 1) * 8;
+
+        for (i = 0; i < size; i++) {
+            append((int) ((longInt >>> shift) & 0xff));
+            shift = shift - 8;
+        }
+    }
+
+    /**
+     * Append text string into mMessage.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    
+    protected void appendTextString(byte[] text) {
+        /*
+         * From WAP-230-WSP-20010705-a:
+         * Text-string = [Quote] *TEXT End-of-string
+         * ; If the first character in the TEXT is in the range of 128-255,
+         * ; a Quote character must precede it. Otherwise the Quote character
+         * ;must be omitted. The Quote is not part of the contents.
+         */
+        if (((text[0]) & 0xff) > TEXT_MAX) { // No need to check for <= 255
+            append(TEXT_MAX);
+        }
+
+        arraycopy(text, 0, text.length);
+        append(0);
+    }
+
+    /**
+     * Append text string into mMessage.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    
+    protected void appendTextString(String str) {
+        /*
+         * From WAP-230-WSP-20010705-a:
+         * Text-string = [Quote] *TEXT End-of-string
+         * ; If the first character in the TEXT is in the range of 128-255,
+         * ; a Quote character must precede it. Otherwise the Quote character
+         * ;must be omitted. The Quote is not part of the contents.
+         */
+        appendTextString(str.getBytes());
+    }
+
+    /**
+     * Append encoded string value to mMessage.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    
+    protected void appendEncodedString(EncodedStringValue enStr) {
+        /*
+         * From OMA-TS-MMS-ENC-V1_3-20050927-C:
+         * Encoded-string-value = Text-string | Value-length Char-set Text-string
+         */
+        assert (enStr != null);
+
+        int charset = enStr.getCharacterSet();
+        byte[] textString = enStr.getTextString();
+        if (null == textString) {
+            return;
+        }
+
+        /*
+         * In the implementation of EncodedStringValue, the charset field will
+         * never be 0. It will always be composed as
+         * Encoded-string-value = Value-length Char-set Text-string
+         */
+        mStack.newbuf();
+        PositionMarker start = mStack.mark();
+
+        appendShortInteger(charset);
+        appendTextString(textString);
+
+        int len = start.getLength();
+        mStack.pop();
+        appendValueLength(len);
+        mStack.copy();
+    }
+
+    /**
+     * Append uintvar integer into mMessage.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    
+    protected void appendUintvarInteger(long value) {
+        /*
+         * From WAP-230-WSP-20010705-a:
+         * To encode a large unsigned integer, split it into 7-bit fragments
+         * and place them in the payloads of multiple octets. The most significant
+         * bits are placed in the first octets with the least significant bits
+         * ending up in the last octet. All octets MUST set the Continue bit to 1
+         * except the last octet, which MUST set the Continue bit to 0.
+         */
+        int i;
+        long max = SHORT_INTEGER_MAX;
+
+        for (i = 0; i < 5; i++) {
+            if (value < max) {
+                break;
+            }
+
+            max = (max << 7) | 0x7fl;
+        }
+
+        while (i > 0) {
+            long temp = value >>> (i * 7);
+            temp = temp & 0x7f;
+
+            append((int) ((temp | 0x80) & 0xff));
+
+            i--;
+        }
+
+        append((int) (value & 0x7f));
+    }
+
+    /**
+     * Append date value into mMessage.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    protected void appendDateValue(long date) {
+        /*
+         * From OMA-TS-MMS-ENC-V1_3-20050927-C:
+         * Date-value = Long-integer
+         */
+        appendLongInteger(date);
+    }
+
+    /**
+     * Append value length to mMessage.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    
+    protected void appendValueLength(long value) {
+        /*
+         * From WAP-230-WSP-20010705-a:
+         * Value-length = Short-length | (Length-quote Length)
+         * ; Value length is used to indicate the length of the value to follow
+         * Short-length = <Any octet 0-30>
+         * Length-quote = <Octet 31>
+         * Length = Uintvar-integer
+         */
+        if (value < LENGTH_QUOTE) {
+            appendShortLength((int) value);
+            return;
+        }
+
+        append(LENGTH_QUOTE);
+        appendUintvarInteger(value);
+    }
+
+    /**
+     * Append quoted string to mMessage.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    
+    protected void appendQuotedString(byte[] text) {
+        /*
+         * From WAP-230-WSP-20010705-a:
+         * Quoted-string = <Octet 34> *TEXT End-of-string
+         * ;The TEXT encodes an RFC2616 Quoted-string with the enclosing
+         * ;quotation-marks <"> removed.
+         */
+        append(QUOTED_STRING_FLAG);
+        arraycopy(text, 0, text.length);
+        append(END_STRING_FLAG);
+    }
+
+    /**
+     * Append quoted string to mMessage.
+     * This implementation doesn't check the validity of parameter, since it
+     * assumes that the values are validated in the GenericPdu setter methods.
+     */
+    
+    protected void appendQuotedString(String str) {
+        /*
+         * From WAP-230-WSP-20010705-a:
+         * Quoted-string = <Octet 34> *TEXT End-of-string
+         * ;The TEXT encodes an RFC2616 Quoted-string with the enclosing
+         * ;quotation-marks <"> removed.
+         */
+        appendQuotedString(str.getBytes());
+    }
+
+    private EncodedStringValue appendAddressType(EncodedStringValue address) {
+        EncodedStringValue temp = null;
+
+        try {
+            int addressType = checkAddressType(address.getString());
+            temp = EncodedStringValue.copy(address);
+            if (PDU_PHONE_NUMBER_ADDRESS_TYPE == addressType) {
+                // Phone number.
+                temp.appendTextString(STRING_PHONE_NUMBER_ADDRESS_TYPE.getBytes());
+            } else if (PDU_IPV4_ADDRESS_TYPE == addressType) {
+                // Ipv4 address.
+                temp.appendTextString(STRING_IPV4_ADDRESS_TYPE.getBytes());
+            } else if (PDU_IPV6_ADDRESS_TYPE == addressType) {
+                // Ipv6 address.
+                temp.appendTextString(STRING_IPV6_ADDRESS_TYPE.getBytes());
+            }
+        } catch (NullPointerException e) {
+            return null;
+        }
+
+        return temp;
+    }
+
+    /**
+     * Append header to mMessage.
+     */
+    
+    private int appendHeader(int field) {
+        switch (field) {
+            case PduHeaders.MMS_VERSION:
+                appendOctet(field);
+
+                int version = mPduHeader.getOctet(field);
+                if (0 == version) {
+                    appendShortInteger(PduHeaders.CURRENT_MMS_VERSION);
+                } else {
+                    appendShortInteger(version);
+                }
+
+                break;
+
+            case PduHeaders.MESSAGE_ID:
+            case PduHeaders.TRANSACTION_ID:
+                byte[] textString = mPduHeader.getTextString(field);
+                if (null == textString) {
+                    return PDU_COMPOSE_FIELD_NOT_SET;
+                }
+
+                appendOctet(field);
+                appendTextString(textString);
+                break;
+
+            case PduHeaders.TO:
+            case PduHeaders.BCC:
+            case PduHeaders.CC:
+                EncodedStringValue[] addr = mPduHeader.getEncodedStringValues(field);
+
+                if (null == addr) {
+                    return PDU_COMPOSE_FIELD_NOT_SET;
+                }
+
+                EncodedStringValue temp;
+                for (int i = 0; i < addr.length; i++) {
+                    temp = appendAddressType(addr[i]);
+                    if (temp == null) {
+                        return PDU_COMPOSE_CONTENT_ERROR;
+                    }
+
+                    appendOctet(field);
+                    appendEncodedString(temp);
+                }
+                break;
+
+            case PduHeaders.FROM:
+                // Value-length (Address-present-token Encoded-string-value | Insert-address-token)
+                appendOctet(field);
+
+                EncodedStringValue from = mPduHeader.getEncodedStringValue(field);
+                if ((from == null)
+                        || TextUtils.isEmpty(from.getString())
+                        || new String(from.getTextString()).equals(
+                        PduHeaders.FROM_INSERT_ADDRESS_TOKEN_STR)) {
+                    // Length of from = 1
+                    append(1);
+                    // Insert-address-token = <Octet 129>
+                    append(PduHeaders.FROM_INSERT_ADDRESS_TOKEN);
+                } else {
+                    mStack.newbuf();
+                    PositionMarker fstart = mStack.mark();
+
+                    // Address-present-token = <Octet 128>
+                    append(PduHeaders.FROM_ADDRESS_PRESENT_TOKEN);
+
+                    temp = appendAddressType(from);
+                    if (temp == null) {
+                        return PDU_COMPOSE_CONTENT_ERROR;
+                    }
+
+                    appendEncodedString(temp);
+
+                    int flen = fstart.getLength();
+                    mStack.pop();
+                    appendValueLength(flen);
+                    mStack.copy();
+                }
+                break;
+
+            case PduHeaders.READ_STATUS:
+            case PduHeaders.STATUS:
+            case PduHeaders.REPORT_ALLOWED:
+            case PduHeaders.PRIORITY:
+            case PduHeaders.DELIVERY_REPORT:
+            case PduHeaders.READ_REPORT:
+            case PduHeaders.RETRIEVE_STATUS:
+                int octet = mPduHeader.getOctet(field);
+                if (0 == octet) {
+                    return PDU_COMPOSE_FIELD_NOT_SET;
+                }
+
+                appendOctet(field);
+                appendOctet(octet);
+                break;
+
+            case PduHeaders.DATE:
+                long date = mPduHeader.getLongInteger(field);
+                if (-1 == date) {
+                    return PDU_COMPOSE_FIELD_NOT_SET;
+                }
+
+                appendOctet(field);
+                appendDateValue(date);
+                break;
+
+            case PduHeaders.SUBJECT:
+            case PduHeaders.RETRIEVE_TEXT:
+                EncodedStringValue enString =
+                        mPduHeader.getEncodedStringValue(field);
+                if (null == enString) {
+                    return PDU_COMPOSE_FIELD_NOT_SET;
+                }
+
+                appendOctet(field);
+                appendEncodedString(enString);
+                break;
+
+            case PduHeaders.MESSAGE_CLASS:
+                byte[] messageClass = mPduHeader.getTextString(field);
+                if (null == messageClass) {
+                    return PDU_COMPOSE_FIELD_NOT_SET;
+                }
+
+                appendOctet(field);
+                if (Arrays.equals(messageClass,
+                        PduHeaders.MESSAGE_CLASS_ADVERTISEMENT_STR.getBytes())) {
+                    appendOctet(PduHeaders.MESSAGE_CLASS_ADVERTISEMENT);
+                } else if (Arrays.equals(messageClass,
+                        PduHeaders.MESSAGE_CLASS_AUTO_STR.getBytes())) {
+                    appendOctet(PduHeaders.MESSAGE_CLASS_AUTO);
+                } else if (Arrays.equals(messageClass,
+                        PduHeaders.MESSAGE_CLASS_PERSONAL_STR.getBytes())) {
+                    appendOctet(PduHeaders.MESSAGE_CLASS_PERSONAL);
+                } else if (Arrays.equals(messageClass,
+                        PduHeaders.MESSAGE_CLASS_INFORMATIONAL_STR.getBytes())) {
+                    appendOctet(PduHeaders.MESSAGE_CLASS_INFORMATIONAL);
+                } else {
+                    appendTextString(messageClass);
+                }
+                break;
+
+            case PduHeaders.EXPIRY:
+                long expiry = mPduHeader.getLongInteger(field);
+                if (-1 == expiry) {
+                    return PDU_COMPOSE_FIELD_NOT_SET;
+                }
+
+                appendOctet(field);
+
+                mStack.newbuf();
+                PositionMarker expiryStart = mStack.mark();
+
+                append(PduHeaders.VALUE_RELATIVE_TOKEN);
+                appendLongInteger(expiry);
+
+                int expiryLength = expiryStart.getLength();
+                mStack.pop();
+                appendValueLength(expiryLength);
+                mStack.copy();
+                break;
+
+            default:
+                return PDU_COMPOSE_FIELD_NOT_SUPPORTED;
+        }
+
+        return PDU_COMPOSE_SUCCESS;
+    }
+
+    /**
+     * Make ReadRec.Ind.
+     */
+    private int makeReadRecInd() {
+        if (mMessage == null) {
+            mMessage = new ByteArrayOutputStream();
+            mPosition = 0;
+        }
+
+        // X-Mms-Message-Type
+        appendOctet(PduHeaders.MESSAGE_TYPE);
+        appendOctet(PduHeaders.MESSAGE_TYPE_READ_REC_IND);
+
+        // X-Mms-MMS-Version
+        if (appendHeader(PduHeaders.MMS_VERSION) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        // Message-ID
+        if (appendHeader(PduHeaders.MESSAGE_ID) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        // To
+        if (appendHeader(PduHeaders.TO) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        // From
+        if (appendHeader(PduHeaders.FROM) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        // Date Optional
+        appendHeader(PduHeaders.DATE);
+
+        // X-Mms-Read-Status
+        if (appendHeader(PduHeaders.READ_STATUS) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        // X-Mms-Applic-ID Optional(not support)
+        // X-Mms-Reply-Applic-ID Optional(not support)
+        // X-Mms-Aux-Applic-Info Optional(not support)
+
+        return PDU_COMPOSE_SUCCESS;
+    }
+
+    /**
+     * Make NotifyResp.Ind.
+     */
+    private int makeNotifyResp() {
+        if (mMessage == null) {
+            mMessage = new ByteArrayOutputStream();
+            mPosition = 0;
+        }
+
+        //    X-Mms-Message-Type
+        appendOctet(PduHeaders.MESSAGE_TYPE);
+        appendOctet(PduHeaders.MESSAGE_TYPE_NOTIFYRESP_IND);
+
+        // X-Mms-Transaction-ID
+        if (appendHeader(PduHeaders.TRANSACTION_ID) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        // X-Mms-MMS-Version
+        if (appendHeader(PduHeaders.MMS_VERSION) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        //  X-Mms-Status
+        if (appendHeader(PduHeaders.STATUS) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        // X-Mms-Report-Allowed Optional
+        appendHeader(PduHeaders.REPORT_ALLOWED);
+
+        return PDU_COMPOSE_SUCCESS;
+    }
+
+    /**
+     * Make Acknowledge.Ind.
+     */
+    private int makeAckInd() {
+        if (mMessage == null) {
+            mMessage = new ByteArrayOutputStream();
+            mPosition = 0;
+        }
+
+        //    X-Mms-Message-Type
+        appendOctet(PduHeaders.MESSAGE_TYPE);
+        appendOctet(PduHeaders.MESSAGE_TYPE_ACKNOWLEDGE_IND);
+
+        // X-Mms-Transaction-ID
+        if (appendHeader(PduHeaders.TRANSACTION_ID) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        //     X-Mms-MMS-Version
+        if (appendHeader(PduHeaders.MMS_VERSION) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        // X-Mms-Report-Allowed Optional
+        appendHeader(PduHeaders.REPORT_ALLOWED);
+
+        return PDU_COMPOSE_SUCCESS;
+    }
+
+    /**
+     * Make Send.req.
+     */
+    private int makeSendRetrievePdu(int type) {
+        if (mMessage == null) {
+            mMessage = new ByteArrayOutputStream();
+            mPosition = 0;
+        }
+
+        // X-Mms-Message-Type
+        appendOctet(PduHeaders.MESSAGE_TYPE);
+        appendOctet(type);
+
+        // X-Mms-Transaction-ID
+        appendOctet(PduHeaders.TRANSACTION_ID);
+
+        byte[] trid = mPduHeader.getTextString(PduHeaders.TRANSACTION_ID);
+        if (trid == null) {
+            // Transaction-ID should be set(by Transaction) before make().
+            throw new IllegalArgumentException("Transaction-ID is null.");
+        }
+        appendTextString(trid);
+
+        //  X-Mms-MMS-Version
+        if (appendHeader(PduHeaders.MMS_VERSION) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        // Date Date-value Optional.
+        appendHeader(PduHeaders.DATE);
+
+        // From
+        if (appendHeader(PduHeaders.FROM) != PDU_COMPOSE_SUCCESS) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        boolean recipient = false;
+
+        // To
+        if (appendHeader(PduHeaders.TO) != PDU_COMPOSE_CONTENT_ERROR) {
+            recipient = true;
+        }
+
+        // Cc
+        if (appendHeader(PduHeaders.CC) != PDU_COMPOSE_CONTENT_ERROR) {
+            recipient = true;
+        }
+
+        // Bcc
+        if (appendHeader(PduHeaders.BCC) != PDU_COMPOSE_CONTENT_ERROR) {
+            recipient = true;
+        }
+
+        // Need at least one of "cc", "bcc" and "to".
+        if (false == recipient) {
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        // Subject Optional
+        appendHeader(PduHeaders.SUBJECT);
+
+        // X-Mms-Message-Class Optional
+        // Message-class-value = Class-identifier | Token-text
+        appendHeader(PduHeaders.MESSAGE_CLASS);
+
+        // X-Mms-Expiry Optional
+        appendHeader(PduHeaders.EXPIRY);
+
+        // X-Mms-Priority Optional
+        appendHeader(PduHeaders.PRIORITY);
+
+        // X-Mms-Delivery-Report Optional
+        appendHeader(PduHeaders.DELIVERY_REPORT);
+
+        // X-Mms-Read-Report Optional
+        appendHeader(PduHeaders.READ_REPORT);
+
+        if (type == PduHeaders.MESSAGE_TYPE_RETRIEVE_CONF) {
+            // X-Mms-Retrieve-Status Optional
+            appendHeader(PduHeaders.RETRIEVE_STATUS);
+            // X-Mms-Retrieve-Text Optional
+            appendHeader(PduHeaders.RETRIEVE_TEXT);
+        }
+
+
+        //    Content-Type
+        appendOctet(PduHeaders.CONTENT_TYPE);
+
+        //  Message body
+        return makeMessageBody(type);
+    }
+
+    /**
+     * Make message body.
+     */
+    private int makeMessageBody(int type) {
+        // 1. add body informations
+        mStack.newbuf();  // Switching buffer because we need to
+
+        PositionMarker ctStart = mStack.mark();
+
+        // This contentTypeIdentifier should be used for type of attachment...
+        String contentType = new String(mPduHeader.getTextString(PduHeaders.CONTENT_TYPE));
+        Integer contentTypeIdentifier = mContentTypeMap.get(contentType);
+        if (contentTypeIdentifier == null) {
+            // content type is mandatory
+            return PDU_COMPOSE_CONTENT_ERROR;
+        }
+
+        appendShortInteger(contentTypeIdentifier.intValue());
+
+        // content-type parameter: start
+        PduBody body;
+        if (type == PduHeaders.MESSAGE_TYPE_RETRIEVE_CONF) {
+            body = ((RetrieveConf) mPdu).getBody();
+        } else {
+            body = ((SendReq) mPdu).getBody();
+        }
+        if (null == body || body.getPartsNum() == 0) {
+            // empty message
+            appendUintvarInteger(0);
+            mStack.pop();
+            mStack.copy();
+            return PDU_COMPOSE_SUCCESS;
+        }
+
+        PduPart part;
+        try {
+            part = body.getPart(0);
+
+            byte[] start = part.getContentId();
+            if (start != null) {
+                appendOctet(PduPart.P_DEP_START);
+                if (('<' == start[0]) && ('>' == start[start.length - 1])) {
+                    appendTextString(start);
+                } else {
+                    appendTextString("<" + new String(start) + ">");
+                }
+            }
+
+            // content-type parameter: type
+            appendOctet(PduPart.P_CT_MR_TYPE);
+            appendTextString(part.getContentType());
+        } catch (ArrayIndexOutOfBoundsException e) {
+            e.printStackTrace();
+        }
+
+        int ctLength = ctStart.getLength();
+        mStack.pop();
+        appendValueLength(ctLength);
+        mStack.copy();
+
+        // 3. add content
+        int partNum = body.getPartsNum();
+        appendUintvarInteger(partNum);
+        for (int i = 0; i < partNum; i++) {
+            part = body.getPart(i);
+            mStack.newbuf();  // Leaving space for header lengh and data length
+            PositionMarker attachment = mStack.mark();
+
+            mStack.newbuf();  // Leaving space for Content-Type length
+            PositionMarker contentTypeBegin = mStack.mark();
+
+            byte[] partContentType = part.getContentType();
+
+            if (partContentType == null) {
+                // content type is mandatory
+                return PDU_COMPOSE_CONTENT_ERROR;
+            }
+
+            // content-type value
+            Integer partContentTypeIdentifier =
+                    mContentTypeMap.get(new String(partContentType));
+            if (partContentTypeIdentifier == null) {
+                appendTextString(partContentType);
+            } else {
+                appendShortInteger(partContentTypeIdentifier.intValue());
+            }
+
+            /* Content-type parameter : name.
+             * The value of name, filename, content-location is the same.
+             * Just one of them is enough for this PDU.
+             */
+            byte[] name = part.getName();
+
+            if (null == name) {
+                name = part.getFilename();
+
+                if (null == name) {
+                    name = part.getContentLocation();
+
+                    if (null == name) {
+                        /* at lease one of name, filename, Content-location
+                         * should be available.
+                         */
+                        return PDU_COMPOSE_CONTENT_ERROR;
+                    }
+                }
+            }
+            appendOctet(PduPart.P_DEP_NAME);
+            appendTextString(name);
+
+            // content-type parameter : charset
+            int charset = part.getCharset();
+            if (charset != 0) {
+                appendOctet(PduPart.P_CHARSET);
+                appendShortInteger(charset);
+            }
+
+            int contentTypeLength = contentTypeBegin.getLength();
+            mStack.pop();
+            appendValueLength(contentTypeLength);
+            mStack.copy();
+
+            // content id
+            byte[] contentId = part.getContentId();
+
+            if (null != contentId) {
+                appendOctet(PduPart.P_CONTENT_ID);
+                if (('<' == contentId[0]) && ('>' == contentId[contentId.length - 1])) {
+                    appendQuotedString(contentId);
+                } else {
+                    appendQuotedString("<" + new String(contentId) + ">");
+                }
+            }
+
+            // content-location
+            byte[] contentLocation = part.getContentLocation();
+            if (null != contentLocation) {
+                appendOctet(PduPart.P_CONTENT_LOCATION);
+                appendTextString(contentLocation);
+            }
+
+            // content
+            int headerLength = attachment.getLength();
+
+            int dataLength = 0; // Just for safety...
+            byte[] partData = part.getData();
+
+            if (partData != null) {
+                arraycopy(partData, 0, partData.length);
+                dataLength = partData.length;
+            } else {
+                InputStream cr = null;
+                try {
+                    byte[] buffer = new byte[PDU_COMPOSER_BLOCK_SIZE];
+                    cr = mResolver.openInputStream(part.getDataUri());
+                    int len = 0;
+                    while ((len = cr.read(buffer)) != -1) {
+                        mMessage.write(buffer, 0, len);
+                        mPosition += len;
+                        dataLength += len;
+                    }
+                } catch (FileNotFoundException e) {
+                    return PDU_COMPOSE_CONTENT_ERROR;
+                } catch (IOException e) {
+                    return PDU_COMPOSE_CONTENT_ERROR;
+                } catch (RuntimeException e) {
+                    return PDU_COMPOSE_CONTENT_ERROR;
+                } finally {
+                    if (cr != null) {
+                        try {
+                            cr.close();
+                        } catch (IOException e) {
+                        }
+                    }
+                }
+            }
+
+            if (dataLength != (attachment.getLength() - headerLength)) {
+                throw new RuntimeException("BUG: Length correctness check failed");
+            }
+
+            mStack.pop();
+            appendUintvarInteger(headerLength);
+            appendUintvarInteger(dataLength);
+            mStack.copy();
+        }
+
+        return PDU_COMPOSE_SUCCESS;
+    }
+
+    /**
+     * Record current message informations.
+     */
+    static private class LengthRecordNode {
+        public int currentPosition = 0;
+        public LengthRecordNode next = null;
+        ByteArrayOutputStream currentMessage = null;
+    }
+
+    /**
+     * Mark current message position and stact size.
+     */
+    private class PositionMarker {
+        private int c_pos;   // Current position
+        private int currentStackSize;  // Current stack size
+
+        
+        int getLength() {
+            // If these assert fails, likely that you are finding the
+            // size of buffer that is deep in BufferStack you can only
+            // find the length of the buffer that is on top
+            if (currentStackSize != mStack.stackSize) {
+                throw new RuntimeException("BUG: Invalid call to getLength()");
+            }
+
+            return mPosition - c_pos;
+        }
+    }
+
+    /**
+     * This implementation can be OPTIMIZED to use only
+     * 2 buffers. This optimization involves changing BufferStack
+     * only... Its usage (interface) will not change.
+     */
+    private class BufferStack {
+        int stackSize = 0;
+        private LengthRecordNode stack = null;
+        private LengthRecordNode toCopy = null;
+
+        /**
+         * Create a new message buffer and push it into the stack.
+         */
+        
+        void newbuf() {
+            // You can't create a new buff when toCopy != null
+            // That is after calling pop() and before calling copy()
+            // If you do, it is a bug
+            if (toCopy != null) {
+                throw new RuntimeException("BUG: Invalid newbuf() before copy()");
+            }
+
+            LengthRecordNode temp = new LengthRecordNode();
+
+            temp.currentMessage = mMessage;
+            temp.currentPosition = mPosition;
+
+            temp.next = stack;
+            stack = temp;
+
+            stackSize = stackSize + 1;
+
+            mMessage = new ByteArrayOutputStream();
+            mPosition = 0;
+        }
+
+        /**
+         * Pop the message before and record current message in the stack.
+         */
+        
+        void pop() {
+            ByteArrayOutputStream currentMessage = mMessage;
+            int currentPosition = mPosition;
+
+            mMessage = stack.currentMessage;
+            mPosition = stack.currentPosition;
+
+            toCopy = stack;
+            // Re using the top element of the stack to avoid memory allocation
+
+            stack = stack.next;
+            stackSize = stackSize - 1;
+
+            toCopy.currentMessage = currentMessage;
+            toCopy.currentPosition = currentPosition;
+        }
+
+        /**
+         * Append current message to the message before.
+         */
+        
+        void copy() {
+            arraycopy(toCopy.currentMessage.toByteArray(), 0,
+                    toCopy.currentPosition);
+
+            toCopy = null;
+        }
+
+        /**
+         * Mark current message position
+         */
+        
+        PositionMarker mark() {
+            PositionMarker m = new PositionMarker();
+
+            m.c_pos = mPosition;
+            m.currentStackSize = stackSize;
+
+            return m;
+        }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/RetrieveConf.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/RetrieveConf.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2007 Esmertec AG.
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+/**
+ * M-Retrieve.conf Pdu.
+ */
+public class RetrieveConf extends MultimediaMessagePdu {
+    /**
+     * Empty constructor.
+     * Since the Pdu corresponding to this class is constructed
+     * by the Proxy-Relay server, this class is only instantiated
+     * by the Pdu Parser.
+     *
+     * @throws InvalidHeaderValueException if error occurs.
+     */
+        public RetrieveConf() throws InvalidHeaderValueException {
+        super();
+        setMessageType(PduHeaders.MESSAGE_TYPE_RETRIEVE_CONF);
+    }
+
+    /**
+     * Constructor with given headers.
+     *
+     * @param headers Headers for this PDU.
+     */
+    RetrieveConf(PduHeaders headers) {
+        super(headers);
+    }
+
+    /**
+     * Constructor with given headers and body
+     *
+     * @param headers Headers for this PDU.
+     * @param body    Body of this PDu.
+     */
+        RetrieveConf(PduHeaders headers, PduBody body) {
+        super(headers, body);
+    }
+
+    /**
+     * Get CC value.
+     *
+     * @return the value
+     */
+        public EncodedStringValue[] getCc() {
+        return mPduHeaders.getEncodedStringValues(PduHeaders.CC);
+    }
+
+    /**
+     * Add a "CC" value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+        public void addCc(EncodedStringValue value) {
+        mPduHeaders.appendEncodedStringValue(value, PduHeaders.CC);
+    }
+
+    /**
+     * Get Content-type value.
+     *
+     * @return the value
+     */
+        public byte[] getContentType() {
+        return mPduHeaders.getTextString(PduHeaders.CONTENT_TYPE);
+    }
+
+    /**
+     * Set Content-type value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+        public void setContentType(byte[] value) {
+        mPduHeaders.setTextString(value, PduHeaders.CONTENT_TYPE);
+    }
+
+    /**
+     * Get X-Mms-Delivery-Report value.
+     *
+     * @return the value
+     */
+        public int getDeliveryReport() {
+        return mPduHeaders.getOctet(PduHeaders.DELIVERY_REPORT);
+    }
+
+    /**
+     * Set X-Mms-Delivery-Report value.
+     *
+     * @param value the value
+     * @throws InvalidHeaderValueException if the value is invalid.
+     */
+        public void setDeliveryReport(int value) throws InvalidHeaderValueException {
+        mPduHeaders.setOctet(value, PduHeaders.DELIVERY_REPORT);
+    }
+
+    /**
+     * Get From value.
+     * From-value = Value-length
+     * (Address-present-token Encoded-string-value | Insert-address-token)
+     *
+     * @return the value
+     */
+        public EncodedStringValue getFrom() {
+        return mPduHeaders.getEncodedStringValue(PduHeaders.FROM);
+    }
+
+    /**
+     * Set From value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+        public void setFrom(EncodedStringValue value) {
+        mPduHeaders.setEncodedStringValue(value, PduHeaders.FROM);
+    }
+
+    /**
+     * Get X-Mms-Message-Class value.
+     * Message-class-value = Class-identifier | Token-text
+     * Class-identifier = Personal | Advertisement | Informational | Auto
+     *
+     * @return the value
+     */
+        public byte[] getMessageClass() {
+        return mPduHeaders.getTextString(PduHeaders.MESSAGE_CLASS);
+    }
+
+    /**
+     * Set X-Mms-Message-Class value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+        public void setMessageClass(byte[] value) {
+        mPduHeaders.setTextString(value, PduHeaders.MESSAGE_CLASS);
+    }
+
+    /**
+     * Get Message-ID value.
+     *
+     * @return the value
+     */
+        public byte[] getMessageId() {
+        return mPduHeaders.getTextString(PduHeaders.MESSAGE_ID);
+    }
+
+    /**
+     * Set Message-ID value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+        public void setMessageId(byte[] value) {
+        mPduHeaders.setTextString(value, PduHeaders.MESSAGE_ID);
+    }
+
+    /**
+     * Get X-Mms-Read-Report value.
+     *
+     * @return the value
+     */
+        public int getReadReport() {
+        return mPduHeaders.getOctet(PduHeaders.READ_REPORT);
+    }
+
+    /**
+     * Set X-Mms-Read-Report value.
+     *
+     * @param value the value
+     * @throws InvalidHeaderValueException if the value is invalid.
+     */
+        public void setReadReport(int value) throws InvalidHeaderValueException {
+        mPduHeaders.setOctet(value, PduHeaders.READ_REPORT);
+    }
+
+    /**
+     * Get X-Mms-Retrieve-Status value.
+     *
+     * @return the value
+     */
+        public int getRetrieveStatus() {
+        return mPduHeaders.getOctet(PduHeaders.RETRIEVE_STATUS);
+    }
+
+    /**
+     * Set X-Mms-Retrieve-Status value.
+     *
+     * @param value the value
+     * @throws InvalidHeaderValueException if the value is invalid.
+     */
+        public void setRetrieveStatus(int value) throws InvalidHeaderValueException {
+        mPduHeaders.setOctet(value, PduHeaders.RETRIEVE_STATUS);
+    }
+
+    /**
+     * Get X-Mms-Retrieve-Text value.
+     *
+     * @return the value
+     */
+        public EncodedStringValue getRetrieveText() {
+        return mPduHeaders.getEncodedStringValue(PduHeaders.RETRIEVE_TEXT);
+    }
+
+    /**
+     * Set X-Mms-Retrieve-Text value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+        public void setRetrieveText(EncodedStringValue value) {
+        mPduHeaders.setEncodedStringValue(value, PduHeaders.RETRIEVE_TEXT);
+    }
+
+    /**
+     * Get X-Mms-Transaction-Id.
+     *
+     * @return the value
+     */
+        public byte[] getTransactionId() {
+        return mPduHeaders.getTextString(PduHeaders.TRANSACTION_ID);
+    }
+
+    /**
+     * Set X-Mms-Transaction-Id.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+        public void setTransactionId(byte[] value) {
+        mPduHeaders.setTextString(value, PduHeaders.TRANSACTION_ID);
+    }
+
+    /*
+     * Optional, not supported header fields:
+     *
+     *     public byte[] getApplicId() {return null;}
+     *     public void setApplicId(byte[] value) {}
+     *
+     *     public byte[] getAuxApplicId() {return null;}
+     *     public void getAuxApplicId(byte[] value) {}
+     *
+     *     public byte getContentClass() {return 0x00;}
+     *     public void setApplicId(byte value) {}
+     *
+     *     public byte getDrmContent() {return 0x00;}
+     *     public void setDrmContent(byte value) {}
+     *
+     *     public byte getDistributionIndicator() {return 0x00;}
+     *     public void setDistributionIndicator(byte value) {}
+     *
+     *     public PreviouslySentByValue getPreviouslySentBy() {return null;}
+     *     public void setPreviouslySentBy(PreviouslySentByValue value) {}
+     *
+     *     public PreviouslySentDateValue getPreviouslySentDate() {}
+     *     public void setPreviouslySentDate(PreviouslySentDateValue value) {}
+     *
+     *     public MmFlagsValue getMmFlags() {return null;}
+     *     public void setMmFlags(MmFlagsValue value) {}
+     *
+     *     public MmStateValue getMmState() {return null;}
+     *     public void getMmState(MmStateValue value) {}
+     *
+     *     public byte[] getReplaceId() {return 0x00;}
+     *     public void setReplaceId(byte[] value) {}
+     *
+     *     public byte[] getReplyApplicId() {return 0x00;}
+     *     public void setReplyApplicId(byte[] value) {}
+     *
+     *     public byte getReplyCharging() {return 0x00;}
+     *     public void setReplyCharging(byte value) {}
+     *
+     *     public byte getReplyChargingDeadline() {return 0x00;}
+     *     public void setReplyChargingDeadline(byte value) {}
+     *
+     *     public byte[] getReplyChargingId() {return 0x00;}
+     *     public void setReplyChargingId(byte[] value) {}
+     *
+     *     public long getReplyChargingSize() {return 0;}
+     *     public void setReplyChargingSize(long value) {}
+     */
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/SendReq.java
+++ b/app/src/main/java/me/capcom/smsgateway/modules/mms/pdu/aosp/SendReq.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright (C) 2007-2008 Esmertec AG.
+ * Copyright (C) 2007-2008 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.capcom.smsgateway.modules.mms.pdu.aosp;
+
+import android.util.Log;
+
+public class SendReq extends MultimediaMessagePdu {
+    private static final String TAG = "SendReq";
+
+    public SendReq() {
+        super();
+
+        try {
+            setMessageType(PduHeaders.MESSAGE_TYPE_SEND_REQ);
+            setMmsVersion(PduHeaders.CURRENT_MMS_VERSION);
+            // FIXME: Content-type must be decided according to whether
+            // SMIL part present.
+            setContentType("application/vnd.wap.multipart.related".getBytes());
+            setFrom(new EncodedStringValue(PduHeaders.FROM_INSERT_ADDRESS_TOKEN_STR.getBytes()));
+            setTransactionId(generateTransactionId());
+        } catch (InvalidHeaderValueException e) {
+            // Impossible to reach here since all headers we set above are valid.
+            Log.e(TAG, "Unexpected InvalidHeaderValueException.", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Constructor, used when composing a M-Send.req pdu.
+     *
+     * @param contentType   the content type value
+     * @param from          the from value
+     * @param mmsVersion    current viersion of mms
+     * @param transactionId the transaction-id value
+     * @throws InvalidHeaderValueException if parameters are invalid.
+     *                                     NullPointerException if contentType, form or transactionId is null.
+     */
+    public SendReq(byte[] contentType,
+                   EncodedStringValue from,
+                   int mmsVersion,
+                   byte[] transactionId) throws InvalidHeaderValueException {
+        super();
+        setMessageType(PduHeaders.MESSAGE_TYPE_SEND_REQ);
+        setContentType(contentType);
+        setFrom(from);
+        setMmsVersion(mmsVersion);
+        setTransactionId(transactionId);
+    }
+
+    /**
+     * Constructor with given headers.
+     *
+     * @param headers Headers for this PDU.
+     */
+    SendReq(PduHeaders headers) {
+        super(headers);
+    }
+
+    /**
+     * Constructor with given headers and body
+     *
+     * @param headers Headers for this PDU.
+     * @param body    Body of this PDu.
+     */
+
+    SendReq(PduHeaders headers, PduBody body) {
+        super(headers, body);
+    }
+
+    private byte[] generateTransactionId() {
+        String transactionId = "T" + Long.toHexString(System.currentTimeMillis());
+        return transactionId.getBytes();
+    }
+
+    /**
+     * Get Bcc value.
+     *
+     * @return the value
+     */
+
+    public EncodedStringValue[] getBcc() {
+        return mPduHeaders.getEncodedStringValues(PduHeaders.BCC);
+    }
+
+    /**
+     * Set "BCC" value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+
+    public void setBcc(EncodedStringValue[] value) {
+        mPduHeaders.setEncodedStringValues(value, PduHeaders.BCC);
+    }
+
+    /**
+     * Add a "BCC" value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+
+    public void addBcc(EncodedStringValue value) {
+        mPduHeaders.appendEncodedStringValue(value, PduHeaders.BCC);
+    }
+
+    /**
+     * Get CC value.
+     *
+     * @return the value
+     */
+
+    public EncodedStringValue[] getCc() {
+        return mPduHeaders.getEncodedStringValues(PduHeaders.CC);
+    }
+
+    /**
+     * Set "CC" value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+    public void setCc(EncodedStringValue[] value) {
+        mPduHeaders.setEncodedStringValues(value, PduHeaders.CC);
+    }
+
+    /**
+     * Add a "CC" value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+
+    public void addCc(EncodedStringValue value) {
+        mPduHeaders.appendEncodedStringValue(value, PduHeaders.CC);
+    }
+
+    /**
+     * Get Content-type value.
+     *
+     * @return the value
+     */
+    public byte[] getContentType() {
+        return mPduHeaders.getTextString(PduHeaders.CONTENT_TYPE);
+    }
+
+    /**
+     * Set Content-type value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+
+    public void setContentType(byte[] value) {
+        mPduHeaders.setTextString(value, PduHeaders.CONTENT_TYPE);
+    }
+
+    /**
+     * Get X-Mms-Delivery-Report value.
+     *
+     * @return the value
+     */
+
+    public int getDeliveryReport() {
+        return mPduHeaders.getOctet(PduHeaders.DELIVERY_REPORT);
+    }
+
+    /**
+     * Set X-Mms-Delivery-Report value.
+     *
+     * @param value the value
+     * @throws InvalidHeaderValueException if the value is invalid.
+     */
+
+    public void setDeliveryReport(int value) throws InvalidHeaderValueException {
+        mPduHeaders.setOctet(value, PduHeaders.DELIVERY_REPORT);
+    }
+
+    /**
+     * Get X-Mms-Expiry value.
+     * <p>
+     * Expiry-value = Value-length
+     * (Absolute-token Date-value | Relative-token Delta-seconds-value)
+     *
+     * @return the value
+     */
+
+    public long getExpiry() {
+        return mPduHeaders.getLongInteger(PduHeaders.EXPIRY);
+    }
+
+    /**
+     * Set X-Mms-Expiry value.
+     *
+     * @param value the value
+     */
+
+    public void setExpiry(long value) {
+        mPduHeaders.setLongInteger(value, PduHeaders.EXPIRY);
+    }
+
+    /**
+     * Get X-Mms-MessageSize value.
+     * <p>
+     * Expiry-value = size of message
+     *
+     * @return the value
+     */
+
+    public long getMessageSize() {
+        return mPduHeaders.getLongInteger(PduHeaders.MESSAGE_SIZE);
+    }
+
+    /**
+     * Set X-Mms-MessageSize value.
+     *
+     * @param value the value
+     */
+
+    public void setMessageSize(long value) {
+        mPduHeaders.setLongInteger(value, PduHeaders.MESSAGE_SIZE);
+    }
+
+    /**
+     * Get X-Mms-Message-Class value.
+     * Message-class-value = Class-identifier | Token-text
+     * Class-identifier = Personal | Advertisement | Informational | Auto
+     *
+     * @return the value
+     */
+
+    public byte[] getMessageClass() {
+        return mPduHeaders.getTextString(PduHeaders.MESSAGE_CLASS);
+    }
+
+    /**
+     * Set X-Mms-Message-Class value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+
+    public void setMessageClass(byte[] value) {
+        mPduHeaders.setTextString(value, PduHeaders.MESSAGE_CLASS);
+    }
+
+    /**
+     * Get X-Mms-Read-Report value.
+     *
+     * @return the value
+     */
+
+    public int getReadReport() {
+        return mPduHeaders.getOctet(PduHeaders.READ_REPORT);
+    }
+
+    /**
+     * Set X-Mms-Read-Report value.
+     *
+     * @param value the value
+     * @throws InvalidHeaderValueException if the value is invalid.
+     */
+
+    public void setReadReport(int value) throws InvalidHeaderValueException {
+        mPduHeaders.setOctet(value, PduHeaders.READ_REPORT);
+    }
+
+    /**
+     * Set "To" value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+
+    public void setTo(EncodedStringValue[] value) {
+        mPduHeaders.setEncodedStringValues(value, PduHeaders.TO);
+    }
+
+    /**
+     * Get X-Mms-Transaction-Id field value.
+     *
+     * @return the X-Mms-Report-Allowed value
+     */
+
+    public byte[] getTransactionId() {
+        return mPduHeaders.getTextString(PduHeaders.TRANSACTION_ID);
+    }
+
+    /**
+     * Set X-Mms-Transaction-Id field value.
+     *
+     * @param value the value
+     * @throws NullPointerException if the value is null.
+     */
+
+    public void setTransactionId(byte[] value) {
+        mPduHeaders.setTextString(value, PduHeaders.TRANSACTION_ID);
+    }
+
+    /*
+     * Optional, not supported header fields:
+     *
+     *     public byte getAdaptationAllowed() {return 0};
+     *     public void setAdaptationAllowed(btye value) {};
+     *
+     *     public byte[] getApplicId() {return null;}
+     *     public void setApplicId(byte[] value) {}
+     *
+     *     public byte[] getAuxApplicId() {return null;}
+     *     public void getAuxApplicId(byte[] value) {}
+     *
+     *     public byte getContentClass() {return 0x00;}
+     *     public void setApplicId(byte value) {}
+     *
+     *     public long getDeliveryTime() {return 0};
+     *     public void setDeliveryTime(long value) {};
+     *
+     *     public byte getDrmContent() {return 0x00;}
+     *     public void setDrmContent(byte value) {}
+     *
+     *     public MmFlagsValue getMmFlags() {return null;}
+     *     public void setMmFlags(MmFlagsValue value) {}
+     *
+     *     public MmStateValue getMmState() {return null;}
+     *     public void getMmState(MmStateValue value) {}
+     *
+     *     public byte[] getReplyApplicId() {return 0x00;}
+     *     public void setReplyApplicId(byte[] value) {}
+     *
+     *     public byte getReplyCharging() {return 0x00;}
+     *     public void setReplyCharging(byte value) {}
+     *
+     *     public byte getReplyChargingDeadline() {return 0x00;}
+     *     public void setReplyChargingDeadline(byte value) {}
+     *
+     *     public byte[] getReplyChargingId() {return 0x00;}
+     *     public void setReplyChargingId(byte[] value) {}
+     *
+     *     public long getReplyChargingSize() {return 0;}
+     *     public void setReplyChargingSize(long value) {}
+     *
+     *     public byte[] getReplyApplicId() {return 0x00;}
+     *     public void setReplyApplicId(byte[] value) {}
+     *
+     *     public byte getStore() {return 0x00;}
+     *     public void setStore(byte value) {}
+     */
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
@@ -36,12 +36,26 @@ class MessagesReceiver : BroadcastReceiver(), KoinComponent {
                 SubscriptionsHelper.extractSubscriptionId(context, intent)
             )
 
-            true -> InboxMessage.Data(
-                firstMessage.userData,
-                firstMessage.displayOriginatingAddress,
-                Date(firstMessage.timestampMillis),
-                SubscriptionsHelper.extractSubscriptionId(context, intent)
-            )
+            true -> {
+                val userData = messages
+                    .mapNotNull { it.userData }
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { parts ->
+                        ByteArray(parts.sumOf { it.size }).also { output ->
+                            var offset = 0
+                            for (part in parts) {
+                                part.copyInto(output, destinationOffset = offset)
+                                offset += part.size
+                            }
+                        }
+                    }
+                InboxMessage.Data(
+                    userData,
+                    firstMessage.displayOriginatingAddress,
+                    Date(firstMessage.timestampMillis),
+                    SubscriptionsHelper.extractSubscriptionId(context, intent)
+                )
+            }
         }
 
         receiverSvc.process(

--- a/app/src/main/java/me/capcom/smsgateway/receivers/EventsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/receivers/EventsReceiver.kt
@@ -48,7 +48,11 @@ class EventsReceiver : BroadcastReceiver(), KoinComponent {
 
         const val ACTION_SENT = "me.capcom.smsgateway.ACTION_SENT"
         const val ACTION_DELIVERED = "me.capcom.smsgateway.ACTION_DELIVERED"
+        const val ACTION_MMS_SENT = "me.capcom.smsgateway.ACTION_MMS_SENT"
 
+        const val EXTRA_MESSAGE_ID = "messageId"
+        const val EXTRA_PDU_PATH = "pduPath"
+        
         private fun getInstance(): EventsReceiver {
             return INSTANCE ?: EventsReceiver().also { INSTANCE = it }
         }
@@ -56,8 +60,10 @@ class EventsReceiver : BroadcastReceiver(), KoinComponent {
         fun register(context: Context) {
             context.registerReceiver(
                 getInstance(),
-                IntentFilter(ACTION_SENT)
-                    .apply { addAction(ACTION_DELIVERED) }
+                IntentFilter(ACTION_SENT).apply {
+                    addAction(ACTION_DELIVERED)
+                    addAction(ACTION_MMS_SENT)
+                }
             )
         }
     }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<paths>
-    <files-path
-        name="mms_out"
-        path="mms-out/" />
-    <cache-path
-        name="mms_cache"
-        path="mms-cache/" />
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="mms_out" path="mms-out/" />
+    <files-path name="mms_in" path="mms-in/" />
 </paths>

--- a/app/src/test/java/me/capcom/smsgateway/data/ConvertersTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/data/ConvertersTest.kt
@@ -1,0 +1,68 @@
+package me.capcom.smsgateway.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
+
+class ConvertersTest {
+    private val converters = Converters()
+
+    @Test
+    fun dateFromString_canonical_roundTrips() {
+        val str = "2026-08-28T12:00:00.000Z"
+        val parsed = converters.dateFromString(str)
+        assertEquals(str, converters.dateToString(parsed))
+    }
+
+    @Test
+    fun dateToString_thenFromString_preservesTime() {
+        val original = Date(1_768_000_000_000L)
+        val str = converters.dateToString(original)
+        assertEquals(original.time, converters.dateFromString(str)?.time)
+    }
+
+    @Test
+    fun dateFromString_noMillis_doesNotThrow() {
+        // Legacy value produced by MIGRATION_7_8 via strftime('%FT%TZ', ...) (no .SSS).
+        val value = "2026-08-28T12:00:00"
+        val parsed = converters.dateFromString(value)
+        // Parsed as GMT; 12:00:00 UTC of that date.
+        val expected = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").apply {
+            timeZone = TimeZone.getTimeZone("GMT")
+        }.parse(value)
+        assertEquals(expected?.time, parsed?.time)
+    }
+
+    @Test
+    fun dateFromString_noMillisWithZ_doesNotThrow() {
+        val value = "2026-08-28T12:00:00Z"
+        val parsed = converters.dateFromString(value)
+        val expected = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").apply {
+            timeZone = TimeZone.getTimeZone("GMT")
+        }.parse("2026-08-28T12:00:00")
+        assertEquals(expected?.time, parsed?.time)
+    }
+
+    @Test
+    fun dateFromString_spaceSeparator_doesNotThrow() {
+        val value = "2026-08-28 12:00:00"
+        val parsed = converters.dateFromString(value)
+        val expected = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").apply {
+            timeZone = TimeZone.getTimeZone("GMT")
+        }.parse(value)
+        assertEquals(expected?.time, parsed?.time)
+    }
+
+    @Test
+    fun dateFromString_null_returnsNull() {
+        assertNull(converters.dateFromString(null))
+    }
+
+    @Test
+    fun dateFromString_unparseable_returnsNull() {
+        assertNull(converters.dateFromString("not-a-date"))
+    }
+}

--- a/docs/MMS.md
+++ b/docs/MMS.md
@@ -1,0 +1,374 @@
+# MMS support
+
+The gateway can **send** and **receive** multimedia messages (MMS) carrying
+images, audio, video, and arbitrary binary attachments, in addition to SMS
+and Data SMS.
+
+This document covers:
+- Enabling MMS on the device
+- The `POST /message` shape for sending MMS
+- Webhook events for received MMS
+- Fetching attachments from a received MMS
+- Limits, gotchas, and carrier notes
+
+## Contents
+
+- [MMS support](#mms-support)
+  - [Contents](#contents)
+  - [Requirements](#requirements)
+  - [Setup](#setup)
+    - [Grant the default SMS app role](#grant-the-default-sms-app-role)
+  - [Sending MMS](#sending-mms)
+    - [API](#api)
+    - [Attachment sources](#attachment-sources)
+    - [Example: send an image](#example-send-an-image)
+  - [Receiving MMS](#receiving-mms)
+    - [Flow](#flow)
+    - [Webhook: `mms:received`](#webhook-mmsreceived)
+    - [Webhook: `mms:downloaded`](#webhook-mmsdownloaded)
+    - [Fetching attachment bytes](#fetching-attachment-bytes)
+  - [Inbox API](#inbox-api)
+  - [Cloud mode](#cloud-mode)
+  - [Limits and carrier behavior](#limits-and-carrier-behavior)
+  - [Troubleshooting](#troubleshooting)
+
+## Requirements
+
+- Android 5.0 (API 21) or newer. Android 10+ is recommended.
+- A SIM with an MMS-capable plan and a working MMS APN.
+- `SEND_SMS`, `READ_PHONE_STATE`, `RECEIVE_MMS`, `RECEIVE_WAP_PUSH` permissions
+  granted. These are the same permissions the app already needs for SMS.
+- To actively download inbound MMS, the app must be the **default SMS app**
+  (see below).
+
+## Setup
+
+### Grant the default SMS app role
+
+Sending MMS from a non-default app is allowed by the platform but many US
+carriers (Verizon notably) silently drop those messages. The gateway should
+be the default SMS app on any device that is expected to send or receive
+real MMS traffic.
+
+From inside the app:
+
+1. Open the **Settings** tab.
+2. Tap **Default SMS app**.
+3. Accept the Android prompt to change the default.
+
+The same preference shows whether the role is currently held. To hand the
+role back to another app (Google Messages, Verizon Messages, etc.) use
+Android's own Default apps screen.
+
+Under the hood the app now declares the manifest receivers, activity, and
+service required to qualify for the `android.app.role.SMS` role, so the
+system can grant it without further configuration.
+
+## Sending MMS
+
+### API
+
+The existing `POST /message` endpoint gains a new mutually-exclusive
+content field, `mmsMessage`. Exactly one of `textMessage`, `dataMessage`,
+`mmsMessage`, or the deprecated `message` string must be present.
+
+```json
+{
+  "phoneNumbers": ["+15551234567"],
+  "mmsMessage": {
+    "subject": "Optional subject line",
+    "text": "Optional text body shown alongside attachments",
+    "attachments": [
+      {
+        "contentType": "image/jpeg",
+        "name": "photo.jpg",
+        "data": "<base64-encoded bytes>"
+      }
+    ]
+  },
+  "simNumber": 1,
+  "withDeliveryReport": true,
+  "priority": 100
+}
+```
+
+Field reference:
+
+| Field                       | Type           | Required    | Notes                                                                    |
+| --------------------------- | -------------- | ----------- | ------------------------------------------------------------------------ |
+| `phoneNumbers`              | `string[]`     | yes         | Recipient MSISDNs. E.164 format strongly recommended.                    |
+| `mmsMessage.subject`        | `string`       | no          | Optional MMS subject.                                                    |
+| `mmsMessage.text`           | `string`       | no          | Optional text/plain body part. Can coexist with attachments.             |
+| `mmsMessage.attachments[]`  | `Attachment[]` | conditional | At least one of `text` or `attachments` must be present.                 |
+| `attachments[].contentType` | `string`       | yes         | e.g. `image/jpeg`, `image/png`, `audio/amr`, `video/mp4`.                |
+| `attachments[].name`        | `string`       | no          | Suggested filename, forwarded as Content-Location + Content-Type `name`. |
+| `attachments[].data`        | `string`       | yes         | Base64-encoded bytes.                                                    |
+
+Other top-level message fields (`simNumber`, `withDeliveryReport`,
+`priority`, `ttl`/`validUntil`, `isEncrypted`, `id`) behave the same way
+they do for SMS.
+
+Response is the same `Accepted` shape as SMS, with the request echoed back
+including the stored `mmsMessage` content:
+
+```json
+{
+  "id": "PyDmBQZZXYmyxMwED8Fzy",
+  "deviceId": "...",
+  "state": "Pending",
+  "isEncrypted": false,
+  "mmsMessage": { "...": "..." },
+  "recipients": [
+    { "phoneNumber": "+15551234567", "state": "Pending", "error": null }
+  ],
+  "states": {}
+}
+```
+
+### Attachment sources
+
+Attachments are provided inline as `data` (base64-encoded bytes):
+
+- `data`: inline base64 bytes. For very large payloads, consider hosting the
+  media elsewhere and sending it as a single-part text message containing a
+  link, or keep the payload under a few hundred KB.
+
+### Example: send an image
+
+```sh
+B64=$(base64 -w0 < photo.jpg)
+curl -u "<user>:<pass>" -H 'Content-Type: application/json' \
+  -d "{
+    \"phoneNumbers\":[\"+15551234567\"],
+    \"mmsMessage\":{
+      \"text\":\"Say hi\",
+      \"attachments\":[{
+        \"contentType\":\"image/jpeg\",
+        \"name\":\"photo.jpg\",
+        \"data\":\"$B64\"
+      }]
+    }
+  }" \
+  http://<device_ip>:8080/message
+```
+
+## Receiving MMS
+
+### Flow
+
+1. The carrier delivers a WAP-push notification over SMS. The app
+   parses it and emits the `mms:received` webhook (metadata only — the
+   message body is not yet downloaded).
+2. If the app is the default SMS app, it calls
+   `SmsManager.downloadMultimediaMessage()` to fetch the full PDU from the
+   carrier's MMSC over the dedicated MMS APN.
+3. Once the PDU is downloaded and parsed, the gateway:
+   - Saves each non-SMIL attachment to private storage under
+     `<appData>/files/mms-in/<messageId>/<partId>-<name>`.
+   - Inserts an `incoming_messages` row (type `MMS_DOWNLOADED`).
+   - Emits the `mms:downloaded` webhook carrying part metadata, inline
+     base64 bytes, and a relative URL to fetch the same bytes from the
+     gateway.
+
+If the app is *not* the default SMS app, step 2 is handled by whichever
+app is default; once that app writes the message into `content://mms`,
+the gateway's content observer picks it up and step 3 runs as usual.
+
+### Webhook: `mms:received`
+
+Fired on the incoming WAP-push notification, before the content has been
+downloaded.
+
+```json
+{
+  "event": "mms:received",
+  "payload": {
+    "messageId": "hex-derived-id",
+    "sender": "+15550009999",
+    "recipient": "+15551234567",
+    "simNumber": 1,
+    "transactionId": "T0123abcd",
+    "subject": "Photos",
+    "size": 43210,
+    "contentClass": "IMAGE_BASIC",
+    "receivedAt": "2026-04-20T17:31:00.000+00:00"
+  }
+}
+```
+
+### Webhook: `mms:downloaded`
+
+Fired once the content has been retrieved and stored. Attachments are
+included inline as base64 (`data`) **and** as a URL path on the gateway's
+local HTTP server (`url`) — consumers may use either.
+
+```json
+{
+  "event": "mms:downloaded",
+  "payload": {
+    "messageId": "hex-derived-id",
+    "sender": "+15550009999",
+    "recipient": "+15551234567",
+    "simNumber": 1,
+    "subject": "Photos",
+    "body": "Hi! Here's the photo.",
+    "attachments": [
+      {
+        "partId": 3,
+        "contentType": "image/jpeg",
+        "name": "photo.jpg",
+        "size": 38421,
+        "data": "<base64>",
+        "url": "/inbox/hex-derived-id/attachments/3"
+      }
+    ],
+    "receivedAt": "2026-04-20T17:31:14.000+00:00"
+  }
+}
+```
+
+### Fetching attachment bytes
+
+To avoid base64-inflated webhook payloads you can fetch attachments on
+demand. Authenticate with the same credentials used for the rest of the
+API.
+
+```sh
+curl -u "<user>:<pass>" \
+  http://<device_ip>:8080/inbox/<messageId>/attachments/<partId> \
+  -o photo.jpg
+```
+
+`Content-Type` reflects the attachment's MIME type; `Content-Disposition`
+carries the original filename when one was present.
+
+Required auth scope: `inbox:read`.
+
+## Inbox API
+
+`GET /inbox` — list received messages with optional attachment metadata.
+
+Query parameters:
+
+| Parameter            | Type      | Default | Description                                                      |
+|----------------------|-----------|---------|------------------------------------------------------------------|
+| `type`               | `string`  | —       | Filter by message type (`SMS`, `MMS`, `MMS_DOWNLOADED`, etc.).   |
+| `limit`              | `integer` | `50`    | Max results (1–500).                                             |
+| `offset`             | `integer` | `0`     | Result offset for pagination.                                    |
+| `from`               | `string`  | epoch   | ISO-8601 start of date range.                                    |
+| `to`                 | `string`  | now     | ISO-8601 end of date range.                                      |
+| `deviceId`           | `string`  | —       | Must match the device's own ID if provided.                      |
+| `includeAttachments` | `boolean` | `false` | When `true`, includes per-message attachment metadata (partId, name, size, contentType). |
+
+By default attachment metadata is omitted to avoid unnecessary I/O on large
+result sets. Attachments are always available individually via the
+dedicated endpoint below.
+
+Default response (attachments excluded):
+
+```json
+[
+  {
+    "id": "hex-derived-id",
+    "type": "MMS_DOWNLOADED",
+    "sender": "+15550009999",
+    "recipient": "+15551234567",
+    "simNumber": 1,
+    "contentPreview": "Hi! Here's the photo.",
+    "createdAt": "2026-04-20T17:31:14.000+00:00",
+    "attachments": []
+  }
+]
+```
+
+Pass `?includeAttachments=true` to include attachment metadata:
+
+```json
+[
+  {
+    "id": "hex-derived-id",
+    "type": "MMS_DOWNLOADED",
+    "sender": "+15550009999",
+    "recipient": "+15551234567",
+    "simNumber": 1,
+    "contentPreview": "Hi! Here's the photo.",
+    "createdAt": "2026-04-20T17:31:14.000+00:00",
+    "attachments": [
+      {
+        "partId": 3,
+        "name": "photo.jpg",
+        "size": 38421,
+        "contentType": "image/jpeg"
+      }
+    ]
+  }
+]
+```
+
+- `GET /inbox/{messageId}/attachments/{partId}` — raw attachment bytes.
+
+All endpoints are available in both Local and Cloud modes.
+
+## Cloud mode
+
+The cloud pull protocol (`GET /message`) accepts the same `mmsMessage`
+object inside a `Message` payload. When the device pulls a cloud-queued
+MMS, it composes the PDU locally and sends it via the same code path used
+for local-server requests. State transitions (Processed / Sent / Failed)
+are reported back to the cloud identically to SMS.
+
+## Limits and carrier behavior
+
+- **PDU format.** The gateway composes PDUs with AOSP's reference
+  `PduComposer` (ported from klinker-apps's `pdu_alt`, Apache-2.0), so
+  the output matches Google Messages' format and is accepted by every
+  MMSC we've tested.
+- **Body type.** `multipart/related` is used automatically; Content-Type
+  parameters `type` and `start` reference the first text part so recipient
+  clients render text + attachments correctly even without SMIL.
+- **Size.** Carriers impose per-message PDU limits, typically 300 KB to
+  1.2 MB. Verizon accepts up to ~1.2 MB in practice; T-Mobile and AT&T
+  are similar. Large attachments (video) should be downscaled before
+  sending.
+- **From.** The gateway uses the WSP `insert-address-token` so the MMSC
+  fills in the sender's MSISDN — the approach AOSP and Google Messages
+  both use. If your carrier rejects insert-address-token, pass an
+  explicit From via `SubscriptionsHelper.getPhoneNumber()` and the sender
+  will fall back to that MSISDN.
+- **Self-send.** Some carriers (Verizon included) silently drop MMS
+  addressed to the sender's own MSISDN. Use a second number for
+  round-trip testing.
+- **Recipient parser.** Once a recipient's messaging app rejects a
+  malformed PDU, some MMSCs enter a backoff window (5–60 min) before
+  re-pushing. If you're iterating on PDU issues, test against multiple
+  recipient numbers/carriers to avoid getting stuck on one backoff.
+
+## Troubleshooting
+
+- **Send reports `Sent` but recipient never gets the message.** The MMSC
+  accepted our HTTP POST (that's what `Sent` means) but may have dropped
+  the message later. Confirm the app is the default SMS app, the
+  recipient isn't the sender's own number, and the recipient hasn't
+  blocked the sender.
+- **`MMS_ERROR_IO_ERROR` on send.** The MMS APN was not available or the
+  MMSC returned a non-200. Check mobile data is up and that the active
+  APN has type `mms`. The carrier's own SMS app will surface APN
+  misconfiguration errors that our app cannot — use it as a sanity
+  check first.
+- **`MMS_ERROR_INVALID_APN` / `MMS_ERROR_NO_DATA_NETWORK`.** No
+  MMS-typed APN configured. Add one through Android's Mobile network →
+  Access point names settings, or install the carrier's config profile.
+- **Inbound MMS shows as `mms:received` but never transitions to
+  `mms:downloaded`.** The app likely isn't the default SMS app, or the
+  device dropped the MMS APN while downloading. Check the app's log
+  screen for `MMS download failed` entries.
+- **Inspecting the outgoing PDU for debugging.** With USB debugging
+  enabled:
+  ```sh
+  adb shell run-as me.capcom.smsgateway ls files/mms-out
+  adb shell run-as me.capcom.smsgateway cat files/mms-out/<id>.pdu > out.pdu
+  xxd out.pdu | head
+  ```
+  PDU files are deleted automatically after the `mms:sent` state fires;
+  to retain them across sends, flip the cleanup flag in
+  `MessagesService.processStateIntent`.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds outgoing MMS support across local and cloud request models, durable message content, Android telephony sending, result callbacks, API documentation, and message-history responses.
- Adds MMS composition and sending through Android’s multimedia messaging API.
- Extends gateway and local-server contracts with MMS content and attachments.
- Integrates MMS results into the existing recipient-state and event pipeline.
- Documents MMS request formats and operational requirements.

<h3>Confidence Score: 0/5</h3>

The PR is not safe to merge while MMS terminal states can regress, cancellation can contradict completed sends, and the published attachment contract remains unsupported.

The current MMS flow still allows the asynchronous send result and subsequent broad state transition to overwrite or emit states out of order; cancellation can concurrently replace a completed result or cancel a parent without cancelling any recipient; and clients following the advertised URL-attachment mode cannot construct an accepted request.

**Files Needing Attention:** app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt, app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt, app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/MmsMessage.kt, README.md

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt | Adds MMS queue dispatch, SIM resolution, result handling, attachment decryption, and state propagation. |
| app/src/main/java/me/capcom/smsgateway/modules/mms/MmsSender.kt | Composes MMS PDUs, stages them through a FileProvider, invokes Android telephony, and cleans temporary files. |
| app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/MmsMessage.kt | Defines and validates the local HTTP MMS payload and inline attachment representation. |
| app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayApi.kt | Extends the cloud gateway message contract with MMS content and attachment data. |
| app/src/main/assets/api/swagger.json | Documents MMS request and response content in the embedded OpenAPI schema. |
| app/src/main/java/me/capcom/smsgateway/data/Converters.kt | Makes persisted date parsing tolerant of canonical and legacy timestamp formats. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Local/Cloud API
    participant Queue as Message Queue
    participant Sender as MMS Sender
    participant Android
    participant State as State/Event Pipeline
    Client->>API: Submit MMS request
    API->>Queue: Persist message and recipients
    Queue->>Sender: Send eligible MMS
    Sender->>Android: sendMultimediaMessage
    Android-->>State: ACTION_MMS_SENT
    State->>State: Update recipients and publish result
```
</details>

<sub>Reviews (17): Last reviewed commit: ["\[data\] support legacy date formats"](https://github.com/capcom6/android-sms-gateway/commit/da80bc0f64c117a6bd70ae0644a575c4ad00b6b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51441660)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Message processing](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/message-processing.md)
- Knowledge Base — [Outbound message delivery](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/outbound-message-delivery.md)
- Knowledge Base — [Local HTTP API](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/local-http-api.md)
</details>


<!-- /greptile_comment -->