### PR TITLE
[localserver] add messages sort param

### DIFF
--- a/app/src/main/assets/api/swagger.json
+++ b/app/src/main/assets/api/swagger.json
@@ -2618,6 +2618,19 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "description": "Sort order per JSON:API spec. Use created_at (ascending) or -created_at (descending)",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "default": "-created_at",
+              "enum": [
+                "created_at",
+                "-created_at"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
@@ -76,7 +76,21 @@ interface MessagesDao {
      */
     @Transaction
     @Query("SELECT *, `rowid` FROM message WHERE source = :source AND (:state IS NULL OR state = :state) AND createdAt BETWEEN :start AND :end ORDER BY createdAt DESC LIMIT :limit OFFSET :offset")
-    fun select(
+    fun selectDescending(
+        source: EntitySource,
+        state: ProcessingState?,
+        start: Long,
+        end: Long,
+        limit: Int,
+        offset: Int
+    ): List<MessageWithRecipients>
+
+    /**
+     * Get messages with pagination, filtering and ascending sort
+     */
+    @Transaction
+    @Query("SELECT *, `rowid` FROM message WHERE source = :source AND (:state IS NULL OR state = :state) AND createdAt BETWEEN :start AND :end ORDER BY createdAt ASC, id ASC LIMIT :limit OFFSET :offset")
+    fun selectAscending(
         source: EntitySource,
         state: ProcessingState?,
         start: Long,
@@ -151,7 +165,7 @@ interface MessagesDao {
     fun cancelMessage(id: String) {
         val updated = _cancelMessage(id)
         if (updated == 0) return
-        
+
         _insertMessageState(
             MessageState(id, ProcessingState.Cancelled, System.currentTimeMillis())
         )

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/MessageSort.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/MessageSort.kt
@@ -1,0 +1,28 @@
+package me.capcom.smsgateway.modules.localserver.domain.messages
+
+/**
+ * Sort order for GET /messages, mirroring the Go server contract.
+ */
+enum class MessageSort {
+    CreatedAtAsc,
+    CreatedAtDesc;
+
+    fun toDomain(): me.capcom.smsgateway.modules.messages.data.MessageSort = when (this) {
+        CreatedAtAsc -> me.capcom.smsgateway.modules.messages.data.MessageSort.CreatedAtAsc
+        CreatedAtDesc -> me.capcom.smsgateway.modules.messages.data.MessageSort.CreatedAtDesc
+    }
+
+    companion object {
+        /**
+         * Parse the `sort` query parameter value.
+         * null/absent -> CreatedAtDesc; "created_at" -> CreatedAtAsc;
+         * "-created_at" -> CreatedAtDesc; anything else -> IllegalArgumentException.
+         */
+        fun parse(raw: String?): MessageSort = when (raw) {
+            null -> CreatedAtDesc
+            "created_at" -> CreatedAtAsc
+            "-created_at" -> CreatedAtDesc
+            else -> throw IllegalArgumentException("sort must be one of: created_at, -created_at")
+        }
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
@@ -24,6 +24,7 @@ import me.capcom.smsgateway.modules.localserver.auth.AuthScopes
 import me.capcom.smsgateway.modules.localserver.auth.requireScope
 import me.capcom.smsgateway.modules.localserver.domain.InboxRefreshRequest
 import me.capcom.smsgateway.modules.localserver.domain.messages.DataMessage
+import me.capcom.smsgateway.modules.localserver.domain.messages.MessageSort
 import me.capcom.smsgateway.modules.localserver.domain.messages.PostMessageRequest
 import me.capcom.smsgateway.modules.localserver.domain.messages.TextMessage
 import me.capcom.smsgateway.modules.messages.MessagesService
@@ -66,6 +67,7 @@ class MessagesRoutes(
                     return@get
                 }
             } ?: false
+            val sort = MessageSort.parse(call.request.queryParameters["sort"])
 
             // Parse date range parameters
             val from = call.request.queryParameters["from"]?.let {
@@ -106,7 +108,15 @@ class MessagesRoutes(
 
             // Get messages with pagination
             val messages = try {
-                messagesService.selectMessages(EntitySource.Local, state, from, to, limit, offset)
+                messagesService.selectMessages(
+                    EntitySource.Local,
+                    state,
+                    from,
+                    to,
+                    limit,
+                    offset,
+                    sort.toDomain()
+                )
             } catch (e: Throwable) {
                 call.respond(
                     HttpStatusCode.InternalServerError,

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -32,6 +32,7 @@ import me.capcom.smsgateway.modules.health.domain.CheckResult
 import me.capcom.smsgateway.modules.health.domain.Status
 import me.capcom.smsgateway.modules.logs.LogsService
 import me.capcom.smsgateway.modules.logs.db.LogEntry
+import me.capcom.smsgateway.modules.messages.data.MessageSort
 import me.capcom.smsgateway.modules.messages.data.SendParams
 import me.capcom.smsgateway.modules.messages.data.SendRequest
 import me.capcom.smsgateway.modules.messages.data.StoredSendRequest
@@ -191,8 +192,12 @@ class MessagesService(
         start: Long,
         end: Long,
         limit: Int,
-        offset: Int
-    ) = dao.select(source, state, start, end, limit, offset)
+        offset: Int,
+        sort: MessageSort = MessageSort.CreatedAtDesc
+    ) = when (sort) {
+        MessageSort.CreatedAtDesc -> dao.selectDescending(source, state, start, end, limit, offset)
+        MessageSort.CreatedAtAsc -> dao.selectAscending(source, state, start, end, limit, offset)
+    }
     //#endregion
 
     suspend fun processStateIntent(intent: Intent, resultCode: Int) {

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/data/MessageSort.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/data/MessageSort.kt
@@ -1,0 +1,6 @@
+package me.capcom.smsgateway.modules.messages.data
+
+enum class MessageSort {
+    CreatedAtAsc,
+    CreatedAtDesc
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/localserver/domain/messages/MessageSortTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/localserver/domain/messages/MessageSortTest.kt
@@ -1,0 +1,45 @@
+package me.capcom.smsgateway.modules.localserver.domain.messages
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+class MessageSortTest {
+
+    @Test
+    fun parseValidValues() {
+        val tests = mapOf(
+            null to MessageSort.CreatedAtDesc,
+            "created_at" to MessageSort.CreatedAtAsc,
+            "-created_at" to MessageSort.CreatedAtDesc,
+        )
+
+        tests.forEach { (raw, expected) ->
+            assertEquals("parse($raw)", expected, MessageSort.parse(raw))
+        }
+    }
+
+    @Test
+    fun parseInvalidValues() {
+        val invalidValues = listOf(
+            "",
+            "createdAt",      // PascalCase
+            "asc",            // not a wire value
+            "order",          // different param concept (lifo/fifo)
+            "CREATED_AT",     // uppercase
+            "-created_at ",   // trailing space
+        )
+
+        invalidValues.forEach { raw ->
+            try {
+                MessageSort.parse(raw)
+                fail("Expected IllegalArgumentException for sort=$raw")
+            } catch (e: IllegalArgumentException) {
+                assertEquals(
+                    "sort must be one of: created_at, -created_at",
+                    e.message
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/messages/MessagesServiceTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/messages/MessagesServiceTest.kt
@@ -1,0 +1,262 @@
+package me.capcom.smsgateway.modules.messages
+
+import androidx.lifecycle.LiveData
+import me.capcom.smsgateway.data.dao.MessagesDao
+import me.capcom.smsgateway.data.entities.Message
+import me.capcom.smsgateway.data.entities.MessageRecipient
+import me.capcom.smsgateway.data.entities.MessageState
+import me.capcom.smsgateway.data.entities.MessageWithRecipients
+import me.capcom.smsgateway.data.entities.MessagesStats
+import me.capcom.smsgateway.data.entities.MessagesTotals
+import me.capcom.smsgateway.data.entities.RecipientState
+import me.capcom.smsgateway.domain.EntitySource
+import me.capcom.smsgateway.domain.ProcessingState
+import me.capcom.smsgateway.modules.messages.data.MessageSort
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.lang.reflect.Field
+import java.util.Date
+
+class MessagesServiceTest {
+
+    /**
+     * Hand-written fake (no mocking library). Records select/selectAscending
+     * calls; every other DAO method is out of scope for the dispatch test.
+     */
+    class RecordingMessagesDao : MessagesDao {
+        data class SelectArgs(
+            val source: EntitySource,
+            val state: ProcessingState?,
+            val start: Long,
+            val end: Long,
+            val limit: Int,
+            val offset: Int,
+        )
+
+        val selectCalls = mutableListOf<SelectArgs>()
+        val selectAscendingCalls = mutableListOf<SelectArgs>()
+
+        override fun selectDescending(
+            source: EntitySource,
+            state: ProcessingState?,
+            start: Long,
+            end: Long,
+            limit: Int,
+            offset: Int,
+        ): List<MessageWithRecipients> {
+            selectCalls.add(SelectArgs(source, state, start, end, limit, offset))
+            return emptyList()
+        }
+
+        override fun selectAscending(
+            source: EntitySource,
+            state: ProcessingState?,
+            start: Long,
+            end: Long,
+            limit: Int,
+            offset: Int,
+        ): List<MessageWithRecipients> {
+            selectAscendingCalls.add(SelectArgs(source, state, start, end, limit, offset))
+            return emptyList()
+        }
+
+        override fun countProcessedFrom(timestamp: Long): MessagesStats =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun countFailedFrom(timestamp: Long): MessagesStats =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun getMessagesStats(): LiveData<MessagesTotals> =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun selectLast(limit: Int): LiveData<List<Message>> =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun getPendingFifo(now: Date): MessageWithRecipients? =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun getPendingLifo(now: Date): MessageWithRecipients? =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun nextScheduledTime(): Long? =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun get(id: String): MessageWithRecipients? =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun count(
+            source: EntitySource,
+            state: ProcessingState?,
+            start: Long,
+            end: Long,
+        ): Int = throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun _insert(message: Message) =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun _insertRecipients(recipient: List<MessageRecipient>) =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun _insertMessageState(state: MessageState) =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun _insertRecipientStates(state: List<RecipientState>) =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun _insertRecipientStatesByMessage(messageId: String, state: ProcessingState) =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun _updateMessageState(id: String, state: ProcessingState) =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun _cancelMessage(id: String): Int =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun _setMessageProcessed(id: String) =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun _updateRecipientState(
+            id: String,
+            phoneNumber: String,
+            state: ProcessingState,
+            error: String?,
+        ) = throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun _updateRecipientsState(
+            id: String,
+            state: ProcessingState,
+            error: String?,
+        ) = throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun updateSimNumber(id: String, simNumber: Int) =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override fun updatePartsCount(id: String, partsCount: Int) =
+            throw UnsupportedOperationException("not used in dispatch test")
+
+        override suspend fun truncateLog(until: Long) =
+            throw UnsupportedOperationException("not used in dispatch test")
+    }
+
+    private fun messagesServiceWith(fake: MessagesDao): MessagesService {
+        // MessagesService's constructor touches Android APIs (countryCode field
+        // reads the TelephonyManager), so it cannot run in a plain JVM test.
+        // Allocate the instance without the constructor and inject the dao
+        // field - the only dependency selectMessages uses. No mocking library.
+        // sun.misc.Unsafe is reached via reflection: the Kotlin unit-test
+        // classpath cannot resolve it at compile time.
+        val unsafeClass = Class.forName("sun.misc.Unsafe")
+        val unsafe = unsafeClass
+            .getDeclaredField("theUnsafe")
+            .also { it.isAccessible = true }
+            .get(null)
+
+        val service = unsafeClass
+            .getMethod("allocateInstance", Class::class.java)
+            .invoke(unsafe, MessagesService::class.java) as MessagesService
+
+        val daoField = MessagesService::class.java.getDeclaredField("dao")
+        val offset = unsafeClass
+            .getMethod("objectFieldOffset", Field::class.java)
+            .invoke(unsafe, daoField)
+        unsafeClass
+            .getMethod("putObject", Any::class.java, java.lang.Long.TYPE, Any::class.java)
+            .invoke(unsafe, service, offset, fake)
+        return service
+    }
+
+    @Test
+    fun selectMessagesCreatedAtDescDelegatesToSelect() {
+        val fake = RecordingMessagesDao()
+        val service = messagesServiceWith(fake)
+
+        val result = service.selectMessages(
+            source = EntitySource.Local,
+            state = ProcessingState.Pending,
+            start = 100L,
+            end = 200L,
+            limit = 50,
+            offset = 10,
+            sort = MessageSort.CreatedAtDesc,
+        )
+
+        assertEquals(1, fake.selectCalls.size)
+        assertEquals(0, fake.selectAscendingCalls.size)
+        assertEquals(
+            RecordingMessagesDao.SelectArgs(
+                EntitySource.Local,
+                ProcessingState.Pending,
+                100L,
+                200L,
+                50,
+                10
+            ),
+            fake.selectCalls[0],
+        )
+        assertEquals(emptyList<MessageWithRecipients>(), result)
+    }
+
+    @Test
+    fun selectMessagesCreatedAtAscDelegatesToSelectAscending() {
+        val fake = RecordingMessagesDao()
+        val service = messagesServiceWith(fake)
+
+        val result = service.selectMessages(
+            source = EntitySource.Cloud,
+            state = ProcessingState.Processed,
+            start = 1000L,
+            end = 2000L,
+            limit = 25,
+            offset = 0,
+            sort = MessageSort.CreatedAtAsc,
+        )
+
+        assertEquals(0, fake.selectCalls.size)
+        assertEquals(1, fake.selectAscendingCalls.size)
+        assertEquals(
+            RecordingMessagesDao.SelectArgs(
+                EntitySource.Cloud,
+                ProcessingState.Processed,
+                1000L,
+                2000L,
+                25,
+                0
+            ),
+            fake.selectAscendingCalls[0],
+        )
+        assertEquals(emptyList<MessageWithRecipients>(), result)
+    }
+
+    @Test
+    fun selectMessagesDefaultSortResolvesToCreatedAtDesc() {
+        // Regression guard: omitting the trailing sort param must behave
+        // exactly like explicit CreatedAtDesc (select, NOT selectAscending).
+        val fake = RecordingMessagesDao()
+        val service = messagesServiceWith(fake)
+
+        val args = RecordingMessagesDao.SelectArgs(EntitySource.Local, null, 111L, 222L, 33, 7)
+
+        service.selectMessages(
+            args.source,
+            args.state,
+            args.start,
+            args.end,
+            args.limit,
+            args.offset
+        )
+        service.selectMessages(
+            args.source,
+            args.state,
+            args.start,
+            args.end,
+            args.limit,
+            args.offset,
+            MessageSort.CreatedAtDesc
+        )
+
+        assertEquals(2, fake.selectCalls.size)
+        assertEquals(0, fake.selectAscendingCalls.size)
+        assertEquals(args, fake.selectCalls[0])
+        assertEquals(args, fake.selectCalls[1])
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds ascending and descending creation-time sorting to the local messages endpoint and updates DAO dispatch, API documentation, and regression tests.
- Adds `created_at` and `-created_at` query values with descending as the default.
- Routes each sort direction to a dedicated Room query.
- Corrects the service test to use the messages-domain sort enum expected by `MessagesService`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the test now uses the exact sort enum accepted by `MessagesService`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/test/java/me/capcom/smsgateway/modules/messages/MessagesServiceTest.kt | The test now imports and passes the messages-domain `MessageSort`, resolving the previously reported incompatible-enum compilation issue. |
| app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt | Adds a defaulted domain sort argument and dispatches ascending and descending requests to their respective DAO methods. |
| app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt | Splits message selection into ascending and descending Room queries while preserving existing filters and pagination. |
| app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt | Parses the new query parameter and converts the local-server enum into the service-domain enum. |
| app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/MessageSort.kt | Defines strict wire-value parsing and explicit conversion to the messages-domain sort enum. |
| app/src/main/assets/api/swagger.json | Documents the supported sort values and descending default for GET /messages. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Route as MessagesRoutes
    participant Service as MessagesService
    participant DAO as MessagesDao
    Client->>Route: "GET /messages?sort=created_at|-created_at"
    Route->>Route: Parse and map sort value
    Route->>Service: selectMessages(..., sort)
    alt CreatedAtAsc
        Service->>DAO: selectAscending(...)
    else CreatedAtDesc or omitted
        Service->>DAO: selectDescending(...)
    end
    DAO-->>Service: Filtered message rows
    Service-->>Route: Messages
    Route-->>Client: Response with X-Total-Count
```
</details>

<sub>Reviews (6): Last reviewed commit: ["\[localserver\] add messages sort param"](https://github.com/capcom6/android-sms-gateway/commit/a63233cdbc4c155af0dd6c0dbb81f50504f49a9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52119290)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Data and persistence](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/data-and-persistence.md)
- Knowledge Base — [Embedded local server API](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/local-server-api.md)
- Knowledge Base — [Outbound messaging](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/outbound-messaging.md)
</details>

<!-- /greptile_comment -->