### PR TITLE
[messages] replace scheduled worker on new immediate message

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
@@ -64,6 +64,9 @@ interface MessagesDao {
     @Query("SELECT strftime('%s', MIN(COALESCE(`scheduleAt`, '1970-01-01T00:00:00.000Z'))) * 1000 FROM Message WHERE state = 'Pending'")
     fun nextScheduledTime(): Long?
 
+    @Query("SELECT COUNT(*) FROM message WHERE state = 'Pending' AND priority >= :minPriority AND (scheduleAt IS NULL OR scheduleAt <= :now)")
+    fun countExpeditedDue(minPriority: Byte, now: Date): Int
+
     @Transaction
     @Query("SELECT *, `rowid` FROM message WHERE id = :id")
     fun get(id: String): MessageWithRecipients?

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt
@@ -55,6 +55,12 @@ class MessagesService(
     private val logsService: LogsService,
     private val mmsSender: MmsSender,
 ) {
+    /**
+     * Serializes the worker (KEEP/REPLACE) decisions made from the DB snapshot
+     * with the enqueues and worker reschedules, so that a concurrent enqueue
+     * cannot install a delayed work between the snapshot read and the start call.
+     */
+    private val sendWorkerLock = Any()
     val processingOrder
         get() = settings.processingOrder
 
@@ -130,31 +136,42 @@ class MessagesService(
     fun enqueueMessage(request: SendRequest): MessageWithRecipients {
         val priority = request.params.priority ?: Message.PRIORITY_DEFAULT
         val scheduleAt = request.params.scheduleAt?.time
-        val nextScheduled = dao.nextScheduledTime()?.takeIf { it > 0 }
 
-        val message = try {
-            messages.enqueue(request)
-        } catch (_: android.database.sqlite.SQLiteConstraintException) {
-            throw ConflictException()
+        synchronized(sendWorkerLock) {
+            val nextScheduled = dao.nextScheduledTime()?.takeIf { it > 0 }
+
+            val message = try {
+                messages.enqueue(request)
+            } catch (_: android.database.sqlite.SQLiteConstraintException) {
+                throw ConflictException()
+            }
+
+            val workHoursStart = if (priority < Message.PRIORITY_EXPEDITED) {
+                settings.nextWorkHoursStart()
+            } else {
+                null
+            }
+            val startTime = when {
+                workHoursStart != null && workHoursStart < (nextScheduled ?: 0) -> workHoursStart
+                scheduleAt != null
+                        && scheduleAt > System.currentTimeMillis()
+                        && scheduleAt < (nextScheduled ?: 0) -> scheduleAt
+
+                else -> SendMessagesWorker.IMMEDIATE
+            }
+
+            if (startTime == SendMessagesWorker.IMMEDIATE) {
+                SendMessagesWorker.start(
+                    context,
+                    nextScheduled != null || priority >= Message.PRIORITY_EXPEDITED,
+                    SendMessagesWorker.IMMEDIATE
+                )
+            } else {
+                SendMessagesWorker.start(context, true, startTime)
+            }
+
+            return message
         }
-
-        val workHoursStart = if (priority < Message.PRIORITY_EXPEDITED) {
-            settings.nextWorkHoursStart()
-        } else {
-            null
-        }
-        val startTime = when {
-            workHoursStart != null && workHoursStart < (nextScheduled ?: 0) -> workHoursStart
-            scheduleAt != null
-                    && scheduleAt > System.currentTimeMillis()
-                    && scheduleAt < (nextScheduled ?: 0) -> scheduleAt
-
-            else -> SendMessagesWorker.IMMEDIATE
-        }
-
-        SendMessagesWorker.start(context, true, startTime)
-
-        return message
     }
     //#endregion
 
@@ -290,8 +307,8 @@ class MessagesService(
                 }
 
                 // skip work hours for expedited messages
-                if (priority < Message.PRIORITY_EXPEDITED) {
-                    applyWorkHoursLimit()
+                if (priority < Message.PRIORITY_EXPEDITED && applyWorkHoursLimit()) {
+                    continue
                 }
 
                 if (!withContext(NonCancellable) { sendMessage(message) }) {
@@ -313,10 +330,12 @@ class MessagesService(
             }
         } finally {
             if (coroutineContext.isActive) {
-                // After processing all pending messages, check if there are any scheduled messages for the future
-                val nextScheduledTime = dao.nextScheduledTime() ?: 0
-                if (nextScheduledTime > System.currentTimeMillis()) {
-                    SendMessagesWorker.start(context, true, nextScheduledTime)
+                synchronized(sendWorkerLock) {
+                    // After processing all pending messages, check if there are any scheduled messages for the future
+                    val nextScheduledTime = dao.nextScheduledTime() ?: 0
+                    if (nextScheduledTime > System.currentTimeMillis()) {
+                        SendMessagesWorker.start(context, true, nextScheduledTime)
+                    }
                 }
             }
         }
@@ -336,14 +355,38 @@ class MessagesService(
         delay(settings.limitPeriod.duration - (System.currentTimeMillis() - processedStats.lastTimestamp) + 1000L)
     }
 
-    private suspend fun applyWorkHoursLimit() {
-        val nextStart = settings.nextWorkHoursStart() ?: return
+    /**
+     * Delays message sending until work hours start if outside work hours.
+     *
+     * @return `true` if the current message should be skipped because due
+     * expedited messages must be sent first
+     */
+    private suspend fun applyWorkHoursLimit(): Boolean {
+        val nextStart = settings.nextWorkHoursStart() ?: return false
 
         val delayMs = nextStart - System.currentTimeMillis()
         if (delayMs > 0) {
-            SendMessagesWorker.start(context, true, nextStart)
-            delay(delayMs)
+            val shouldDelay = synchronized(sendWorkerLock) {
+                if (dao.countExpeditedDue(Message.PRIORITY_EXPEDITED, Date()) > 0) {
+                    logsService.insert(
+                        LogEntry.Priority.DEBUG,
+                        MODULE_NAME,
+                        "Deferring message outside work hours: expedited messages are due",
+                    )
+                    false
+                } else {
+                    SendMessagesWorker.start(context, true, nextStart)
+                    true
+                }
+            }
+            if (shouldDelay) {
+                delay(delayMs)
+            }
+
+            return !shouldDelay
         }
+
+        return false
     }
 
     /**

--- a/app/src/test/java/me/capcom/smsgateway/modules/messages/MessagesServiceTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/messages/MessagesServiceTest.kt
@@ -84,6 +84,9 @@ class MessagesServiceTest {
         override fun nextScheduledTime(): Long? =
             throw UnsupportedOperationException("not used in dispatch test")
 
+        override fun countExpeditedDue(minPriority: Byte, now: Date): Int =
+            throw UnsupportedOperationException("not used in dispatch test")
+
         override fun get(id: String): MessageWithRecipients? =
             throw UnsupportedOperationException("not used in dispatch test")
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR serializes send-worker scheduling decisions and defers a selected normal message when expedited work arrives during the work-hours check. It also introduces a database-driven KEEP/REPLACE choice for immediate enqueues.
- Adds a DAO query for due expedited messages.
- Coordinates enqueue, final rescheduling, and work-hours replacement with a shared lock.
- Replaces delayed work for immediate messages when the database snapshot reports scheduled work.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a normal immediate message can remain behind obsolete delayed unique work after the scheduled message is cancelled.

The new conditional KEEP path trusts the current database schedule even though cancellation does not reconcile the already-enqueued unique WorkManager request, allowing a due message to wait until a stale future wake-up.

**Files Needing Attention:** app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt | Adds a due-and-expedited pending-message count aligned with the existing eligibility predicate. |
| app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt | Serializes the previously reported scheduling races, but the new KEEP branch can preserve obsolete delayed unique work after the scheduled row is cancelled. |
| app/src/test/java/me/capcom/smsgateway/modules/messages/MessagesServiceTest.kt | Updates the DAO test double, but does not exercise enqueue scheduling or the cancellation-to-immediate transition. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Enqueue request] --> B[Lock scheduling decisions]
  B --> C[Read next pending schedule]
  C --> D[Persist message]
  D --> E{Immediate start?}
  E -- No --> F[REPLACE with delayed worker]
  E -- Yes --> G{Scheduled row exists or expedited?}
  G -- Yes --> H[REPLACE with immediate worker]
  G -- No --> I[KEEP existing unique worker]
  I --> J[Obsolete delayed work may remain after cancellation]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesService.kt:166
**KEEP preserves cancelled schedule**

When a future-scheduled message installs delayed unique work and is then cancelled, the next normal-priority immediate enqueue sees no scheduled database row and selects `KEEP`. This preserves the obsolete delayed worker, causing the immediate message to remain pending until the cancelled message's former scheduled time or another operation replaces the worker.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (14): Last reviewed commit: ["\[messages\] replace scheduled worker on n..."](https://github.com/capcom6/android-sms-gateway/commit/1697e56f5a0cdef7714fe46533f6d4c782a04df5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53695058)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Message processing](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/message-processing.md)
- Knowledge Base — [Outbound message delivery](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/outbound-message-delivery.md)

<!-- /greptile_comment -->