### PR TITLE
feat(receiver): add sms:device-sent webhook for messages composed on the device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - SMS Receiver settings section with Content Provider Monitoring toggle to disable fallback content observer
+- `sms:device-sent` webhook event reporting outgoing SMS composed on the device itself, so integrations can see both sides of a conversation (opt-in, disabled by default)
 
 ### Fixed
 - Duplicate SMS detection when a message arrives via both broadcast receiver and content observer — use `DATE_SENT` instead of `DATE` in both paths so timestamps match consistently

--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ Use webhooks to receive notifications for messaging events (e.g., incoming SMS a
 | Event               | Description                                                                 |
 | ------------------- | --------------------------------------------------------------------------- |
 | `sms:received`      | Triggered when an SMS message is received                                   |
-| `sms:sent`          | Triggered when an SMS message is sent                                       |
+| `sms:sent`          | Triggered when an SMS message is sent through the gateway API               |
+| `sms:device-sent`   | Triggered when an outgoing SMS is composed on the device itself (opt-in)    |
 | `sms:delivered`     | Triggered when an SMS message is delivered                                  |
 | `sms:failed`        | Triggered when an SMS message fails to send                                 |
 | `sms:data-received` | Triggered when a data SMS is received                                       |

--- a/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
@@ -84,6 +84,25 @@ interface MessagesDao {
         limit: Int,
         offset: Int
     ): List<MessageWithRecipients>
+
+    /**
+     * Counts messages the gateway itself sent to a recipient recently. Used to tell a
+     * genuinely device-composed SMS apart from a gateway send that an OEM messaging
+     * stack mirrored into `content://sms/sent`.
+     *
+     * Recipients are stored in E.164 while the sent box may hold the number in a local
+     * format, so the match is on a trailing digit suffix rather than the whole string.
+     * Content is only compared when it is not encrypted, since an encrypted row holds
+     * ciphertext that can never match the provider's plaintext body.
+     */
+    @Query(
+        "SELECT COUNT(*) FROM message m " +
+                "JOIN messagerecipient r ON r.messageId = m.id " +
+                "WHERE m.processedAt >= :since " +
+                "AND r.phoneNumber LIKE '%' || :phoneSuffix " +
+                "AND (m.isEncrypted != 0 OR m.content = :content)"
+    )
+    fun countRecentSendsTo(phoneSuffix: String, content: String, since: Long): Int
     //#endregion
 
     @Insert

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesRepository.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesRepository.kt
@@ -28,6 +28,13 @@ class MessagesRepository(private val dao: MessagesDao) {
             ?: throw IllegalArgumentException("Message with id $id not found")
     }
 
+    /**
+     * Whether the gateway itself sent [content] to a number ending in [phoneSuffix]
+     * at or after [since]. See [MessagesDao.countRecentSendsTo] for the matching rules.
+     */
+    fun wasSentByGateway(phoneSuffix: String, content: String, since: Long): Boolean =
+        dao.countRecentSendsTo(phoneSuffix, content, since) > 0
+
     fun enqueue(request: SendRequest): MessageWithRecipients {
         val message = MessageWithRecipients(
             Message(

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverSettings.kt
@@ -10,7 +10,17 @@ class ReceiverSettings(
         get() = storage.get<Boolean>(CONTENT_PROVIDER_ENABLED) ?: true
         set(value) = storage.set(CONTENT_PROVIDER_ENABLED, value)
 
+    /**
+     * Report outgoing SMS composed on the device itself via the
+     * `sms:device-sent` webhook. Opt-in: disabled by default so existing
+     * installations keep their current behaviour and webhook volume.
+     */
+    var deviceSentEnabled: Boolean
+        get() = storage.get<Boolean>(DEVICE_SENT_ENABLED) ?: false
+        set(value) = storage.set(DEVICE_SENT_ENABLED, value)
+
     companion object {
         private const val CONTENT_PROVIDER_ENABLED = "content_provider_enabled"
+        private const val DEVICE_SENT_ENABLED = "device_sent_enabled"
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/SmsContentObserver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/SmsContentObserver.kt
@@ -12,6 +12,7 @@ import androidx.core.content.ContextCompat
 import me.capcom.smsgateway.helpers.SubscriptionsHelper
 import me.capcom.smsgateway.modules.logs.LogsService
 import me.capcom.smsgateway.modules.logs.db.LogEntry
+import me.capcom.smsgateway.modules.messages.MessagesRepository
 import me.capcom.smsgateway.modules.receiver.data.InboxMessage
 import me.capcom.smsgateway.modules.webhooks.WebHooksService
 import me.capcom.smsgateway.modules.webhooks.domain.WebHookEvent
@@ -38,6 +39,7 @@ class SmsContentObserver : KoinComponent {
     private val logsService: LogsService by inject()
     private val receiverSettings: ReceiverSettings by inject()
     private val webHooksService: WebHooksService by inject()
+    private val messagesRepository: MessagesRepository by inject()
 
     private var handlerThread: HandlerThread? = null
     private var observer: ContentObserver? = null
@@ -266,6 +268,11 @@ class SmsContentObserver : KoinComponent {
                     null
                 }
 
+                if (isGatewayEcho(address, body, date)) {
+                    storage.sentSmsLastProcessedID = id
+                    continue
+                }
+
                 try {
                     val simSlotIndex = subId?.let {
                         SubscriptionsHelper.getSimSlotIndex(context, it)
@@ -297,6 +304,41 @@ class SmsContentObserver : KoinComponent {
         }
     }
 
+    /**
+     * Whether a row in the sent box is really this gateway's own API send, mirrored into
+     * the provider by the messaging stack, rather than a message a human composed on the
+     * phone. Such a row would otherwise be reported as `sms:device-sent` on top of the
+     * `sms:sent` already emitted for it.
+     *
+     * The gateway itself never writes to the SMS provider (it holds neither `WRITE_SMS`
+     * nor the default-SMS-app role) and `SmsManager.sendTextMessage` does not persist on
+     * stock Android, so on AOSP this should never match. Some OEM builds do mirror sent
+     * messages regardless of the sending app, and this guards that case.
+     *
+     * Deliberately conservative: on any failure it returns false, so the worst outcome is
+     * a duplicate event rather than a silently dropped message.
+     */
+    private fun isGatewayEcho(address: String, body: String, sentAt: Date): Boolean {
+        val digits = address.filter { it.isDigit() }
+        if (digits.isEmpty()) return false
+
+        return try {
+            messagesRepository.wasSentByGateway(
+                phoneSuffix = digits.takeLast(PHONE_MATCH_DIGITS),
+                content = body,
+                since = sentAt.time - GATEWAY_ECHO_WINDOW_MS,
+            )
+        } catch (e: Exception) {
+            logsService.insert(
+                LogEntry.Priority.WARN,
+                MODULE_NAME,
+                "Could not check whether a sent SMS originated from the gateway",
+                mapOf("error" to (e.message ?: e.toString())),
+            )
+            false
+        }
+    }
+
     private fun canReadSms(): Boolean = ContextCompat.checkSelfPermission(
         context,
         android.Manifest.permission.READ_SMS,
@@ -304,5 +346,11 @@ class SmsContentObserver : KoinComponent {
 
     companion object {
         private const val TAG = "SmsContentObserver"
+
+        /** How far back to look for a matching gateway send. */
+        private const val GATEWAY_ECHO_WINDOW_MS = 5 * 60 * 1000L
+
+        /** Trailing digits compared, since the sent box may store a local number format. */
+        private const val PHONE_MATCH_DIGITS = 9
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/SmsContentObserver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/SmsContentObserver.kt
@@ -9,9 +9,13 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.provider.Telephony
 import androidx.core.content.ContextCompat
+import me.capcom.smsgateway.helpers.SubscriptionsHelper
 import me.capcom.smsgateway.modules.logs.LogsService
 import me.capcom.smsgateway.modules.logs.db.LogEntry
 import me.capcom.smsgateway.modules.receiver.data.InboxMessage
+import me.capcom.smsgateway.modules.webhooks.WebHooksService
+import me.capcom.smsgateway.modules.webhooks.domain.WebHookEvent
+import me.capcom.smsgateway.modules.webhooks.payload.SmsEventPayload
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.Date
@@ -32,6 +36,8 @@ class SmsContentObserver : KoinComponent {
     private val storage: StateStorage by inject()
     private val receiverSvc: ReceiverService by inject()
     private val logsService: LogsService by inject()
+    private val receiverSettings: ReceiverSettings by inject()
+    private val webHooksService: WebHooksService by inject()
 
     private var handlerThread: HandlerThread? = null
     private var observer: ContentObserver? = null
@@ -53,7 +59,10 @@ class SmsContentObserver : KoinComponent {
         // Initialize high-water mark to current max ID so existing rows in
         // the inbox are not re-processed on first start.
         if (storage.smsLastProcessedID == 0L) {
-            storage.smsLastProcessedID = queryMaxSmsId()
+            storage.smsLastProcessedID = queryMaxSmsId(Telephony.Sms.Inbox.CONTENT_URI)
+        }
+        if (receiverSettings.deviceSentEnabled && storage.sentSmsLastProcessedID == 0L) {
+            storage.sentSmsLastProcessedID = queryMaxSmsId(Telephony.Sms.Sent.CONTENT_URI)
         }
 
         val thread = HandlerThread("SmsContentObserver").apply { start() }
@@ -64,6 +73,7 @@ class SmsContentObserver : KoinComponent {
             override fun onChange(selfChange: Boolean) {
                 super.onChange(selfChange)
                 processNewMessages()
+                processNewSentMessages()
             }
         }
         observer = obs
@@ -80,7 +90,10 @@ class SmsContentObserver : KoinComponent {
         // Catch up rows that arrived while the app process was stopped or before
         // READ_SMS was granted. ContentObserver callbacks are edge-triggered, so
         // already-inserted SMS rows would otherwise remain pending forever.
-        handler.post { processNewMessages() }
+        handler.post {
+            processNewMessages()
+            processNewSentMessages()
+        }
     }
 
     fun stop() {
@@ -90,12 +103,12 @@ class SmsContentObserver : KoinComponent {
         handlerThread = null
     }
 
-    private fun queryMaxSmsId(): Long {
+    private fun queryMaxSmsId(uri: Uri): Long {
         if (!canReadSms()) return 0
 
         val cursor = try {
             context.contentResolver.query(
-                Telephony.Sms.Inbox.CONTENT_URI,
+                uri,
                 arrayOf(Telephony.Sms._ID),
                 null, null,
                 Telephony.Sms._ID + " DESC LIMIT 1",
@@ -182,6 +195,104 @@ class SmsContentObserver : KoinComponent {
                     )
                 }
                 storage.smsLastProcessedID = id
+            }
+        }
+    }
+
+    /**
+     * Picks up outgoing SMS written to `content://sms/sent` by the device's own
+     * messaging app and reports them through the `sms:device-sent` webhook.
+     *
+     * Without this, a conversation seen through the gateway is one-sided: replies
+     * typed directly on the phone are invisible to the integration, because the
+     * gateway only knows about messages it sent itself through its API.
+     *
+     * Uses the same high-water mark technique as the inbox scan, with a separate
+     * marker, and is skipped entirely unless explicitly enabled in settings.
+     */
+    private fun processNewSentMessages() {
+        if (!receiverSettings.deviceSentEnabled) return
+
+        if (!canReadSms()) {
+            logsService.insert(
+                LogEntry.Priority.WARN,
+                MODULE_NAME,
+                "Skipping sent SMS processing because READ_SMS is not granted",
+            )
+            return
+        }
+
+        val mark = storage.sentSmsLastProcessedID
+
+        val projection = mutableListOf(
+            Telephony.Sms._ID,
+            Telephony.Sms.ADDRESS,
+            Telephony.Sms.DATE,
+            Telephony.Sms.BODY,
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+            projection += Telephony.Sms.SUBSCRIPTION_ID
+        }
+
+        val cursor = try {
+            context.contentResolver.query(
+                Telephony.Sms.Sent.CONTENT_URI,
+                projection.toTypedArray(),
+                Telephony.Sms._ID + " > ?",
+                arrayOf(mark.toString()),
+                Telephony.Sms._ID + " ASC",
+            )
+        } catch (e: SecurityException) {
+            logsService.insert(
+                LogEntry.Priority.WARN,
+                MODULE_NAME,
+                "Skipping sent SMS processing because provider access was denied",
+                mapOf("error" to (e.message ?: e.toString())),
+            )
+            return
+        } ?: return
+
+        cursor.use { c ->
+            while (c.moveToNext()) {
+                val id = c.getLong(0)
+                val address = c.getString(1) ?: ""
+                // DATE_SENT is commonly 0 for locally composed messages, so the
+                // provider's DATE (row insertion time) is the reliable timestamp here.
+                val date = Date(c.getLong(2))
+                val body = c.getString(3) ?: ""
+                val subId = if (projection.size > 4) {
+                    c.getInt(4).takeIf { it >= 0 }
+                } else {
+                    null
+                }
+
+                try {
+                    val simSlotIndex = subId?.let {
+                        SubscriptionsHelper.getSimSlotIndex(context, it)
+                    }
+                    webHooksService.emit(
+                        context,
+                        WebHookEvent.SmsDeviceSent,
+                        SmsEventPayload.SmsDeviceSent(
+                            messageId = "sent:$id",
+                            sender = simSlotIndex?.let {
+                                SubscriptionsHelper.getPhoneNumber(context, it)
+                            },
+                            recipient = address,
+                            simNumber = simSlotIndex?.let { it + 1 },
+                            message = body,
+                            sentAt = date,
+                        ),
+                    )
+                } catch (e: Exception) {
+                    logsService.insert(
+                        LogEntry.Priority.ERROR,
+                        MODULE_NAME,
+                        "Failed processing sent SMS (id=$id)",
+                        mapOf("smsId" to id, "error" to (e.message ?: e.toString())),
+                    )
+                }
+                storage.sentSmsLastProcessedID = id
             }
         }
     }

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/StateStorage.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/StateStorage.kt
@@ -14,10 +14,15 @@ class StateStorage(
         get() = storage.get<Long>(SMS_LAST_PROCESSED_ID) ?: 0
         set(value) = storage.set(SMS_LAST_PROCESSED_ID, value)
 
+    var sentSmsLastProcessedID: Long
+        get() = storage.get<Long>(SENT_SMS_LAST_PROCESSED_ID) ?: 0
+        set(value) = storage.set(SENT_SMS_LAST_PROCESSED_ID, value)
+
     companion object {
         private val PREFIX = "state."
 
         private val MMS_LAST_PROCESSED_ID = PREFIX + "last_processed_id"
         private val SMS_LAST_PROCESSED_ID = PREFIX + "sms_last_processed_id"
+        private val SENT_SMS_LAST_PROCESSED_ID = PREFIX + "sent_sms_last_processed_id"
     }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt
@@ -32,4 +32,12 @@ enum class WebHookEvent(val value: String) {
 
     @SerializedName("sms:cancelled")
     SmsCancelled("sms:cancelled"),
+
+    /**
+     * An outgoing SMS composed on the device itself (e.g. in the default
+     * messaging app), as opposed to [SmsSent], which reports messages the
+     * gateway sent through its own API.
+     */
+    @SerializedName("sms:device-sent")
+    SmsDeviceSent("sms:device-sent"),
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsEventPayload.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsEventPayload.kt
@@ -55,6 +55,20 @@ sealed class SmsEventPayload(
         val receivedAt: Date,
     ) : SmsEventPayload(messageId, sender, recipient, simNumber, sender)
 
+    /**
+     * An outgoing SMS composed on the device itself. [sender] is the device's
+     * own number (when resolvable) and [recipient] is the remote party, which
+     * is the opposite of the *Received payloads above.
+     */
+    class SmsDeviceSent(
+        messageId: String,
+        sender: String?,
+        recipient: String,
+        simNumber: Int?,
+        val message: String,
+        val sentAt: Date,
+    ) : SmsEventPayload(messageId, sender, recipient, simNumber, recipient)
+
     class SmsCancelled(
         messageId: String,
         sender: String?,


### PR DESCRIPTION
Implements #427.

## What this does

Adds an opt-in `sms:device-sent` webhook event that reports outgoing SMS composed **on the device itself** (in the phone's own messaging app), so an integration can see both sides of a conversation instead of only the inbound half.

## Approach

`SmsContentObserver` already registers on the whole `content://sms` tree with `notifyForDescendants=true`, so writes to the sent box already trigger `onChange` today — the class simply only ever queried the inbox. This PR generalises `queryMaxSmsId` to take a URI and adds a parallel `processNewSentMessages()` scan of `Telephony.Sms.Sent.CONTENT_URI`, using the same high-water-mark technique with its own separate marker.

A few deliberate decisions, happy to change any of them:

- **Off by default.** `ReceiverSettings.deviceSentEnabled` defaults to `false`, so existing installations get no behaviour change and no extra webhook traffic. There is no UI toggle in this PR — I did not want to guess at your settings-screen conventions; say the word and I will add one.
- **Emitted directly, not via `ReceiverService.process`.** That path persists rows as *incoming* messages and dedups against them, which would be wrong for outgoing ones.
- **Uses `Telephony.Sms.DATE`, not `DATE_SENT`.** For locally composed messages `DATE_SENT` is commonly `0`.
- **Separate high-water marker** (`state.sent_sms_last_processed_id`), initialised to the current max on first enable so the existing sent box is not replayed.
- **No new permission.** `READ_SMS` already covers the sent box.
- `messageId` is prefixed (`sent:$id`) to keep it from colliding with gateway-generated message IDs.

## Payload

```json
{
  "event": "sms:device-sent",
  "payload": {
    "messageId": "sent:1234",
    "phoneNumber": "+15551234567",
    "sender": "+15559876543",
    "recipient": "+15551234567",
    "simNumber": 1,
    "message": "…",
    "sentAt": "2026-08-17T10:00:00.000Z"
  }
}
```

`sender` is this device, `recipient` is the remote party — the outgoing direction. It follows the existing `SmsEventPayload` shape, so `phoneNumber` is populated for backwards compatibility.

## ⚠️ Not built, not tested on a device

I want to be straightforward about this rather than have you find out during review: **I do not have a JDK or the Android SDK available in the environment where I wrote this, so the code has never been compiled and has never run on a phone.** Please treat it as a well-researched proposal rather than verified work.

What I did verify, statically against this codebase:

- all four newly imported classes exist (`SubscriptionsHelper`, `WebHooksService`, `WebHookEvent`, `SmsEventPayload`)
- the helper signatures match the call sites: `SubscriptionsHelper.getSimSlotIndex(context: Context, subscriptionId: Int): Int?` and `getPhoneNumber(context: Context, simSlotIndex: Int): String?`
- `WebHooksService.emit(context: Context, event: WebHookEvent, payload: Any)` matches how it is called
- `WebHooksService` is registered via `singleOf` in `webhooksModule`, and `ReceiverSettings` / `StateStorage` are registered in `modules/settings/Module.kt`, so the Koin injections resolve
- the new enum constant and payload subclass follow the existing patterns in their files

What I could **not** verify, and where I would look first:

- that it compiles
- runtime behaviour on a real device — in particular whether the sent-box row is written early enough (some OEM messaging apps insert into `content://sms/queued` or `outbox` first and move the row to `sent` later, which could mean the row is seen with a `_id` you have already passed, or seen twice)
- multi-SIM behaviour of the `SUBSCRIPTION_ID` → slot mapping on the sent box
- interaction with the default-SMS-app role on newer Android versions

If you would rather take just the idea and implement it yourself, that is completely fine — the issue stands on its own and I will not be offended.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds opt-in monitoring of Android's sent SMS provider and emits a new `sms:device-sent` webhook payload for outgoing messages.

- Adds receiver settings and a separate persistent sent-box high-water mark.
- Scans new sent-provider rows and queues webhook deliveries with SIM and addressing metadata.
- Extends the webhook event/payload vocabulary and documents the new event.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until gateway-originated sends are excluded from the device-sent event and the coupled server accepts the new webhook type.

The observer currently classifies all sent-provider rows as device-composed, duplicating gateway-send notifications, while the cloud configuration server rejects the new event and therefore cannot provision matching webhook definitions.

**Files Needing Attention:** app/src/main/java/me/capcom/smsgateway/modules/receiver/SmsContentObserver.kt; app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/receiver/SmsContentObserver.kt | Adds sent-box scanning and direct webhook emission, but does not distinguish device-composed messages from gateway-originated sends. |
| app/src/main/java/me/capcom/smsgateway/modules/receiver/ReceiverSettings.kt | Adds a disabled-by-default persistent feature flag; the intentionally omitted normal configuration surface limits practical enablement. |
| app/src/main/java/me/capcom/smsgateway/modules/receiver/StateStorage.kt | Adds an independent persistent high-water mark for sent SMS provider rows. |
| app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt | Adds the Android event value without updating the coupled server vocabulary that validates cloud webhook definitions. |
| app/src/main/java/me/capcom/smsgateway/modules/webhooks/payload/SmsEventPayload.kt | Adds an outgoing-device payload with recipient-backed compatibility phone number and sent timestamp. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Android sent SMS provider] --> B[SmsContentObserver]
    B --> C{deviceSentEnabled}
    C -- false --> D[Skip]
    C -- true --> E[Query rows above sent high-water mark]
    E --> F[Build SmsDeviceSent payload]
    F --> G[WebHooksService]
    G --> H[Durable webhook queue]
    H --> I[Configured endpoint]
    J[Gateway SmsManager send] --> A
    J --> K[Sent-result event]
    K --> L[sms:sent webhook]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
app/src/main/java/me/capcom/smsgateway/modules/receiver/SmsContentObserver.kt:246-248
**Sent rows misclassify gateway messages**

When Android persists a gateway/API send in `Telephony.Sms.Sent`, this query selects it without checking its origin and emits `sms:device-sent` in addition to the existing `sms:sent` event, causing duplicate and misclassified webhook traffic for the same message.

### Issue 2
app/src/main/java/me/capcom/smsgateway/modules/webhooks/domain/WebHookEvent.kt:40-42
**Cloud rejects the new event**

When a cloud webhook is configured for `sms:device-sent`, the related server's [webhook validation](https://github.com/android-sms-gateway/server/blob/HEAD/internal/sms-gateway/modules/webhooks/service.go) rejects the value because its fixed event vocabulary does not contain it, so cloud users cannot create a matching subscriber for these emissions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(receiver): add sms:device-sent webh..."](https://github.com/capcom6/android-sms-gateway/commit/e126c3d4b47a86cb06dd47e2f96ee49430a8bf6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54052155)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Inbound messaging](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/inbound-messaging.md)
- Knowledge Base — [Webhook delivery](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/webhook-delivery.md)
- Knowledge Base — [Settings and preferences](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/settings-and-preferences.md)
- Knowledge Base — [Event bus and orchestration](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/capcom6/android-sms-gateway/-/docs/event-bus-and-orchestration.md)
</details>

<!-- /greptile_comment -->
---

### Update after review

**Cloud mode needs a companion change.** The webhook event vocabulary lives in `client-go/smsgateway/domain_webhooks.go` (`webhookEventTypes`), which the server validates against via `IsValidWebhookEvent`. So as it stands this event works for **locally registered** webhooks — registration through the on-device `/webhooks` API goes via the Kotlin enum — but a cloud user cannot register a subscriber for `sms:device-sent` until the constant is added to `client-go` and the server bumps the dependency. I did not want to open PRs across your other repositories uninvited; happy to send that one if you want it.

**Guard against OEM echo** (69fd5ac). The gateway never writes to the SMS provider and `SmsManager.sendTextMessage` does not persist on stock Android, so an API send should not reach the sent box on AOSP — but some OEM builds mirror sent messages regardless of the sending app, which would double-report them. The observer now checks its own message store first. It is a heuristic (trailing-digit recipient match, content compared only when unencrypted, 5 minute window) and it fails open, so the worst case is a duplicate event rather than a dropped message.

Both commits remain uncompiled and untested on a device, as noted above.
