### PR TITLE
[localserver] require unique phone numbers

### DIFF
--- a/app/src/main/assets/api/swagger.json
+++ b/app/src/main/assets/api/swagger.json
@@ -2873,7 +2873,7 @@
                 }
               }
             },
-            "description": "Message with such ID already exists"
+            "description": "Message with the same ID already exists"
           },
           "500": {
             "content": {

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/PostMessageRequest.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/PostMessageRequest.kt
@@ -86,6 +86,10 @@ data class PostMessageRequest(
             throw IllegalArgumentException("Empty phone numbers list")
         }
 
+        if (phoneNumbers.distinct().size != phoneNumbers.size) {
+            throw IllegalArgumentException("phone numbers must be unique")
+        }
+
         if (simNumber != null && simNumber < 1) {
             throw IllegalArgumentException("SIM number cannot be less than 1")
         }

--- a/app/src/test/java/me/capcom/smsgateway/modules/localserver/domain/messages/PostMessageRequestTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/localserver/domain/messages/PostMessageRequestTest.kt
@@ -1,0 +1,62 @@
+package me.capcom.smsgateway.modules.localserver.domain.messages
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+internal class PostMessageRequestTest {
+
+    private fun request(phoneNumbers: List<String>): PostMessageRequest =
+        PostMessageRequest(
+            id = null,
+            message = "test",
+            phoneNumbers = phoneNumbers,
+            simNumber = null,
+            withDeliveryReport = null,
+            isEncrypted = null,
+            _ttl = null,
+            _validUntil = null,
+        )
+
+    @Test
+    fun duplicatePhoneNumbersThrows() {
+        val e = assertThrows(IllegalArgumentException::class.java) {
+            request(listOf("0123456789", "0123456789")).validate()
+        }
+
+        assertEquals("phone numbers must be unique", e.message)
+    }
+
+    @Test
+    fun duplicatePhoneNumbersNonAdjacentThrows() {
+        val e = assertThrows(IllegalArgumentException::class.java) {
+            request(listOf("0123456789", "0987654321", "0123456789")).validate()
+        }
+
+        assertEquals("phone numbers must be unique", e.message)
+    }
+
+    @Test
+    fun distinctPhoneNumbersPass() {
+        val request = request(listOf("0123456789", "0987654321", "+79111111111"))
+
+        assertSame(request, request.validate())
+    }
+
+    @Test
+    fun singlePhoneNumberPasses() {
+        val request = request(listOf("0123456789"))
+
+        assertSame(request, request.validate())
+    }
+
+    @Test
+    fun emptyPhoneNumbersThrows() {
+        val e = assertThrows(IllegalArgumentException::class.java) {
+            request(emptyList()).validate()
+        }
+
+        assertEquals("Empty phone numbers list", e.message)
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds request validation requiring raw phone-number strings to be unique, adds focused unit tests, and adjusts one API response description.
- Rejects exact duplicate recipients during `PostMessageRequest` validation.
- Tests exact, non-adjacent, distinct, single, and empty recipient lists.
- Clarifies the duplicate-message-ID response description.

<h3>Confidence Score: 3/5</h3>

The PR does not appear safe to merge until canonical duplicate recipients are rejected and the published OpenAPI contract reflects runtime uniqueness validation.

Raw-string comparison still allows equivalent phone-number representations to normalize to one destination and be sent more than once, while the OpenAPI schema continues to accept exact duplicates that runtime validation rejects.

**Files Needing Attention:** app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/PostMessageRequest.kt; app/src/main/assets/api/swagger.json

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/PostMessageRequest.kt | Adds exact-string recipient uniqueness validation, but the previously reported canonical-duplicate behavior remains. |
| app/src/main/assets/api/swagger.json | Clarifies response wording while leaving the previously reported runtime/schema uniqueness mismatch outstanding. |
| app/src/test/java/me/capcom/smsgateway/modules/localserver/domain/messages/PostMessageRequestTest.kt | Adds unit coverage for exact duplicates and ordinary validation cases. |

</details>

<sub>Reviews (10): Last reviewed commit: ["\[localserver\] require unique phone numbe..."](https://github.com/capcom6/android-sms-gateway/commit/94d98406e601028a34edc2bc1508dc18d7ddcfd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53871826)</sub>

<!-- /greptile_comment -->