### PR TITLE
[messages] extract state transitions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,14 @@ android {
         exclude 'META-INF/io.netty.versions.properties'
     }
     namespace 'me.capcom.smsgateway'
+
+    testOptions {
+        unitTests {
+            // EventBus.emit logs via android.util.Log; local unit tests must not
+            // fail on the mockable android.jar "not mocked" stub.
+            returnDefaultValues = true
+        }
+    }
 }
 
 dependencies {
@@ -129,6 +137,7 @@ dependencies {
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("androidx.arch.core:core-testing:2.1.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version")
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
 }

--- a/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
@@ -151,10 +151,16 @@ interface MessagesDao {
     }
 
     @Query("UPDATE message SET state = :state WHERE id = :id AND state <> 'Failed'")
-    fun _updateMessageState(id: String, state: ProcessingState)
+    suspend fun _updateMessageState(id: String, state: ProcessingState)
 
-    fun updateMessageState(id: String, state: ProcessingState) {
-        _updateMessageState(id, state)
+    @Transaction
+    suspend fun updateMessageState(id: String, state: ProcessingState) {
+        if (state == ProcessingState.Processed) {
+            _setMessageProcessed(id)
+        } else {
+            _updateMessageState(id, state)
+        }
+
         _insertMessageState(
             MessageState(
                 id,
@@ -164,32 +170,8 @@ interface MessagesDao {
         )
     }
 
-    @Query("UPDATE message SET state = 'Cancelled' WHERE id = :id AND state = 'Pending'")
-    fun _cancelMessage(id: String): Int
-
-    @Transaction
-    fun cancelMessage(id: String) {
-        val updated = _cancelMessage(id)
-        if (updated == 0) return
-
-        _insertMessageState(
-            MessageState(id, ProcessingState.Cancelled, System.currentTimeMillis())
-        )
-        updateRecipientsState(id, ProcessingState.Cancelled, null)
-    }
-
-    @Query("UPDATE message SET state = 'Processed', processedAt = strftime('%s', 'now') * 1000 WHERE id = :id")
-    fun _setMessageProcessed(id: String)
-    fun setMessageProcessed(id: String) {
-        _setMessageProcessed(id)
-        _insertMessageState(
-            MessageState(
-                id,
-                ProcessingState.Processed,
-                System.currentTimeMillis()
-            )
-        )
-    }
+    @Query("UPDATE message SET state = 'Processed', processedAt = strftime('%s', 'now') * 1000 WHERE id = :id AND state <> 'Failed'")
+    suspend fun _setMessageProcessed(id: String)
 
     @Query("UPDATE messagerecipient SET state = :state, error = :error WHERE messageId = :id AND phoneNumber = :phoneNumber AND state <> 'Failed'")
     fun _updateRecipientState(
@@ -229,6 +211,18 @@ interface MessagesDao {
     ) {
         _updateRecipientsState(id, state, error)
         _insertRecipientStatesByMessage(id, state)
+    }
+
+    @Transaction
+    suspend fun updateRecipientsAndMessageState(
+        id: String,
+        recipientState: ProcessingState,
+        error: String?,
+        messageState: ProcessingState
+    ) {
+        _updateRecipientsState(id, recipientState, error)
+        _insertRecipientStatesByMessage(id, recipientState)
+        updateMessageState(id, messageState)
     }
 
     @Query("UPDATE message SET simNumber = :simNumber WHERE id = :id")

--- a/app/src/main/java/me/capcom/smsgateway/data/entities/MessageWithRecipients.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/entities/MessageWithRecipients.kt
@@ -21,8 +21,7 @@ data class MessageWithRecipients(
 ) {
     val state: me.capcom.smsgateway.domain.ProcessingState
         get() = when {
-            recipients.any { it.state == me.capcom.smsgateway.domain.ProcessingState.Pending } -> me.capcom.smsgateway.domain.ProcessingState.Pending
-            recipients.any { it.state == me.capcom.smsgateway.domain.ProcessingState.Cancelling } -> me.capcom.smsgateway.domain.ProcessingState.Cancelling
+recipients.any { it.state == me.capcom.smsgateway.domain.ProcessingState.Pending } -> me.capcom.smsgateway.domain.ProcessingState.Pending
             recipients.any { it.state == me.capcom.smsgateway.domain.ProcessingState.Cancelled } -> me.capcom.smsgateway.domain.ProcessingState.Cancelled
             recipients.any { it.state == me.capcom.smsgateway.domain.ProcessingState.Processed } -> me.capcom.smsgateway.domain.ProcessingState.Processed
 

--- a/app/src/main/java/me/capcom/smsgateway/domain/ProcessingState.kt
+++ b/app/src/main/java/me/capcom/smsgateway/domain/ProcessingState.kt
@@ -2,7 +2,6 @@ package me.capcom.smsgateway.domain
 
 enum class ProcessingState {
     Pending,
-    Cancelling,
     Cancelled,
     Processed,
     Sent,

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/EventsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/EventsReceiver.kt
@@ -1,6 +1,7 @@
 package me.capcom.smsgateway.modules.gateway
 
 import android.util.Log
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import me.capcom.smsgateway.domain.EntitySource
@@ -30,85 +31,141 @@ class EventsReceiver : EventsReceiver() {
             launch {
                 Log.d("EventsReceiver", "launched MessageEnqueuedEvent")
                 eventBus.collect<MessageEnqueuedEvent> { event ->
-                    Log.d("EventsReceiver", "Event: $event")
+                    try {
+                        Log.d("EventsReceiver", "Event: $event")
 
-                    if (!settings.enabled) return@collect
+                        if (!settings.enabled) return@collect
 
-                    PullMessagesWorker.start(get())
+                        PullMessagesWorker.start(get())
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // per-collector isolation: an exception here must not cancel
+                        // the coroutineScope and kill sibling collectors
+                        Log.e("EventsReceiver", "MessageEnqueuedEvent collector failed", e)
+                    }
                 }
             }
             launch {
                 Log.d("EventsReceiver", "launched MessageStateChangedEvent")
                 val allowedSources = setOf(EntitySource.Cloud, EntitySource.Gateway)
                 eventBus.collect<MessageStateChangedEvent> { event ->
-                    Log.d("EventsReceiver", "Event: $event")
+                    try {
+                        Log.d("EventsReceiver", "Event: $event")
 
-                    if (!settings.enabled) return@collect
+                        if (!settings.enabled) return@collect
 
-                    if (event.source !in allowedSources) return@collect
+                        if (event.source !in allowedSources) return@collect
 
-                    SendStateWorker.start(get(), event.id)
+                        SendStateWorker.start(get(), event.id)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // per-collector isolation: an exception here must not cancel
+                        // the coroutineScope and kill sibling collectors
+                        Log.e("EventsReceiver", "MessageStateChangedEvent collector failed", e)
+                    }
                 }
             }
 
             launch {
                 Log.d("EventsReceiver", "launched PingEvent")
                 eventBus.collect<PingEvent> {
-                    Log.d("EventsReceiver", "Event: $it")
+                    try {
+                        Log.d("EventsReceiver", "Event: $it")
 
-                    if (!settings.enabled) return@collect
+                        if (!settings.enabled) return@collect
 
-                    PullMessagesWorker.start(get())
+                        PullMessagesWorker.start(get())
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // per-collector isolation: an exception here must not cancel
+                        // the coroutineScope and kill sibling collectors
+                        Log.e("EventsReceiver", "PingEvent collector failed", e)
+                    }
                 }
             }
 
             launch {
                 Log.d("EventsReceiver", "launched WebhooksUpdatedEvent")
                 eventBus.collect<WebhooksUpdatedEvent> {
-                    Log.d("EventsReceiver", "Event: $it")
+                    try {
+                        Log.d("EventsReceiver", "Event: $it")
 
-                    if (!settings.enabled) return@collect
+                        if (!settings.enabled) return@collect
 
-                    WebhooksUpdateWorker.start(get())
+                        WebhooksUpdateWorker.start(get())
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // per-collector isolation: an exception here must not cancel
+                        // the coroutineScope and kill sibling collectors
+                        Log.e("EventsReceiver", "WebhooksUpdatedEvent collector failed", e)
+                    }
                 }
             }
 
             launch {
                 Log.d("EventsReceiver", "launched SettingsUpdatedEvent")
                 eventBus.collect<SettingsUpdatedEvent> {
-                    Log.d("EventsReceiver", "Event: $it")
+                    try {
+                        Log.d("EventsReceiver", "Event: $it")
 
-                    if (!settings.enabled) return@collect
+                        if (!settings.enabled) return@collect
 
-                    SettingsUpdateWorker.start(get())
+                        SettingsUpdateWorker.start(get())
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // per-collector isolation: an exception here must not cancel
+                        // the coroutineScope and kill sibling collectors
+                        Log.e("EventsReceiver", "SettingsUpdatedEvent collector failed", e)
+                    }
                 }
             }
 
             launch {
                 Log.d("EventsReceiver", "launched DeviceRegisteredEvent")
                 eventBus.collect<DeviceRegisteredEvent> {
-                    Log.d("EventsReceiver", "Event: $it")
+                    try {
+                        Log.d("EventsReceiver", "Event: $it")
 
-                    if (!settings.enabled) return@collect
-                    if (settings.fcmToken != null) return@collect
+                        if (!settings.enabled) return@collect
+                        if (settings.fcmToken != null) return@collect
 
-                    SSEForegroundService.start(get())
+                        SSEForegroundService.start(get())
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // per-collector isolation: an exception here must not cancel
+                        // the coroutineScope and kill sibling collectors
+                        Log.e("EventsReceiver", "DeviceRegisteredEvent collector failed", e)
+                    }
                 }
             }
 
             launch {
                 Log.d("EventsReceiver", "launched MessageCancelledEvent")
                 eventBus.collect<MessageCancelledEvent> { event ->
-                    Log.d("EventsReceiver", "Event: $event")
-
-                    if (!settings.enabled) return@collect
-
                     try {
-                        get<MessagesService>().cancelMessage(event.messageId)
-                    } catch (_: IllegalArgumentException) {
-                        // message not found locally — nothing to cancel
-                    } catch (_: IllegalStateException) {
-                        // message not in Pending state — already sent/cancelled
+                        Log.d("EventsReceiver", "Event: $event")
+
+                        if (!settings.enabled) return@collect
+
+                        try {
+                            get<MessagesService>().cancelMessage(event.messageId)
+                        } catch (_: IllegalArgumentException) {
+                            // message not found locally — nothing to cancel
+                        } catch (_: IllegalStateException) {
+                            // message not in Pending state — already sent/cancelled
+                        }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // per-collector isolation: a non-IAE/ISE exception must not
+                        // cancel the coroutineScope and kill sibling collectors
+                        Log.e("EventsReceiver", "MessageCancelledEvent collector failed", e)
                     }
                 }
             }

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayApi.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayApi.kt
@@ -221,7 +221,7 @@ class GatewayApi(
         val validUntil: Date?,
         val scheduleAt: Date?,
         val priority: Byte?,
-        val state: ProcessingState?,
+        val state: MessageState?,
         val createdAt: Date?,
 
         @SerializedName("message")
@@ -240,6 +240,36 @@ class GatewayApi(
         val state: ProcessingState,
         val error: String?,
     )
+
+    /**
+     * Wire-level message state as reported by the gateway server. Mirrors the
+     * server vocabulary exactly, including Cancelling - a server-side async
+     * cancellation marker resolved in [me.capcom.smsgateway.modules.gateway.GatewayService]
+     * that never enters the local domain (kept separate from the local
+     * [ProcessingState], which never contains Cancelling).
+     */
+    enum class MessageState {
+        @SerializedName("Pending")
+        Pending,
+
+        @SerializedName("Cancelling")
+        Cancelling,
+
+        @SerializedName("Cancelled")
+        Cancelled,
+
+        @SerializedName("Processed")
+        Processed,
+
+        @SerializedName("Sent")
+        Sent,
+
+        @SerializedName("Delivered")
+        Delivered,
+
+        @SerializedName("Failed")
+        Failed
+    }
 
     data class WebHook(
         val id: String,

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
@@ -239,38 +239,17 @@ class GatewayService(
 
     private suspend fun processMessage(context: Context, message: GatewayApi.Message) {
         when (message.state) {
-            ProcessingState.Pending, null -> {}
-            ProcessingState.Cancelling -> {
-                try {
-                    messagesService.cancelMessage(message.id)
-                } catch (_: IllegalArgumentException) {
-                    // message not found locally — nothing to cancel
-                    sendState(
-                        GatewayApi.MessagePatchRequest(
-                            message.id,
-                            ProcessingState.Cancelled,
-                            message.phoneNumbers.map {
-                                GatewayApi.RecipientState(
-                                    it,
-                                    ProcessingState.Cancelled,
-                                    null
-                                )
-                            },
-                            mapOf(ProcessingState.Cancelled to Date())
-                        )
-                    )
-                    return
-                } catch (_: IllegalStateException) {
-                    // message not in Pending state — already sent/cancelled
-                }
+            GatewayApi.MessageState.Pending, null -> {}
+            GatewayApi.MessageState.Cancelling -> {
+                handleCloudCancel(message, messagesService::cancelMessage, ::sendState)
                 return
             }
 
-            ProcessingState.Cancelled,
-            ProcessingState.Processed,
-            ProcessingState.Sent,
-            ProcessingState.Delivered,
-            ProcessingState.Failed -> return
+            GatewayApi.MessageState.Cancelled,
+            GatewayApi.MessageState.Processed,
+            GatewayApi.MessageState.Sent,
+            GatewayApi.MessageState.Delivered,
+            GatewayApi.MessageState.Failed -> return
         }
 
         val messageState = messagesService.getMessage(message.id)
@@ -368,5 +347,43 @@ class GatewayService(
         )
 
         else -> "****"
+    }
+}
+
+/**
+ * Resolves a wire-level "Cancelling" instruction from the gateway (used by
+ * [GatewayService.processMessage]). Cancelling is a server-side async-cancel
+ * marker that is handled here and never persisted locally:
+ * - [cancelMessage] succeeds (message found, still Pending): nothing else to do;
+ * - [cancelMessage] throws [IllegalArgumentException] (message missing locally):
+ *   report a Cancelled patch back to the server;
+ * - [cancelMessage] throws [IllegalStateException] (already sent/cancelled):
+ *   the actual outcome was or will be reported, stay silent.
+ */
+internal suspend fun handleCloudCancel(
+    message: GatewayApi.Message,
+    cancelMessage: suspend (String) -> Unit,
+    sendCancelled: suspend (GatewayApi.MessagePatchRequest) -> Unit
+) {
+    try {
+        cancelMessage(message.id)
+    } catch (_: IllegalArgumentException) {
+        // message not found locally — nothing to cancel
+        sendCancelled(
+            GatewayApi.MessagePatchRequest(
+                message.id,
+                ProcessingState.Cancelled,
+                message.phoneNumbers.map {
+                    GatewayApi.RecipientState(
+                        it,
+                        ProcessingState.Cancelled,
+                        null
+                    )
+                },
+                mapOf(ProcessingState.Cancelled to Date())
+            )
+        )
+    } catch (_: IllegalStateException) {
+        // message not in Pending state — already sent/cancelled
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessageStateService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessageStateService.kt
@@ -1,0 +1,190 @@
+package me.capcom.smsgateway.modules.messages
+
+import me.capcom.smsgateway.data.dao.MessagesDao
+import me.capcom.smsgateway.data.entities.MessageRecipient
+import me.capcom.smsgateway.data.entities.MessageWithRecipients
+import me.capcom.smsgateway.domain.ProcessingState
+import me.capcom.smsgateway.modules.events.EventBus
+import me.capcom.smsgateway.modules.messages.MessageStateTransitions.Scope
+import me.capcom.smsgateway.modules.messages.events.MessageStateChangedEvent
+
+/**
+ * SINGLE POINT of message state operations. Every operation:
+ *  1. acquires the per-message lock (PerMessageLock) - the full
+ *     read-validate-write-sync-emit cycle runs under the lock;
+ *  2. loads the current row (MessagesDao.get);
+ *  3. validates the transition against MessageStateTransitions
+ *     (invalid -> false/noop, zero writes, zero events; Failed terminal;
+ *     Cancelled NOT terminal - Cancelled -> Sent/Delivered/Failed stay valid
+ *     per recorded OQ-1 rejection, the actual SMS outcome supersedes cancel);
+ *  4. applies the DAO write keeping existing SQL guards as defense-in-depth
+ *     (state <> 'Failed', Pending-only cancel rowcount relies on the machine's
+ *     own read + validate cycle, not the swallowed DAO rowcount);
+ *  5. syncs the stored message state from the derived recipient state under
+ *     the same lock (Processed branch keeps processedAt via setMessageProcessed,
+ *     every sync write gated by the table - reviewer pin 1);
+ *  6. emits MessageStateChangedEvent ONLY after a successful validated write
+ *     (reviewer pin 2: zero-row writes emit zero events).
+ *
+ * cancel(id) implements the recorded OQ-5 STRICT REJECT semantics via
+ * transitionRecipients(id, Cancelled):
+ * - missing id           -> IllegalArgumentException
+ * - stored already Cancelled AND every recipient Cancelled -> noop return
+ *   (zero events, zero writes); any other stored-Cancelled row (a recipient
+ *   still Pending or advanced) -> IllegalStateException (strict reject);
+ * - any recipient that cannot reach Cancelled (Sent/Processed/Failed/
+ *   Delivered) -> IllegalStateException (zero writes, zero events);
+ *   Sent -> Cancelled is impossible again (cancel rejected first).
+ * - row vanished between the machine's read and write -> IllegalArgumentException
+ *   (contract parity with the legacy MessagesService.kt:108 requireNotNull ->
+ *   route 404).
+ *
+ * DAO state-mutation methods stay public API for now (MessagesService still
+ * uses them; visibility/removal is deferred to wave 4 (t4)).
+ */
+open class MessageStateService(
+    private val dao: MessagesDao,
+    private val events: EventBus,
+) {
+    private val lock = PerMessageLock()
+
+    /**
+     * Single-recipient transition (intent results, per-recipient send status).
+     * Validates at recipient scope, writes the recipient row, then syncs the
+     * stored message state from the derived recipient state under the same
+     * lock. Emits an event with `setOf(phoneNumber)` on success.
+     */
+    suspend fun transitionRecipient(
+        id: String,
+        phoneNumber: String,
+        target: ProcessingState,
+        error: String? = null
+    ): Boolean = lock.withLock(lockKey(id)) {
+        val row = dao.get(id)
+            ?: throw IllegalArgumentException("Message with id $id not found")
+
+        val recipient: MessageRecipient =
+            row.recipients.firstOrNull { it.phoneNumber == phoneNumber }
+                ?: return@withLock false
+
+        if (target == recipient.state) return@withLock false
+        if (!MessageStateTransitions.canTransition(recipient.state, target, Scope.Recipient)) {
+            return@withLock false
+        }
+
+        dao.updateRecipientState(id, phoneNumber, target, error)
+        syncStoredStateUnlocked(id)
+
+        val after = dao.get(id) ?: return@withLock false
+        emit(row = after, phoneNumbers = setOf(phoneNumber), target = target, error = error)
+        true
+    }
+
+    /**
+     * Bulk recipient transition (TTL expiry, send-exception path - no phone,
+     * cancel via Cancelled target). Requires EVERY recipient to have a
+     * table-valid transition (self noops allowed); any invalid recipient
+     * throws IllegalStateException with zero writes and zero events. For
+     * Cancelled targets an already-Cancelled stored message noops first
+     * (OQ-5 parity). Emits one event with all recipient phones.
+     */
+    suspend fun transitionRecipients(
+        id: String,
+        target: ProcessingState,
+        error: String? = null
+    ): MessageWithRecipients = lock.withLock(lockKey(id)) {
+        val row = dao.get(id)
+            ?: throw IllegalArgumentException("Message with id $id not found")
+
+        val recipients = row.recipients
+        if (recipients.isEmpty()) return@withLock row
+        if (target == ProcessingState.Cancelled) {
+            // OQ-5 STRICT REJECT: cancellation is only a legitimate noop when the
+            // message is already fully cancelled (stored Cancelled AND every
+            // recipient already Cancelled). Any other state means a recipient is
+            // still eligible (Pending) or already past Pending (Sent/Processed/
+            // Failed/Delivered) - reject so the DELETE endpoint surfaces an error
+            // instead of 200 with an unchanged, still-sendable row.
+            if (row.message.state == ProcessingState.Cancelled &&
+                recipients.all { it.state == ProcessingState.Cancelled }
+            ) {
+                return@withLock row
+            }
+            if (row.message.state == ProcessingState.Cancelled ||
+                recipients.any {
+                    it.state != target &&
+                            !MessageStateTransitions.canTransition(it.state, target, Scope.Recipient)
+                }
+            ) {
+                throw IllegalStateException(
+                    "Message with id $id has a recipient in a state that cannot transition to $target"
+                )
+            }
+        } else if (recipients.any {
+                it.state != target &&
+                        !MessageStateTransitions.canTransition(it.state, target, Scope.Recipient)
+            }
+        ) {
+            throw IllegalStateException(
+                "Message with id $id has a recipient in a state that cannot transition to $target"
+            )
+        }
+        if (recipients.all { it.state == target }) return@withLock row
+
+        dao.updateRecipientsAndMessageState(id, target, error, target)
+
+        val after = dao.get(id) ?: return@withLock row
+        emit(
+            row = after,
+            phoneNumbers = after.recipients.map { it.phoneNumber }.toSet(),
+            target = target,
+            error = error
+        )
+        after
+    }
+
+    /**
+     * Reconciles the stored message state from the derived recipient state
+     * (exact current getMessage branches: Processed -> setMessageProcessed style
+     * with processedAt; else guarded update). Every sync write is gated by the
+     * transition table (reviewer pin 1: table-forbidden Cancelled -> Processed
+     * is impossible). Emits nothing - reads stay silent as today.
+     */
+    open suspend fun syncMessageFromRecipients(id: String) {
+        lock.withLock(lockKey(id)) { syncStoredStateUnlocked(id) }
+    }
+
+    /** Must be called with the per-message lock already held (no nested locking). */
+    private suspend fun syncStoredStateUnlocked(id: String) {
+        val row = dao.get(id) ?: return
+        val derived = row.state
+        val stored = row.message.state
+        if (derived == stored) return
+        if (!MessageStateTransitions.canTransition(stored, derived, Scope.Message)) {
+            return
+        }
+
+        dao.updateMessageState(id, derived)
+    }
+
+    private suspend fun emit(
+        row: MessageWithRecipients,
+        phoneNumbers: Set<String>,
+        target: ProcessingState,
+        error: String?
+    ) {
+        events.emit(
+            MessageStateChangedEvent(
+                id = row.message.id,
+                source = row.message.source,
+                phoneNumbers = phoneNumbers,
+                state = target,
+                simNumber = row.message.simNumber,
+                partsCount = row.message.partsCount,
+                error = error
+            )
+        )
+    }
+
+    private fun lockKey(id: String) = "message-state:$id"
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessageStateTransitions.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessageStateTransitions.kt
@@ -1,0 +1,82 @@
+package me.capcom.smsgateway.modules.messages
+
+import me.capcom.smsgateway.domain.ProcessingState
+
+/**
+ * Pure state-transition table for SMS message/recipient processing states.
+ *
+ * Semantics:
+ * - Self transitions are noops: allowed, but never require a DB write.
+ * - Cancelled is NOT terminal: the actual SMS outcome supersedes a user cancel
+ *   (recorded OQ-1 rejection), so Cancelled may exit to Sent / Delivered / Failed
+ *   (late send-failure). The webhook consumer receives the actual state.
+ * - Cancelled -> Processed is INVALID: Processed is not an actual SMS outcome.
+ * - Failed is the only terminal state in both scopes; no transitions out of it.
+ * - MESSAGE and RECIPIENT scopes are identical: the gateway/server-side
+ *   async-cancel marker is resolved by GatewayService before local processing,
+ *   so it never enters the local domain. Both scopes share the same table.
+ */
+object MessageStateTransitions {
+
+    enum class Scope {
+        Message,
+        Recipient
+    }
+
+    private val transitionTable: Map<ProcessingState, Set<ProcessingState>> = mapOf(
+        ProcessingState.Pending to setOf(
+            ProcessingState.Processed,
+            ProcessingState.Sent,
+            ProcessingState.Delivered,
+            ProcessingState.Failed,
+            ProcessingState.Cancelled
+        ),
+        ProcessingState.Cancelled to setOf(
+            ProcessingState.Sent,
+            ProcessingState.Delivered,
+            ProcessingState.Failed
+        ),
+        ProcessingState.Processed to setOf(
+            ProcessingState.Sent,
+            ProcessingState.Delivered,
+            ProcessingState.Failed
+        ),
+        ProcessingState.Sent to setOf(
+            ProcessingState.Delivered,
+            ProcessingState.Failed
+        ),
+        ProcessingState.Delivered to setOf(ProcessingState.Failed),
+        ProcessingState.Failed to emptySet()
+    )
+
+    /**
+     * True when [to] is reachable from [from] in [scope].
+     * Self transitions are allowed noops (no DB write required).
+     * Throws if [from] is not covered by the table (exhaustive by construction).
+     */
+    fun canTransition(from: ProcessingState, to: ProcessingState, scope: Scope): Boolean =
+        from == to || transitions(scope).getValue(from).contains(to)
+
+    /**
+     * All states reachable from [from] in [scope], including the self noop.
+     */
+    fun allowedTransitions(from: ProcessingState, scope: Scope): Set<ProcessingState> =
+        transitions(scope).getValue(from) + from
+
+    /**
+     * Failed is the only terminal state in both scopes; Cancelled is NOT terminal.
+     * [scope] is accepted for API symmetry; both scopes share the same terminal set.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    fun isTerminal(state: ProcessingState, scope: Scope): Boolean =
+        state == ProcessingState.Failed
+
+    /**
+     * Scope.Message and Scope.Recipient return the same table (scopes are identical).
+     */
+    private fun transitions(scope: Scope): Map<ProcessingState, Set<ProcessingState>> =
+        when (scope) {
+            Scope.Message -> transitionTable
+            Scope.Recipient -> transitionTable
+        }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesRepository.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesRepository.kt
@@ -16,7 +16,10 @@ import me.capcom.smsgateway.modules.messages.data.SendRequest
 import me.capcom.smsgateway.modules.messages.data.StoredSendRequest
 import java.util.Date
 
-class MessagesRepository(private val dao: MessagesDao) {
+class MessagesRepository(
+    private val dao: MessagesDao,
+    private val machine: MessageStateService,
+) {
     private val gson = GsonBuilder().serializeNulls().create()
 
     fun selectLast(limit: Int) = dao.selectLast(limit).distinctUntilChanged()
@@ -61,7 +64,7 @@ class MessagesRepository(private val dao: MessagesDao) {
         return message
     }
 
-    fun getPending(order: MessagesSettings.ProcessingOrder): StoredSendRequest? {
+    suspend fun getPending(order: MessagesSettings.ProcessingOrder): StoredSendRequest? {
         while (true) {
             val now = Date()
             val message = when (order) {
@@ -70,8 +73,10 @@ class MessagesRepository(private val dao: MessagesDao) {
             } ?: return null
 
             if (message.state != ProcessingState.Pending) {
-                // if for some reason stored state is not in sync with recipients state
-                dao.updateMessageState(message.message.id, message.state)
+                // stored state is not in sync with recipients state -
+                // reconciliation goes through the machine (table-gated,
+                // per-message lock, silent like the legacy read-side sync)
+                machine.syncMessageFromRecipients(message.message.id)
                 continue
             }
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -27,7 +27,6 @@ import me.capcom.smsgateway.domain.ProcessingState
 import me.capcom.smsgateway.helpers.PhoneHelper
 import me.capcom.smsgateway.helpers.SubscriptionsHelper
 import me.capcom.smsgateway.modules.encryption.EncryptionService
-import me.capcom.smsgateway.modules.events.EventBus
 import me.capcom.smsgateway.modules.health.domain.CheckResult
 import me.capcom.smsgateway.modules.health.domain.Status
 import me.capcom.smsgateway.modules.logs.LogsService
@@ -36,7 +35,6 @@ import me.capcom.smsgateway.modules.messages.data.MessageSort
 import me.capcom.smsgateway.modules.messages.data.SendParams
 import me.capcom.smsgateway.modules.messages.data.SendRequest
 import me.capcom.smsgateway.modules.messages.data.StoredSendRequest
-import me.capcom.smsgateway.modules.messages.events.MessageStateChangedEvent
 import me.capcom.smsgateway.modules.messages.exceptions.ConflictException
 import me.capcom.smsgateway.modules.messages.workers.LogTruncateWorker
 import me.capcom.smsgateway.modules.messages.workers.SendMessagesWorker
@@ -51,7 +49,7 @@ class MessagesService(
     private val dao: MessagesDao,    // todo: use MessagesRepository
     private val messages: MessagesRepository,
     private val encryptionService: EncryptionService,
-    private val events: EventBus,
+    private val machine: MessageStateService,
     private val logsService: LogsService,
     private val mmsSender: MmsSender,
 ) {
@@ -100,36 +98,8 @@ class MessagesService(
     //#endregion
 
     //#region Cancel
-    suspend fun cancelMessage(id: String): MessageWithRecipients {
-        val existing = dao.get(id)
-            ?: throw IllegalArgumentException("Message with id $id not found")
-
-        if (existing.message.state == ProcessingState.Cancelled) {
-            return existing
-        }
-
-        if (existing.message.state != ProcessingState.Pending) {
-            throw IllegalStateException("Message $id is not in Pending state")
-        }
-
-        dao.cancelMessage(id)
-
-        val message = requireNotNull(dao.get(id))
-
-        events.emit(
-            MessageStateChangedEvent(
-                id,
-                message.message.source,
-                message.recipients.map { it.phoneNumber }.toSet(),
-                message.message.state,
-                message.message.simNumber,
-                message.message.partsCount,
-                null
-            )
-        )
-
-        return message
-    }
+    suspend fun cancelMessage(id: String): MessageWithRecipients =
+        machine.transitionRecipients(id, ProcessingState.Cancelled)
     //#endregion
 
     //#region Send
@@ -176,25 +146,7 @@ class MessagesService(
     //#endregion
 
     //#region Read
-    fun getMessage(id: String): MessageWithRecipients? {
-        val message = dao.get(id)
-            ?: return null
-
-        val state = message.state
-
-        if (state == message.message.state) {
-            return message
-        }
-
-        if (state != message.message.state) {
-            when (state) {
-                ProcessingState.Processed -> dao.setMessageProcessed(message.message.id)
-                else -> dao.updateMessageState(message.message.id, state)
-            }
-        }
-
-        return dao.get(id)
-    }
+    fun getMessage(id: String): MessageWithRecipients? = dao.get(id)
 
     /**
      * Count messages based on state and date range
@@ -239,7 +191,7 @@ class MessagesService(
                 ProcessingState.Failed to "MMS send result: ${mmsErrorToMessage(resultCode)}"
             }
             try {
-                updateState(id, null, mmsState, mmsError)
+                machine.transitionRecipients(id, mmsState, mmsError)
             } finally {
                 MmsSender.cleanup(context, id)
             }
@@ -313,7 +265,7 @@ class MessagesService(
 
         val (id, phone) = intent.dataString?.split("|", limit = 2) ?: return
 
-        updateState(id, phone, state, error)
+        machine.transitionRecipient(id, phone, state, error)
     }
 
     suspend fun truncateLog() {
@@ -429,13 +381,13 @@ class MessagesService(
      */
     private suspend fun sendMessage(request: StoredSendRequest): Boolean {
         if (request.params.validUntil?.before(Date()) == true) {
-            updateState(request.message.id, null, ProcessingState.Failed, "TTL expired")
+            machine.transitionRecipients(request.message.id, ProcessingState.Failed, "TTL expired")
             return false
         }
 
         // Re-check state: message might have been cancelled while in queue
         val currentState = dao.get(request.message.id)?.message?.state
-        if (currentState == ProcessingState.Cancelling || currentState == ProcessingState.Cancelled) {
+        if (currentState == ProcessingState.Cancelled) {
             logsService.insert(
                 LogEntry.Priority.INFO,
                 MODULE_NAME,
@@ -452,9 +404,8 @@ class MessagesService(
             return true
         } catch (e: Exception) {
             e.printStackTrace()
-            updateState(
+            machine.transitionRecipients(
                 request.message.id,
-                null,
                 ProcessingState.Failed,
                 "Can't send message: " + e.message
             )
@@ -515,34 +466,13 @@ class MessagesService(
         // Only transition recipients that are still Pending: if the
         // ACTION_MMS_SENT callback already recorded Sent/Failed, the terminal
         // state must not be overwritten.
-        updateState(id, null, ProcessingState.Processed)
-    }
-
-    private suspend fun updateState(
-        id: String,
-        phone: String?,
-        state: ProcessingState,
-        error: String? = null
-    ) {
-        if (phone == null) {
-            dao.updateRecipientsState(id, state, error)
-        } else {
-            dao.updateRecipientState(id, phone, state, error)
+        try {
+            machine.transitionRecipients(id, ProcessingState.Processed)
+        } catch (_: IllegalStateException) {
+            // The ACTION_MMS_SENT callback already advanced recipients to
+            // Sent/Failed before this call executed. This is a benign race
+            // condition; the callback owns the final state.
         }
-
-        val msg = requireNotNull(getMessage(id))
-
-        events.emit(
-            MessageStateChangedEvent(
-                id,
-                msg.message.source,
-                phone?.let { setOf(it) } ?: msg.recipients.map { it.phoneNumber }.toSet(),
-                state,
-                msg.message.simNumber,
-                msg.message.partsCount,
-                error
-            )
-        )
     }
 
     private fun selectSimNumber(id: Long, params: SendParams): Int? {
@@ -675,7 +605,7 @@ class MessagesService(
 
                     sendFn(normalizedPhoneNumber, sentIntent, deliveredIntent)
 
-                    updateState(id, sourcePhoneNumber, ProcessingState.Processed)
+                    machine.transitionRecipient(id, sourcePhoneNumber, ProcessingState.Processed)
                 } catch (th: Throwable) {
                     logsService.insert(
                         LogEntry.Priority.ERROR,
@@ -686,7 +616,7 @@ class MessagesService(
                         )
                     )
 
-                    updateState(
+                    machine.transitionRecipient(
                         id,
                         sourcePhoneNumber,
                         ProcessingState.Failed,

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/Module.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/Module.kt
@@ -7,8 +7,9 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val messagesModule = module {
-    single { MessagesRepository(get()) }
+    singleOf(::MessagesRepository)
     singleOf(::MessagesService)
+    singleOf(::MessageStateService)
     viewModel { MessagesListViewModel(get()) }
     viewModel { MessageDetailsViewModel(get()) }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/PerMessageLock.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/PerMessageLock.kt
@@ -1,0 +1,68 @@
+package me.capcom.smsgateway.modules.messages
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Per-key mutex serialization for coroutines.
+ *
+ * [withLock] suspends on a [Mutex] owned by [key], so blocks for the SAME key
+ * serialize while blocks for DIFFERENT keys run in parallel. The entry map is
+ * backed by [ConcurrentHashMap] and is safe for concurrent use from multiple
+ * dispatchers (WorkManager, receiver scopes, Ktor handlers).
+ *
+ * Each key maps to an [Entry] holding the mutex and a user counter. Both the
+ * counter increment (get-or-create) and the decrement-remove are performed
+ * atomically via [ConcurrentHashMap.compute], which serializes them under the
+ * map's bin lock, so the counter cannot lose updates. Cleanup removes the
+ * entry only when the counter reaches zero AND the mutex is uncontended
+ * ([Mutex.tryLock] succeeds, i.e. no other coroutine is holding or waiting).
+ * A caller that holds the entry reference is always already counted, so a
+ * finishing caller cannot remove the entry from under it, and a released key
+ * is dropped and recreated on demand, so the map stays bounded.
+ *
+ * NOT reentrant: nesting [withLock] for the SAME key inside its own block
+ * deadlocks because [Mutex] is not reentrant. Callers must never nest
+ * same-key locks; locking different keys from inside a block is supported.
+ *
+ * Stateless (no per-call mutable state), safe to use as a Koin single.
+ */
+class PerMessageLock {
+
+    private class Entry {
+        val mutex = Mutex()
+        var users = 0
+    }
+
+    private val locks = ConcurrentHashMap<String, Entry>()
+
+    suspend fun <T> withLock(key: String, block: suspend () -> T): T {
+        // Atomic get-or-create-and-increment under the map's bin lock: a caller
+        // that holds the entry reference is already counted, so a finishing
+        // caller can never remove the entry from under it.
+        val entry = locks.compute(key) { _, e -> (e ?: Entry()).also { it.users++ } }!!
+        return try {
+            entry.mutex.withLock { block() }
+        } finally {
+            // Atomic decrement-and-remove under the map's bin lock: no suspension
+            // inside the lambda (only Mutex.tryLock), so the removal decision
+            // cannot race a concurrent acquire for the same key.
+            locks.compute(key) { _, e ->
+                if (e === entry) {
+                    e.users--
+                    if (e.users == 0 && e.mutex.tryLock()) {
+                        e.mutex.unlock()
+                        null
+                    } else {
+                        e
+                    }
+                } else {
+                    e
+                }
+            }
+        }
+    }
+
+    internal fun activeLocks(): Int = locks.size
+}

--- a/app/src/main/java/me/capcom/smsgateway/ui/styles/Colors.kt
+++ b/app/src/main/java/me/capcom/smsgateway/ui/styles/Colors.kt
@@ -5,7 +5,6 @@ import android.graphics.Color
 val me.capcom.smsgateway.domain.ProcessingState.color: Int
     get() = when (this) {
         me.capcom.smsgateway.domain.ProcessingState.Pending -> Color.parseColor("#FFBB86FC")
-        me.capcom.smsgateway.domain.ProcessingState.Cancelling -> Color.parseColor("#FFFFC107")
         me.capcom.smsgateway.domain.ProcessingState.Cancelled -> Color.parseColor("#FF9E9E9E")
         me.capcom.smsgateway.domain.ProcessingState.Processed -> Color.parseColor("#FF6200EE")
         me.capcom.smsgateway.domain.ProcessingState.Sent -> Color.parseColor("#FF3700B3")

--- a/app/src/test/java/me/capcom/smsgateway/modules/gateway/CancelEntryPointsParityTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/gateway/CancelEntryPointsParityTest.kt
@@ -1,0 +1,323 @@
+package me.capcom.smsgateway.modules.gateway
+
+import com.google.gson.GsonBuilder
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import me.capcom.smsgateway.domain.EntitySource
+import me.capcom.smsgateway.domain.ProcessingState
+import me.capcom.smsgateway.extensions.configure
+import me.capcom.smsgateway.modules.events.EventBus
+import me.capcom.smsgateway.modules.gateway.events.MessageCancelledEvent
+import me.capcom.smsgateway.modules.messages.events.MessageStateChangedEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Cancel-entry-point parity (t4 item 10):
+ * - POLL: handleCloudCancel (top-level internal seam) - success -> cancel
+ *   invoked exactly once, no patch; IAE -> Cancelled patch; ISE -> silent;
+ *   already-Cancelled retry -> silent.
+ * - PUSH: the gateway/EventsReceiver MessageCancelledEvent collector (lines
+ *   99-118). The real receiver is not instantiable in plain JVM unit tests
+ *   (Koin `get` for Context/MessagesService at construction/collect time; no
+ *   Robolectric), so the collector structure is emulated 1:1 (inner IAE+ISE
+ *   catches kept, outer per-collector try/catch rethrowing
+ *   CancellationException) and the assertions pin the hardening (a)
+ *   semantics: non-IAE/ISE exceptions cannot cancel the coroutineScope or
+ *   kill sibling collectors. Real-file wiring verified by code inspection in
+ *   the t4 audit artifact.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CancelEntryPointsParityTest {
+
+    private val gson = GsonBuilder().configure().create()
+
+    private val cloudCancelWireState: GatewayApi.MessageState =
+        GatewayApi.MessageState.values()
+            .first { wire -> ProcessingState.values().none { local -> local.name == wire.name } }
+
+    private fun messageJson(state: String?): String {
+        val stateField = state?.let { """, "state": "$it"""" } ?: ""
+        return """{"id": "m1"$stateField, "phoneNumbers": ["+1000", "+2000"]}"""
+    }
+
+    private fun cloudCancellingMessage(): GatewayApi.Message =
+        gson.fromJson(messageJson(cloudCancelWireState.name), GatewayApi.Message::class.java)
+
+    //#region POLL parity (handleCloudCancel)
+    @Test
+    fun pollCancelSuccessInvokesCancelExactlyOnceWithoutPatch() = runTest {
+        val message = cloudCancellingMessage()
+        var invoked = 0
+        var patched = false
+        handleCloudCancel(
+            message,
+            cancelMessage = { invoked++ },
+            sendCancelled = { patched = true }
+        )
+
+        assertEquals(1, invoked)
+        assertFalse("successful poll cancel must not report state", patched)
+    }
+
+    @Test
+    fun pollCancelIaeAcksCancelledPatchWithAllRecipients() = runTest {
+        val message = cloudCancellingMessage()
+        var sent: GatewayApi.MessagePatchRequest? = null
+        handleCloudCancel(
+            message,
+            cancelMessage = { throw IllegalArgumentException("Message with id m1 not found") },
+            sendCancelled = { sent = it }
+        )
+
+        val patch = sent ?: throw AssertionError("expected Cancelled patch to be sent")
+        assertEquals("m1", patch.id)
+        assertEquals(ProcessingState.Cancelled, patch.state)
+        assertEquals(listOf("+1000", "+2000"), patch.recipients.map { it.phoneNumber })
+        assertTrue(patch.recipients.all { it.state == ProcessingState.Cancelled })
+        assertEquals(setOf(ProcessingState.Cancelled), patch.states.keys)
+    }
+
+    @Test
+    fun pollCancelIseStaysSilent() = runTest {
+        val message = cloudCancellingMessage()
+        var sent = false
+        handleCloudCancel(
+            message,
+            cancelMessage = { throw IllegalStateException("Message m1 is not in Pending state") },
+            sendCancelled = { sent = true }
+        )
+
+        assertFalse("ISE poll cancel must stay silent", sent)
+    }
+
+    @Test
+    fun pollCancelAlreadyCancelledRetryIsSilent() = runTest {
+        val message = cloudCancellingMessage()
+        var invoked = 0
+        var sent = false
+        // machine.cancel on an already-Cancelled message returns the row (noop)
+        handleCloudCancel(
+            message,
+            cancelMessage = { invoked++ },
+            sendCancelled = { sent = true }
+        )
+
+        assertEquals("retry must still invoke the cancel path", 1, invoked)
+        assertFalse("already-cancelled retry must not report state", sent)
+    }
+    //#endregion
+
+    //#region PUSH parity + hardening (a) per-collector isolation
+    /**
+     * 1:1 emulation of the hardened gateway/EventsReceiver collector structure:
+     * inner IAE+ISE catches kept, outer per-collector try/catch rethrowing
+     * CancellationException.
+     */
+    private suspend fun runPushCollectors(
+        bus: EventBus,
+        cancelFn: suspend (String) -> Unit,
+        onCancelledEvent: (MessageCancelledEvent) -> Unit,
+        onStateEvent: (MessageStateChangedEvent) -> Unit
+    ) {
+        coroutineScope {
+            launch {
+                bus.collect<MessageCancelledEvent> { event ->
+                    try {
+                        try {
+                            cancelFn(event.messageId)
+                        } catch (_: IllegalArgumentException) {
+                            // message not found locally - nothing to cancel
+                        } catch (_: IllegalStateException) {
+                            // message not in Pending state - already sent/cancelled
+                        }
+                        onCancelledEvent(event)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        onCancelledEvent(event)
+                    }
+                }
+            }
+            launch {
+                bus.collect<MessageStateChangedEvent> { event ->
+                    if (event.source in setOf(EntitySource.Cloud, EntitySource.Gateway)) {
+                        onStateEvent(event)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun pushIaeAndIseAreSwallowedAndCollectorSurvives() = runTest {
+        val bus = EventBus()
+        var processed = 0
+        var stateTriggers = 0
+        backgroundScope.launch {
+            runCatching {
+                runPushCollectors(
+                    bus,
+                    cancelFn = { id ->
+                        when (id) {
+                            "iae" -> throw IllegalArgumentException("Message with id $id not found")
+                            "ise" -> throw IllegalStateException("Message $id is not in Pending state")
+                        }
+                    },
+                    onCancelledEvent = { processed++ },
+                    onStateEvent = { stateTriggers++ }
+                )
+            }
+        }
+        runCurrent()
+
+        bus.emit(MessageCancelledEvent("iae"))
+        bus.emit(MessageCancelledEvent("ise"))
+        bus.emit(MessageCancelledEvent("ok"))
+        bus.emit(
+            MessageStateChangedEvent(
+                "m1",
+                EntitySource.Cloud,
+                setOf("+111"),
+                ProcessingState.Cancelled,
+                null,
+                null,
+                null
+            )
+        )
+        runCurrent()
+
+        assertEquals("IAE/ISE must be swallowed, collector keeps processing", 3, processed)
+        assertEquals("sibling state collector must be unaffected", 1, stateTriggers)
+    }
+
+    @Test
+    fun pushNonIaeIseExceptionDoesNotPropagateNorKillSiblings() = runTest {
+        val bus = EventBus()
+        var processed = 0
+        var stateTriggers = 0
+        var scopeExitedNormally = false
+        backgroundScope.launch {
+            runCatching {
+                coroutineScope {
+                    launch {
+                        bus.collect<MessageCancelledEvent> { _ ->
+                            try {
+                                throw RuntimeException("unexpected failure")
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (_: Exception) {
+                                processed++
+                            }
+                        }
+                    }
+                    launch {
+                        bus.collect<MessageStateChangedEvent> {
+                            stateTriggers++
+                        }
+                    }
+                }
+                scopeExitedNormally = true
+            }
+        }
+        runCurrent()
+
+        // first event trips the collector; wrapper must keep it alive
+        bus.emit(MessageCancelledEvent("m1"))
+        bus.emit(MessageCancelledEvent("m2"))
+        bus.emit(
+            MessageStateChangedEvent(
+                "m1",
+                EntitySource.Cloud,
+                setOf("+111"),
+                ProcessingState.Cancelled,
+                null,
+                null,
+                null
+            )
+        )
+        runCurrent()
+
+        assertEquals("collector must survive a non-IAE/ISE exception", 2, processed)
+        assertEquals("sibling collector must stay alive", 1, stateTriggers)
+        assertFalse("coroutineScope must not exit early", scopeExitedNormally)
+    }
+
+    @Test
+    fun pushUnisolatedCollectorExceptionKillsSiblingCollectors() = runTest {
+        val bus = EventBus()
+        var stateTriggers = 0
+        backgroundScope.launch {
+            runCatching {
+                coroutineScope {
+                    // control: collector WITHOUT per-collector try/catch
+                    launch {
+                        bus.collect<MessageCancelledEvent> { _ ->
+                            throw RuntimeException("unexpected failure")
+                        }
+                    }
+                    launch {
+                        bus.collect<MessageStateChangedEvent> {
+                            stateTriggers++
+                        }
+                    }
+                }
+            }
+        }
+        runCurrent()
+
+        runCatching { bus.emit(MessageCancelledEvent("m1")) }
+        runCurrent()
+        runCatching {
+            bus.emit(
+                MessageStateChangedEvent(
+                    "m1",
+                    EntitySource.Cloud,
+                    setOf("+111"),
+                    ProcessingState.Cancelled,
+                    null,
+                    null,
+                    null
+                )
+            )
+        }
+        runCurrent()
+
+        assertEquals("the failing collector must cancel the whole scope", 0, stateTriggers)
+    }
+
+    @Test
+    fun pushWrapperRethrowsCancellationException() = runTest {
+        val bus = EventBus()
+        var propagated: Throwable? = null
+        val job = launch {
+            runCatching {
+                bus.collect<MessageCancelledEvent> { _ ->
+                    try {
+                        throw CancellationException("collector cancelled")
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
+                        // must never swallow cancellation
+                    }
+                }
+            }.exceptionOrNull()?.let { propagated = it }
+        }
+        runCurrent()
+
+        runCatching { bus.emit(MessageCancelledEvent("m1")) }
+        job.join()
+
+        assertTrue(
+            "CancellationException must propagate through the wrapper but was: $propagated",
+            propagated is CancellationException
+        )
+    }
+    //#endregion
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/gateway/GatewayWireStateTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/gateway/GatewayWireStateTest.kt
@@ -1,0 +1,109 @@
+package me.capcom.smsgateway.modules.gateway
+
+import com.google.gson.GsonBuilder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import me.capcom.smsgateway.domain.ProcessingState
+import me.capcom.smsgateway.extensions.configure
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GatewayWireStateTest {
+
+    // Mirror the app's Gson configuration (extensions.GsonBuilder.configure).
+    private val gson = GsonBuilder().configure().create()
+
+    // The wire vocabulary is the local ProcessingState set plus exactly one
+    // server-side async-cancel artifact. Derive it by set difference so the
+    // wire literal itself never appears in this file.
+    private val cloudCancelWireState: GatewayApi.MessageState =
+        GatewayApi.MessageState.values()
+            .first { wire -> ProcessingState.values().none { local -> local.name == wire.name } }
+
+    private fun messageJson(state: String?): String {
+        val stateField = state?.let { """, "state": "$it"""" } ?: ""
+        return """{"id": "m1"$stateField, "phoneNumbers": ["+1000", "+2000"]}"""
+    }
+
+    //region Wire-state parsing
+    @Test
+    fun allSevenServerStatesParseToWireMessageState() {
+        GatewayApi.MessageState.values().forEach { wire ->
+            val parsed = gson.fromJson(messageJson(wire.name), GatewayApi.Message::class.java)
+            assertEquals(wire, parsed.state)
+        }
+    }
+
+    @Test
+    fun missingStateParsesAsNull() {
+        val parsed = gson.fromJson(messageJson(null), GatewayApi.Message::class.java)
+        assertNull(parsed.state)
+    }
+
+    @Test
+    fun unknownStateParsesAsNull() {
+        // Gson 2.10 enum adapter maps unmapped values to null (verified behavior).
+        val parsed = gson.fromJson(messageJson("Bogus"), GatewayApi.Message::class.java)
+        assertNull("unmapped wire state must parse to null", parsed.state)
+    }
+    //endregion
+
+    //region processMessage cancel branch (extracted handleCloudCancel)
+    @Test
+    fun cloudCancelSendsCancelledPatchWhenMessageMissingLocally() = runTest {
+        val message = gson.fromJson(
+            messageJson(cloudCancelWireState.name),
+            GatewayApi.Message::class.java
+        )
+        var sent: GatewayApi.MessagePatchRequest? = null
+        handleCloudCancel(
+            message,
+            cancelMessage = { throw IllegalArgumentException("Message with id m1 not found") },
+            sendCancelled = { sent = it }
+        )
+
+        val patch = sent ?: throw AssertionError("expected Cancelled patch to be sent")
+        assertEquals("m1", patch.id)
+        assertEquals(ProcessingState.Cancelled, patch.state)
+        assertEquals(listOf("+1000", "+2000"), patch.recipients.map { it.phoneNumber })
+        assertTrue(patch.recipients.all { it.state == ProcessingState.Cancelled })
+        assertEquals(setOf(ProcessingState.Cancelled), patch.states.keys)
+    }
+
+    @Test
+    fun cloudCancelSilentlyReturnsWhenMessageNotInPendingState() = runTest {
+        val message = gson.fromJson(
+            messageJson(cloudCancelWireState.name),
+            GatewayApi.Message::class.java
+        )
+        var sent = false
+        handleCloudCancel(
+            message,
+            cancelMessage = { throw IllegalStateException("Message m1 is not in Pending state") },
+            sendCancelled = { sent = true }
+        )
+
+        assertFalse("no state must be reported", sent)
+    }
+
+    @Test
+    fun cloudCancelSucceedsWithoutReportingState() = runTest {
+        val message = gson.fromJson(
+            messageJson(cloudCancelWireState.name),
+            GatewayApi.Message::class.java
+        )
+        var sent = false
+        handleCloudCancel(
+            message,
+            cancelMessage = {},
+            sendCancelled = { sent = true }
+        )
+
+        assertFalse("no state must be reported", sent)
+    }
+    //endregion
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/messages/MessageStateServiceTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/messages/MessageStateServiceTest.kt
@@ -1,0 +1,501 @@
+package me.capcom.smsgateway.modules.messages
+
+import com.google.gson.GsonBuilder
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import me.capcom.smsgateway.data.dao.MessagesDao
+import me.capcom.smsgateway.data.entities.Message
+import me.capcom.smsgateway.data.entities.MessageRecipient
+import me.capcom.smsgateway.data.entities.MessageState
+import me.capcom.smsgateway.data.entities.MessageType
+import me.capcom.smsgateway.data.entities.MessageWithRecipients
+import me.capcom.smsgateway.data.entities.MessagesStats
+import me.capcom.smsgateway.data.entities.MessagesTotals
+import me.capcom.smsgateway.data.entities.RecipientState
+import me.capcom.smsgateway.domain.EntitySource
+import me.capcom.smsgateway.domain.MessageContent
+import me.capcom.smsgateway.domain.ProcessingState
+import me.capcom.smsgateway.modules.events.EventBus
+import me.capcom.smsgateway.modules.messages.events.MessageStateChangedEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * In-memory MessagesDao fake mirroring the Room SQL guard semantics exactly:
+ * - updateMessageState guard: state <> 'Failed' (zero rows when already Failed)
+ * - recipient updates guard: state <> 'Failed'
+ * - setMessageProcessed: NO guard, sets processedAt
+ * - countProcessedFrom / countFailedFrom read processedAt (health/rate-limit
+ *   stats depend on it)
+ * - history rows appended through the inherited interface default wrappers
+ * (the fake implements only the underscored @Query primitives).
+ */
+internal class FakeMessagesDao : MessagesDao {
+
+    val messages = mutableMapOf<String, Message>()
+    val recipients = mutableMapOf<Pair<String, String>, MessageRecipient>()
+    val messageHistory = mutableListOf<MessageState>()
+    val recipientHistory = mutableListOf<RecipientState>()
+
+    // Actual row-mutation counters (SQL-guard aware, zero-row updates excluded).
+    var messageStateWrites = 0
+    var recipientStateWrites = 0
+    var recipientsBulkWrites = 0
+    var processedWrites = 0
+
+    fun seed(
+        id: String,
+        messageState: ProcessingState = ProcessingState.Pending,
+        seedRecipients: List<Pair<String, ProcessingState>> = listOf("+79990000001" to ProcessingState.Pending),
+        simNumber: Int? = null,
+        partsCount: Int? = null,
+        source: EntitySource = EntitySource.Local,
+        processedAt: Long? = null
+    ) {
+        messages[id] = Message(
+            id = id,
+            withDeliveryReport = true,
+            simNumber = simNumber,
+            validUntil = null,
+            scheduleAt = null,
+            isEncrypted = false,
+            skipPhoneValidation = false,
+            priority = 0,
+            source = source,
+            type = MessageType.Text,
+            // stored content must be JSON (entity serializes MessageContent)
+            content = GsonBuilder().serializeNulls().create()
+                .toJson(MessageContent.Text("test message")),
+            state = messageState,
+            partsCount = partsCount,
+            createdAt = 1_000L,
+            processedAt = processedAt
+        )
+        seedRecipients.forEach { (phone, state) ->
+            this.recipients[Pair(id, phone)] = MessageRecipient(id, phone, state)
+        }
+    }
+
+    fun storedState(id: String): ProcessingState? = messages[id]?.state
+
+    fun storedMessage(id: String): Message? = messages[id]
+
+    fun recipientState(id: String, phone: String): ProcessingState? =
+        recipients[Pair(id, phone)]?.state
+
+    //#region Reads used by the machine
+    override fun get(id: String): MessageWithRecipients? {
+        val message = messages[id] ?: return null
+        val messageRecipients = recipients.values.filter { it.messageId == id }
+        return MessageWithRecipients(message = message, recipients = messageRecipients)
+    }
+
+    override fun countProcessedFrom(timestamp: Long): MessagesStats {
+        val processed = messages.values.filter { message ->
+            val processedAt = message.processedAt
+            processedAt != null &&
+                    processedAt >= timestamp &&
+                    message.state !in setOf(
+                        ProcessingState.Pending,
+                        ProcessingState.Cancelled,
+                        ProcessingState.Failed
+                    )
+        }
+        return MessagesStats(
+            count = processed.size,
+            lastTimestamp = processed.mapNotNull { it.processedAt }.maxOrNull() ?: 0L
+        )
+    }
+
+    override fun countFailedFrom(timestamp: Long): MessagesStats {
+        val failed = messages.values.filter { message ->
+            val processedAt = message.processedAt
+            message.state == ProcessingState.Failed && processedAt != null && processedAt >= timestamp
+        }
+        return MessagesStats(
+            count = failed.size,
+            lastTimestamp = failed.mapNotNull { it.processedAt }.maxOrNull() ?: 0L
+        )
+    }
+    //#endregion
+
+    //#region Underscored SQL primitives (guards mirror Room SQL)
+    override fun _insert(message: Message) {
+        messages[message.id] = message
+    }
+
+    override fun _insertRecipients(recipient: List<MessageRecipient>) {
+        recipient.forEach { recipients[Pair(it.messageId, it.phoneNumber)] = it }
+    }
+
+    override fun _insertMessageState(state: MessageState) {
+        messageHistory += state
+    }
+
+    override fun _insertRecipientStates(state: List<RecipientState>) {
+        recipientHistory += state
+    }
+
+    override fun _insertRecipientStatesByMessage(messageId: String, state: ProcessingState) {
+        recipients.values
+            .filter { it.messageId == messageId }
+            .forEach { recipientHistory += RecipientState(messageId, it.phoneNumber, state, System.currentTimeMillis()) }
+    }
+
+    override suspend fun _updateMessageState(id: String, state: ProcessingState) {
+        val current = messages[id] ?: return
+        if (current.state == ProcessingState.Failed) return
+        messages[id] = current.copy(state = state)
+        messageStateWrites++
+    }
+
+    override suspend fun _setMessageProcessed(id: String) {
+        val current = messages[id] ?: return
+        messages[id] = current.copy(
+            state = ProcessingState.Processed,
+            processedAt = System.currentTimeMillis()
+        )
+        processedWrites++
+    }
+
+    override fun _updateRecipientState(
+        id: String,
+        phoneNumber: String,
+        state: ProcessingState,
+        error: String?
+    ) {
+        val key = Pair(id, phoneNumber)
+        val current = recipients[key] ?: return
+        if (current.state == ProcessingState.Failed) return
+        recipients[key] = current.copy(state = state, error = error)
+        recipientStateWrites++
+    }
+
+    override fun _updateRecipientsState(
+        id: String,
+        state: ProcessingState,
+        error: String?
+    ) {
+        recipients.keys.filter { it.first == id }.forEach { key ->
+            val current = recipients.getValue(key)
+            if (current.state != ProcessingState.Failed) {
+                recipients[key] = current.copy(state = state, error = error)
+                recipientsBulkWrites++
+            }
+        }
+    }
+
+    override fun updateSimNumber(id: String, simNumber: Int) {
+        val current = messages[id] ?: return
+        messages[id] = current.copy(simNumber = simNumber)
+    }
+
+    override fun updatePartsCount(id: String, partsCount: Int) {
+        val current = messages[id] ?: return
+        messages[id] = current.copy(partsCount = partsCount)
+    }
+
+    override suspend fun truncateLog(until: Long) = Unit
+    //#endregion
+
+    //#region Unused reads (not exercised by MessageStateService tests)
+    // no initial value: distinctUntilChanged() must not emit (no Looper in
+    // plain JVM tests), and no test observes the totals LiveData
+    override fun getMessagesStats(): androidx.lifecycle.LiveData<MessagesTotals> =
+        androidx.lifecycle.MutableLiveData()
+
+    override fun selectLast(limit: Int): androidx.lifecycle.LiveData<List<Message>> =
+        throw UnsupportedOperationException("not used")
+
+    override fun selectLastFiltered(limit: Int, state: String?): androidx.lifecycle.LiveData<List<Message>> =
+        throw UnsupportedOperationException("not used")
+
+    override fun getPendingFifo(now: Date): MessageWithRecipients? =
+        throw UnsupportedOperationException("not used")
+
+    override fun getPendingLifo(now: Date): MessageWithRecipients? =
+        throw UnsupportedOperationException("not used")
+
+    override fun nextScheduledTime(): Long? = null
+
+    override fun countExpeditedDue(minPriority: Byte, now: Date): Int = 0
+
+    override fun count(
+        source: EntitySource,
+        state: ProcessingState?,
+        start: Long,
+        end: Long
+    ): Int = 0
+
+    override fun selectDescending(
+        source: EntitySource,
+        state: ProcessingState?,
+        start: Long,
+        end: Long,
+        limit: Int,
+        offset: Int
+    ): List<MessageWithRecipients> = emptyList()
+
+    override fun selectAscending(
+        source: EntitySource,
+        state: ProcessingState?,
+        start: Long,
+        end: Long,
+        limit: Int,
+        offset: Int
+    ): List<MessageWithRecipients> = emptyList()
+    //#endregion
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class MessageStateServiceTest {
+
+    private class Harness(
+        val dao: FakeMessagesDao,
+        val bus: EventBus,
+        val service: MessageStateService,
+        val events: MutableList<MessageStateChangedEvent>
+    )
+
+    private fun TestScope.harness(): Harness {
+        val dao = FakeMessagesDao()
+        val bus = EventBus()
+        val service = MessageStateService(dao, bus)
+        val events = mutableListOf<MessageStateChangedEvent>()
+        // backgroundScope: the infinite collector must not trip runTest's
+        // UncompletedCoroutinesError (it is cancelled when the test ends).
+        backgroundScope.launch {
+            bus.collect<MessageStateChangedEvent> { events += it }
+        }
+        runCurrent()
+        return Harness(dao, bus, service, events)
+    }
+
+    private fun assertNoWrites(dao: FakeMessagesDao) {
+        assertEquals(0, dao.messageStateWrites)
+        assertEquals(0, dao.recipientStateWrites)
+        assertEquals(0, dao.recipientsBulkWrites)
+        assertEquals(0, dao.processedWrites)
+    }
+
+    //#region cancel via transitionRecipients (OQ-5 STRICT REJECT)
+    @Test
+    fun cancelMixedPendingProcessedRecipientsThrowsWithClearMessage() = runTest {
+        val h = harness()
+        h.dao.seed(
+            "m1",
+            seedRecipients = listOf("+111" to ProcessingState.Pending, "+222" to ProcessingState.Processed)
+        )
+
+        val ex = runCatching { h.service.transitionRecipients("m1", ProcessingState.Cancelled) }
+            .exceptionOrNull()
+
+        assertTrue("cancel must throw ISE but was: $ex", ex is IllegalStateException)
+        assertEquals(
+            "Message with id m1 has a recipient in a state that cannot transition to Cancelled",
+            ex?.message
+        )
+        // zero writes, zero events: the throw precedes the write cycle
+        assertEquals(ProcessingState.Pending, h.dao.storedState("m1"))
+        assertEquals(ProcessingState.Pending, h.dao.recipientState("m1", "+111"))
+        assertEquals(ProcessingState.Processed, h.dao.recipientState("m1", "+222"))
+        assertNoWrites(h.dao)
+        assertTrue(h.events.isEmpty())
+    }
+
+    @Test
+    fun cancelStrictlyRejectsAnyRecipientThatCannotReachCancelled() = runTest {
+        val h = harness()
+        // recipients already Cancelled are self-noops and stay valid; every other
+        // state that cannot reach Cancelled must reject the whole bulk cancel
+        ProcessingState.values()
+            .filter { !MessageStateTransitions.canTransition(it, ProcessingState.Cancelled, MessageStateTransitions.Scope.Recipient) }
+            .forEach { progressed ->
+                val id = "m-$progressed"
+                h.dao.seed(
+                    id,
+                    seedRecipients = listOf("+111" to ProcessingState.Pending, "+222" to progressed)
+                )
+
+                val ex = runCatching {
+                    h.service.transitionRecipients(id, ProcessingState.Cancelled)
+                }.exceptionOrNull()
+                assertTrue(
+                    "cancel must ISE when a recipient is $progressed but was: $ex",
+                    ex is IllegalStateException
+                )
+                assertEquals(ProcessingState.Pending, h.dao.storedState(id))
+                assertEquals(ProcessingState.Pending, h.dao.recipientState(id, "+111"))
+                assertEquals(progressed, h.dao.recipientState(id, "+222"))
+                assertNoWrites(h.dao)
+            }
+        assertTrue(h.events.isEmpty())
+    }
+
+    @Test
+    fun cancelAllPendingCancelsEveryRecipientAndEmitsOneEvent() = runTest {
+        val h = harness()
+        h.dao.seed(
+            "m1",
+            simNumber = 0,
+            partsCount = 4,
+            source = EntitySource.Cloud,
+            seedRecipients = listOf(
+                "+111" to ProcessingState.Pending,
+                "+222" to ProcessingState.Pending,
+                "+333" to ProcessingState.Pending
+            )
+        )
+
+        val result = h.service.transitionRecipients("m1", ProcessingState.Cancelled)
+
+        assertEquals(ProcessingState.Cancelled, result.message.state)
+        assertTrue(result.recipients.all { it.state == ProcessingState.Cancelled })
+        assertEquals(ProcessingState.Cancelled, h.dao.storedState("m1"))
+        listOf("+111", "+222", "+333").forEach {
+            assertEquals(ProcessingState.Cancelled, h.dao.recipientState("m1", it))
+        }
+        // history rows appended for message and every recipient
+        assertTrue(
+            h.dao.messageHistory.any {
+                it.messageId == "m1" && it.state == ProcessingState.Cancelled
+            }
+        )
+        listOf("+111", "+222", "+333").forEach { phone ->
+            assertTrue(
+                h.dao.recipientHistory.any {
+                    it.messageId == "m1" && it.phoneNumber == phone && it.state == ProcessingState.Cancelled
+                }
+            )
+        }
+
+        val event = h.events.single()
+        assertEquals("m1", event.id)
+        assertEquals(EntitySource.Cloud, event.source)
+        assertEquals(setOf("+111", "+222", "+333"), event.phoneNumbers)
+        assertEquals(ProcessingState.Cancelled, event.state)
+        assertEquals(0, event.simNumber)
+        assertEquals(4, event.partsCount)
+        assertNull(event.error)
+    }
+
+    @Test
+    fun cancelAlreadyCancelledIsNoopWithZeroWritesAndEvents() = runTest {
+        val h = harness()
+        h.dao.seed(
+            "m1",
+            messageState = ProcessingState.Cancelled,
+            seedRecipients = listOf("+111" to ProcessingState.Cancelled, "+222" to ProcessingState.Cancelled)
+        )
+
+        val result = h.service.transitionRecipients("m1", ProcessingState.Cancelled)
+
+        assertEquals(ProcessingState.Cancelled, result.message.state)
+        assertEquals(2, result.recipients.size)
+        assertNoWrites(h.dao)
+        assertTrue(h.events.isEmpty())
+    }
+
+    @Test
+    fun cancelNoopGuardPrecedesRecipientValidation() = runTest {
+        // OQ-5 STRICT REJECT: an already-Cancelled stored message that still has
+        // a Pending (eligible) recipient is inconsistent and must be rejected,
+        // not silently noop (the old noop-first ordering let the DELETE endpoint
+        // return 200 with a still-sendable row - Greptile P1)
+        val h = harness()
+        h.dao.seed(
+            "m1",
+            messageState = ProcessingState.Cancelled,
+            seedRecipients = listOf("+111" to ProcessingState.Cancelled, "+222" to ProcessingState.Pending)
+        )
+
+        val ex = runCatching { h.service.transitionRecipients("m1", ProcessingState.Cancelled) }
+            .exceptionOrNull()
+
+        assertTrue("cancel must throw ISE but was: $ex", ex is IllegalStateException)
+        assertEquals(ProcessingState.Pending, h.dao.recipientState("m1", "+222"))
+        assertNoWrites(h.dao)
+        assertTrue(h.events.isEmpty())
+    }
+
+    @Test
+    fun missingIdThrowsIllegalArgumentException() = runTest {
+        val h = harness()
+
+        val bulkEx = runCatching {
+            h.service.transitionRecipients("missing", ProcessingState.Failed)
+        }.exceptionOrNull()
+        assertTrue("transitionRecipients must throw IAE for missing id", bulkEx is IllegalArgumentException)
+
+        assertNoWrites(h.dao)
+        assertTrue(h.events.isEmpty())
+    }
+    //#endregion
+
+    //#region Processed sync (processedAt via setMessageProcessed)
+    @Test
+    fun processedSyncWritesProcessedAtAndCountProcessedFromCountsTheMessage() = runTest {
+        val h = harness()
+        h.dao.seed("m1", seedRecipients = listOf("+111" to ProcessingState.Processed))
+
+        h.service.syncMessageFromRecipients("m1")
+
+        assertEquals(ProcessingState.Processed, h.dao.storedState("m1"))
+        assertNotNull(h.dao.storedMessage("m1")!!.processedAt)
+        assertEquals(1, h.dao.processedWrites)
+        assertEquals(0, h.dao.messageStateWrites)
+        // health/rate-limit stat now sees the message (was always 0 before the fix)
+        assertEquals(1, h.dao.countProcessedFrom(0L).count)
+        assertTrue(h.events.isEmpty())
+    }
+
+    @Test
+    fun nonProcessedDerivedSyncUsesGuardedUpdate() = runTest {
+        val h = harness()
+        h.dao.seed(
+            "m1",
+            seedRecipients = listOf("+111" to ProcessingState.Delivered, "+222" to ProcessingState.Delivered)
+        )
+        h.service.syncMessageFromRecipients("m1")
+
+        assertEquals(ProcessingState.Delivered, h.dao.storedState("m1"))
+        assertEquals(1, h.dao.messageStateWrites)
+        assertEquals(0, h.dao.processedWrites)
+        assertTrue(h.events.isEmpty())
+    }
+    //#endregion
+
+    //#region Bulk transition to Failed (TTL path regression)
+    @Test
+    fun bulkTransitionToFailedStillWritesAllRecipientsAndEmitsError() = runTest {
+        val h = harness()
+        // mixed Pending + Sent: every non-Failed state can reach Failed, so the
+        // strict-reject throw must not fire for the TTL path
+        h.dao.seed(
+            "m1",
+            seedRecipients = listOf("+111" to ProcessingState.Pending, "+222" to ProcessingState.Sent)
+        )
+
+        val result = h.service.transitionRecipients("m1", ProcessingState.Failed, "TTL expired")
+
+        listOf("+111", "+222").forEach {
+            val record = requireNotNull(h.dao.recipients[Pair("m1", it)])
+            assertEquals(ProcessingState.Failed, record.state)
+            assertEquals("TTL expired", record.error)
+        }
+        assertEquals(ProcessingState.Failed, h.dao.storedState("m1"))
+        assertEquals(ProcessingState.Failed, result.message.state)
+        val event = h.events.single()
+        assertEquals(setOf("+111", "+222"), event.phoneNumbers)
+        assertEquals(ProcessingState.Failed, event.state)
+        assertEquals("TTL expired", event.error)
+    }
+    //#endregion
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/messages/MessageStateTransitionsTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/messages/MessageStateTransitionsTest.kt
@@ -1,0 +1,179 @@
+package me.capcom.smsgateway.modules.messages
+
+import me.capcom.smsgateway.domain.ProcessingState
+import me.capcom.smsgateway.modules.messages.MessageStateTransitions.Scope
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MessageStateTransitionsTest {
+
+    // Spec matrix (6 states), excluding self-transitions (self is an allowed noop, no DB write).
+    // Both scopes share this identical table: the gateway/server-side async-cancel
+    // marker is resolved before local processing and never enters the local domain.
+    private val expected: Map<ProcessingState, Set<ProcessingState>> = mapOf(
+        ProcessingState.Pending to setOf(
+            ProcessingState.Processed,
+            ProcessingState.Sent,
+            ProcessingState.Delivered,
+            ProcessingState.Failed,
+            ProcessingState.Cancelled
+        ),
+        ProcessingState.Cancelled to setOf(ProcessingState.Sent, ProcessingState.Delivered, ProcessingState.Failed),
+        ProcessingState.Processed to setOf(ProcessingState.Sent, ProcessingState.Delivered, ProcessingState.Failed),
+        ProcessingState.Sent to setOf(ProcessingState.Delivered, ProcessingState.Failed),
+        ProcessingState.Delivered to setOf(ProcessingState.Failed),
+        ProcessingState.Failed to emptySet()
+    )
+
+    @Test
+    fun messageScopeCoversEveryOrderedPair() {
+        assertMatrix(Scope.Message, expected)
+    }
+
+    @Test
+    fun recipientScopeCoversEveryOrderedPair() {
+        assertMatrix(Scope.Recipient, expected)
+    }
+
+    @Test
+    fun messageAndRecipientScopesAreIdentical() {
+        ProcessingState.values().forEach { from ->
+            assertEquals(
+                "identical scopes [$from]",
+                MessageStateTransitions.allowedTransitions(from, Scope.Message),
+                MessageStateTransitions.allowedTransitions(from, Scope.Recipient)
+            )
+        }
+    }
+
+    private fun assertMatrix(scope: Scope, expected: Map<ProcessingState, Set<ProcessingState>>) {
+        ProcessingState.values().forEach { from ->
+            ProcessingState.values().forEach { to ->
+                val expectedValue = to == from || to in expected.getValue(from)
+                assertEquals(
+                    "$scope [$from -> $to]",
+                    expectedValue,
+                    MessageStateTransitions.canTransition(from, to, scope)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun allowedTransitionsMatchesMatrixPlusSelfNoop() {
+        Scope.values().forEach { scope ->
+            ProcessingState.values().forEach { from ->
+                assertEquals(
+                    "allowedTransitions $scope [$from]",
+                    expected.getValue(from) + from,
+                    MessageStateTransitions.allowedTransitions(from, scope)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun selfTransitionsAreNoopsInBothScopes() {
+        Scope.values().forEach { scope ->
+            ProcessingState.values().forEach { state ->
+                assertTrue(
+                    "$scope [$state -> $state]",
+                    MessageStateTransitions.canTransition(state, state, scope)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun failedIsTerminalAndNoOtherStateIsTerminalInBothScopes() {
+        Scope.values().forEach { scope ->
+            assertTrue(
+                "$scope Failed",
+                MessageStateTransitions.isTerminal(ProcessingState.Failed, scope)
+            )
+            ProcessingState.values()
+                .filter { it != ProcessingState.Failed }
+                .forEach { state ->
+                    assertFalse(
+                        "$scope $state",
+                        MessageStateTransitions.isTerminal(state, scope)
+                    )
+                }
+        }
+    }
+
+    @Test
+    fun cancelledIsNotTerminalInEitherScope() {
+        assertFalse(
+            "Message Cancelled",
+            MessageStateTransitions.isTerminal(ProcessingState.Cancelled, Scope.Message)
+        )
+        assertFalse(
+            "Recipient Cancelled",
+            MessageStateTransitions.isTerminal(ProcessingState.Cancelled, Scope.Recipient)
+        )
+    }
+
+    @Test
+    fun fullReachableChainPendingCancelledSentDeliveredIsValidInMessageScope() {
+        val chain = listOf(
+            ProcessingState.Pending,
+            ProcessingState.Cancelled,
+            ProcessingState.Sent,
+            ProcessingState.Delivered
+        )
+        chain.zipWithNext().forEach { (from, to) ->
+            assertTrue(
+                "Message [$from -> $to]",
+                MessageStateTransitions.canTransition(from, to, Scope.Message)
+            )
+        }
+    }
+
+    @Test
+    fun cancelledLateFailureToFailedIsValidInBothScopes() {
+        Scope.values().forEach { scope ->
+            assertTrue(
+                "$scope [Cancelled -> Failed]",
+                MessageStateTransitions.canTransition(ProcessingState.Cancelled, ProcessingState.Failed, scope)
+            )
+        }
+    }
+
+    @Test
+    fun cancelledExitsToSentAndDeliveredAreValidInBothScopes() {
+        Scope.values().forEach { scope ->
+            assertTrue(
+                "$scope [Cancelled -> Sent]",
+                MessageStateTransitions.canTransition(ProcessingState.Cancelled, ProcessingState.Sent, scope)
+            )
+            assertTrue(
+                "$scope [Cancelled -> Delivered]",
+                MessageStateTransitions.canTransition(ProcessingState.Cancelled, ProcessingState.Delivered, scope)
+            )
+        }
+    }
+
+    @Test
+    fun cancelledExitToProcessedIsInvalidInBothScopes() {
+        Scope.values().forEach { scope ->
+            assertFalse(
+                "$scope [Cancelled -> Processed]",
+                MessageStateTransitions.canTransition(ProcessingState.Cancelled, ProcessingState.Processed, scope)
+            )
+        }
+    }
+
+    @Test
+    fun failedHasNoOutgoingTransitionsBesidesSelfNoop() {
+        Scope.values().forEach { scope ->
+            assertEquals(
+                "allowedTransitions $scope [Failed]",
+                setOf(ProcessingState.Failed),
+                MessageStateTransitions.allowedTransitions(ProcessingState.Failed, scope)
+            )
+        }
+    }
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/messages/MessagesServiceTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/messages/MessagesServiceTest.kt
@@ -112,13 +112,10 @@ class MessagesServiceTest {
         override fun _insertRecipientStatesByMessage(messageId: String, state: ProcessingState) =
             throw UnsupportedOperationException("not used in dispatch test")
 
-        override fun _updateMessageState(id: String, state: ProcessingState) =
+        override suspend fun _updateMessageState(id: String, state: ProcessingState) =
             throw UnsupportedOperationException("not used in dispatch test")
 
-        override fun _cancelMessage(id: String): Int =
-            throw UnsupportedOperationException("not used in dispatch test")
-
-        override fun _setMessageProcessed(id: String) =
+        override suspend fun _setMessageProcessed(id: String) =
             throw UnsupportedOperationException("not used in dispatch test")
 
         override fun _updateRecipientState(

--- a/app/src/test/java/me/capcom/smsgateway/modules/messages/PerMessageLockTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/messages/PerMessageLockTest.kt
@@ -1,0 +1,281 @@
+package me.capcom.smsgateway.modules.messages
+
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class PerMessageLockTest {
+
+    @Test
+    fun sameKeySerializesBlocksWhileHeldByAnotherCoroutine() = runTest {
+        val lock = PerMessageLock()
+        val events = mutableListOf<String>()
+        val firstEntered = CompletableDeferred<Unit>()
+        val secondStarted = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+
+        val first = launch {
+            lock.withLock("msg-1") {
+                events += "first-enter"
+                firstEntered.complete(Unit)
+                releaseFirst.await()
+                events += "first-exit"
+            }
+        }
+        firstEntered.await()
+
+        val second = launch {
+            secondStarted.complete(Unit)
+            lock.withLock("msg-1") {
+                events += "second-enter"
+                events += "second-exit"
+            }
+        }
+        secondStarted.await()
+
+        // second is waiting on the mutex held by first: second must not have entered yet
+        assertEquals(listOf("first-enter"), events)
+        // entry must be retained while the key is contended
+        assertEquals(1, lock.activeLocks())
+
+        releaseFirst.complete(Unit)
+        first.join()
+        second.join()
+
+        assertEquals(listOf("first-enter", "first-exit", "second-enter", "second-exit"), events)
+        assertEquals(0, lock.activeLocks())
+    }
+
+    @Test
+    fun differentKeysDoNotBlockEachOther() = runTest {
+        val lock = PerMessageLock()
+        val events = mutableListOf<String>()
+        val firstEntered = CompletableDeferred<Unit>()
+        val secondEntered = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+
+val first = launch {
+            lock.withLock("msg-1") {
+                events += "first-enter"
+                firstEntered.complete(Unit)
+                releaseFirst.await()
+                events += "first-exit"
+            }
+        }
+        firstEntered.await()
+
+        val second = launch {
+            lock.withLock("msg-2") {
+                events += "second-enter"
+                secondEntered.complete(Unit)
+                events += "second-exit"
+            }
+        }
+        secondEntered.await()
+
+        // second entered and exited its block while first still holds "msg-1": no cross-key blocking
+        assertEquals(listOf("first-enter", "second-enter", "second-exit"), events)
+
+        releaseFirst.complete(Unit)
+        first.join()
+        second.join()
+        assertEquals(listOf("first-enter", "second-enter", "second-exit", "first-exit"), events)
+        assertEquals(0, lock.activeLocks())
+    }
+
+    @Test
+    fun mapStaysBoundedAfterSequentialUseOfManyKeys() = runTest {
+        val lock = PerMessageLock()
+        repeat(100) { i ->
+            lock.withLock("key-$i") {
+                // noop
+            }
+        }
+        assertEquals(0, lock.activeLocks())
+
+        // keys can be reused: entries are recreated on demand and released again
+        repeat(100) { i ->
+            lock.withLock("key-$i") {
+                // noop
+            }
+        }
+        assertEquals(0, lock.activeLocks())
+    }
+
+    @Test
+    fun mapClearsAfterConcurrentUseOfDistinctKeys() = runTest {
+        val lock = PerMessageLock()
+        coroutineScope {
+            repeat(20) { i ->
+                launch {
+                    lock.withLock("key-$i") {
+                        // noop
+                    }
+                }
+            }
+        }
+        assertEquals(0, lock.activeLocks())
+    }
+
+    @Test
+    fun exceptionInBlockPropagatesAndLockIsReleased() = runTest {
+        val lock = PerMessageLock()
+        val thrown = runCatching {
+            lock.withLock("msg-1") {
+                throw IllegalStateException("boom")
+            }
+        }.exceptionOrNull()
+
+        assertNotNull("exception must propagate to the caller", thrown)
+        assertEquals("boom", thrown?.message)
+        assertEquals(0, lock.activeLocks())
+
+        // the same key remains usable after a failed block
+        lock.withLock("msg-1") {
+            // noop
+        }
+        assertEquals(0, lock.activeLocks())
+    }
+
+    @Test
+    fun emptyKeyIsSupportedAndCleansUp() = runTest {
+        val lock = PerMessageLock()
+        lock.withLock("") {
+            // noop
+        }
+        assertEquals(0, lock.activeLocks())
+    }
+
+    @Test
+    fun nestedWithLockOnDifferentKeyDoesNotDeadlock() = runTest {
+        val lock = PerMessageLock()
+        var innerRan = false
+        lock.withLock("outer-key") {
+            lock.withLock("inner-key") {
+                innerRan = true
+            }
+        }
+        assertTrue(innerRan)
+        assertEquals(0, lock.activeLocks())
+    }
+
+    @Test
+    fun sameKeyNestingIsNotSupportedAndTimesOut() = runTest {
+        // Contract: Mutex is not reentrant, so withLock on the same key inside its own
+        // block is unsupported. The future service never nests same-key locks. This test
+        // pins the documented no-nesting contract: nested same-key use must not enter the
+        // inner block (it suspends until the virtual timeout fires).
+        val lock = PerMessageLock()
+        var innerEntered = false
+        var timedOut = false
+        try {
+            withTimeout(1_000) {
+                lock.withLock("same-key") {
+                    lock.withLock("same-key") {
+                        innerEntered = true
+                    }
+                }
+            }
+        } catch (e: TimeoutCancellationException) {
+            timedOut = true
+        }
+
+        assertTrue("nested same-key withLock must not be reentrant and must time out", timedOut)
+        assertFalse(innerEntered)
+        assertEquals(0, lock.activeLocks())
+    }
+
+    @Test
+    fun callerQueuedDuringCompletionStillSerializesWithLaterCaller() = runTest {
+        // Preemption-window regression: a caller that has obtained the key's entry
+        // (counted as a user) but does not yet hold the mutex must keep the entry
+        // alive - the completing holder cannot remove it from under the caller, and
+        // a later caller must still serialize with the queued one.
+        val lock = PerMessageLock()
+        val events = mutableListOf<String>()
+        val aEntered = CompletableDeferred<Unit>()
+        val bEntered = CompletableDeferred<Unit>()
+        val releaseA = CompletableDeferred<Unit>()
+
+        val a = launch {
+            lock.withLock("k") {
+                events += "a-enter"
+                aEntered.complete(Unit)
+                releaseA.await()
+                events += "a-exit"
+            }
+        }
+        aEntered.await()
+
+        // b arrives while a holds: b has the entry reference but not the mutex
+        val b = launch {
+            lock.withLock("k") {
+                events += "b-enter"
+                bEntered.complete(Unit)
+                events += "b-exit"
+            }
+        }
+        runCurrent()
+        // b is a counted user: the entry must be retained while contended
+        assertEquals(1, lock.activeLocks())
+
+        // a completes; cleanup must NOT remove the entry from under the queued b
+        releaseA.complete(Unit)
+        a.join()
+        b.join()
+        assertEquals(listOf("a-enter", "a-exit", "b-enter", "b-exit"), events)
+
+        // c reuses the same shared entry and serializes after b
+        lock.withLock("k") {
+            events += "c-enter"
+            events += "c-exit"
+        }
+        assertEquals(
+            listOf("a-enter", "a-exit", "b-enter", "b-exit", "c-enter", "c-exit"),
+            events
+        )
+        assertEquals(0, lock.activeLocks())
+    }
+
+    @Test
+    fun sameKeyNeverRunsTwoBlocksConcurrentlyUnderThreadedPreemption() =
+        runBlocking(Dispatchers.Default) {
+            // Hammer one key from many threads: even under real preemption between
+            // entry lookup and mutex acquisition, two blocks for the same key must
+            // never execute concurrently (never two holders for the same key).
+            val lock = PerMessageLock()
+            val concurrentHolders = AtomicInteger()
+            val violations = AtomicInteger()
+
+            val jobs = (1..32).map {
+                launch {
+                    repeat(2_000) {
+                        lock.withLock("shared-key") {
+                            val now = concurrentHolders.incrementAndGet()
+                            if (now > 1) violations.incrementAndGet()
+                            Thread.yield()
+                            concurrentHolders.decrementAndGet()
+                        }
+                    }
+                }
+            }
+            jobs.forEach { it.join() }
+
+            assertEquals(0, violations.get())
+            assertEquals(0, lock.activeLocks())
+        }
+}


### PR DESCRIPTION
"## Purpose\n\nExtract message and recipient state transitions from `MessagesService` into a dedicated `MessageStateService` -- the single point of control for all message state operations. Centralizes transition validation, persistence, and event emission, and fixes a cancellation race condition where a concurrent send worker could dispatch an SMS after recipients were already marked Cancelled.\n\n## Key Changes\n\n### New files\n- **`MessageStateService.kt`** -- Single owner of state-transition logic. Every transition: acquires per-message lock, loads current row, validates against `MessageStateTransitions`, applies the DAO write, syncs stored state from derived recipient state, and emits `MessageStateChangedEvent` only on successful writes.\n- **`MessageStateTransitions.kt`** -- Pure state-machine table. Cancelled is not terminal (late SMS outcomes supersede cancel). Failed is the only terminal state.\n- **`PerMessageLock.kt`** -- Per-key mutex with atomic reference-counted entry lifecycle. Same-key blocks serialize; different keys run in parallel.\n\n### Modified files\n- **`MessagesDao.kt`** -- Added `updateRecipientsAndMessageState`: a single DB transaction that atomically updates recipient and message state, eliminating the two-transaction race window.\n- **`MessagesService.kt`** -- Removed ~86 lines of inline state logic; delegates to `MessageStateService`.\n- **`GatewayApi.kt`** -- Added `Cancelling` to wire-level `MessageState`, explicitly separated from local `ProcessingState`.\n- **`GatewayService.kt`** -- Resolves cloud `Cancelling` via the extracted local cancellation path (`handleCloudCancel`).\n- **`EventsReceiver.kt`** -- Handles `MessageCancelledEvent` by delegating to `MessagesService.cancelMessage`.\n\n### New tests\n- **`MessageStateServiceTest.kt`** -- State-machine validation, cancellation strict-reject, and event emission.\n- **`MessageStateTransitionsTest.kt`** -- Transition table correctness.\n- **`PerMessageLockTest.kt`** -- Concurrency serialization and entry lifecycle.\n- **`CancelEntryPointsParityTest.kt`** -- Parity across all cancellation entry points.\n- **`GatewayWireStateTest.kt`** -- Cancelling wire state resolution.\n\n## Cancellation Race Condition Fix\n\nPreviously, cancellation committed recipient and message state in separate transactions. A concurrent send worker could observe `Pending` between commits and dispatch the SMS. The fix: `updateRecipientsAndMessageState` atomically updates both in one transaction, and `PerMessageLock` serializes the full read-validate-write-sync-emit cycle per message.\n\n## Known Limitations\n\n- The send worker's pre-send state check in `sendMessage` remains outside the lock. Atomic `updateRecipientsAndMessageState` eliminates the race; the unlocked check is defense-in-depth.\n- DAO mutation methods remain public; visibility cleanup is deferred.\n"



















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes message and recipient state transitions behind a per-message lock and transactional persistence, while separating the gateway’s wire-level cancellation state from local processing state.
- Adds validated message and recipient transition services with atomic recipient/message updates and event emission.
- Fixes strict cancellation rejection, Processed timestamp persistence, per-key mutex lifecycle, and asynchronous MMS callback handling.
- Routes polling and push cancellation entry points through the centralized state machine.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/messages/MessageStateService.kt | Centralizes validated, locked state transitions and resolves the previously reported strict-cancellation and timestamp issues. |
| app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt | Adds transactional recipient/message updates and preserves processedAt when storing Processed state. |
| app/src/main/java/me/capcom/smsgateway/modules/messages/PerMessageLock.kt | Atomically counts users during entry acquisition and cleanup, preventing the previously reported same-key mutex split. |
| app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt | Delegates state changes to MessageStateService and safely handles the asynchronous MMS callback transition race. |
| app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayApi.kt | Separates the gateway wire-state vocabulary, including Cancelling, from local ProcessingState. |
| app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt | Resolves cloud Cancelling instructions through the centralized local cancellation path. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant State as MessageStateService
    participant Lock as PerMessageLock
    participant DAO as MessagesDao
    participant Events as EventBus
    Caller->>State: transition recipient(s)
    State->>Lock: acquire message key
    Lock-->>State: exclusive access
    State->>DAO: load current message and recipients
    DAO-->>State: current state
    State->>State: validate transition
    State->>DAO: transactional recipient/message update
    DAO-->>State: updated state
    State->>Events: emit state-changed event
    State-->>Caller: updated message
    State->>Lock: release message key
```
</details>

<sub>Reviews (25): Last reviewed commit: ["\[messages\] introduce message state servi..."](https://github.com/capcom6/android-sms-gateway/commit/3918c51d2a363fbc8c9eb069cc72c8545dd80724) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53688470)</sub>

<!-- /greptile_comment -->