### PR TITLE
[messages] new API for delivery status parsing

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -258,15 +258,50 @@ class MessagesService(
 
             EventsReceiver.ACTION_DELIVERED -> when (resultCode) {
                 Activity.RESULT_OK -> {
-                    val message = SmsMessage.createFromPdu(
-                        intent.extras?.getByteArray("pdu")
-                    )
-                    when {
-                        message.status.toUInt() < 0b0100000u -> ProcessingState.Delivered to message.status.takeIf { it > 0 }
-                            ?.let { "Delivery result from SC ${message.serviceCenterAddress}: ${message.status}" }
+                    val pdu = intent.extras?.getByteArray("pdu")
+                    val format = intent.getStringExtra("format")
+                    val message = if (format != null
+                        && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                    ) {
+                        SmsMessage.createFromPdu(pdu, format)
+                    } else {
+                        SmsMessage.createFromPdu(pdu)
+                    }
 
-                        message.status.toUInt() < 0b1000000u -> return // SC will make more attempts
-                        else -> ProcessingState.Failed to "Delivery result from SC ${message.serviceCenterAddress}: ${message.status}"
+                    val rawStatus = message.status
+                    val scAddress = message.serviceCenterAddress
+                    val status = if (format == "3gpp2") {
+                        rawStatus
+                    } else {
+                        rawStatus and 0x7F
+                    }
+                    logsService.insert(
+                        LogEntry.Priority.DEBUG,
+                        MODULE_NAME,
+                        "Delivery report parsed",
+                        mapOf(
+                            "format" to (format ?: "default(3gpp)"),
+                            "rawStatus" to rawStatus,
+                            "status" to status,
+                            "scAddress" to scAddress,
+                        )
+                    )
+
+                    when {
+                        format == "3gpp2" -> when (rawStatus ushr 24 and 0x3) {
+                            0 -> ProcessingState.Delivered to (rawStatus ushr 16 and 0xFF).takeIf { it > 0 }
+                                ?.let { "Delivery result from SC $scAddress: $it" }
+
+                            1 -> return // SC will make more attempts
+                            else -> ProcessingState.Failed to
+                                "Delivery result from SC $scAddress: ${rawStatus ushr 16 and 0xFF}"
+                        }
+
+                        status < 0b0100000 -> ProcessingState.Delivered to status.takeIf { it > 0 }
+                            ?.let { "Delivery result from SC $scAddress: $it" }
+
+                        status < 0b1000000 -> return // SC will make more attempts
+                        else -> ProcessingState.Failed to "Delivery result from SC $scAddress: $status"
                     }
                 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates Android SMS delivery-report parsing to distinguish 3GPP and 3GPP2 status layouts.
- Uses the callback format when constructing `SmsMessage`.
- Decodes CDMA error classes and status codes from their high-bit fields.
- Masks the 3GPP status flag before classifying delivery outcomes.
- Adds structured debug logging for parsed delivery reports.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt | Corrects format-specific delivery-report parsing and classification without leaving a blocking issue from the previous review threads. |

</details>

<sub>Reviews (13): Last reviewed commit: ["\[messages\] new API for delivery status p..."](https://github.com/capcom6/android-sms-gateway/commit/bbe91bd822eb14b750a1d5b6fa40548e8641984c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53197632)</sub>

**Context used:**

- Knowledge Base — [Message processing](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/message-processing.md)
- Knowledge Base — [Outbound message delivery](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/outbound-message-delivery.md)

<!-- /greptile_comment -->