### PR TITLE
[localserver] expose `createdAt` field

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,40 @@
+# Environment Configuration Template for SMS Gateway for Android
+#
+# This project is an Android application: runtime configuration is done
+# in-app. However, release signing reads credentials from environment
+# variables when building with Gradle (app/build.gradle).
+#
+# Debug builds do not need any of these variables. They are required only
+# when building the signed `release` or `insecure` build types locally.
+#
+# Usage: export the variables in your shell or set them in your IDE's run
+# configuration before running ./gradlew assembleRelease / assembleInsecure.
+# The keystore file itself must be present at the project root (keystore.jks).
+
+# =============================================================================
+# SIGNING CONFIGURATION
+# =============================================================================
+
+# Keystore store password
+# Purpose: Password of the signing keystore file (keystore.jks) referenced by
+# the release signing config
+# Format: String
+# Example: change-me
+SIGNING_STORE_PASSWORD=change-me
+
+# Keystore key alias
+# Purpose: Alias of the signing key inside the keystore that signs the APK/AAB
+# Format: String
+# Example: my-key-alias
+SIGNING_KEY_ALIAS=my-key-alias
+
+# Keystore key password
+# Purpose: Password of the private key identified by SIGNING_KEY_ALIAS
+# Format: String
+# Example: change-me
+SIGNING_KEY_PASSWORD=change-me
+
+# NOTE: In GitHub Actions CI (release-build.yml, build-apk.yml) these values
+# are supplied as repository secrets (SIGNING_STORE_PASSWORD,
+# SIGNING_KEY_ALIAS, SIGNING_KEY_PASSWORD, SIGNING_KEY_STORE_BASE64,
+# GOOGLE_SERVICES_JSON) and not read from a .env file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Expose `createdAt` field in local server messages endpoint [6b4cc62]
+
+## [v1.75.0] - 2026-09-04
+
+### Added
+- Webhook queue diagnostics list screen [3ce35144]
+
+### Changed
+- Update translations [956f9d6]
+
+## [v1.74.1] - 2026-09-02
+
+### Changed
+- Replace scheduled worker on new immediate message [b179de8]
+
+## [v1.74.0] - 2026-08-31
+
+### Added
+- MMS sending support [1b6c76b]
+
+### Changed
+- Support legacy date formats [c90101d]
+
+## [v1.73.0] - 2026-08-27
+
+### Added
+- Allow to filter messages by state and type [71bf841]
+
+### Changed
+- Update translations [f4f1ea5]
+
+## [v1.72.1] - 2026-08-25
+
+### Added
+- New API for resolving phone numbers [0657438]
+
+## [v1.72.0] - 2026-08-21
+
+### Changed
+- Add sort param for messages requests [9f65754]
+
+## [v1.71.1] - 2026-08-20
+
+### Changed
+- Use scheduling instead of polling for webhooks worker [e4acf42]
+
+## [v1.71.0] - 2026-08-18
+
+### Added
+- Batch webhooks support [05351ce]
+
+### Maintenance
+- Update swagger, readme, and changelog [9c95ca2e]
+
+## [v1.70.4] - 2026-08-14
+
+### Fixed
+- Message queue no longer gets stuck when there is a scheduled message [5e1def4]
+
 ## [v1.70.3] - 2026-08-11
 
 ### Changed
@@ -1148,7 +1210,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDK version check for SmsManager compatibility [4b7e593]
 
 
-[Unreleased]: https://github.com/capcom6/android-sms-gateway/compare/v1.66.1...HEAD
+[Unreleased]: https://github.com/capcom6/android-sms-gateway/compare/v1.75.0...HEAD
 [v1.0.0]: https://github.com/capcom6/android-sms-gateway/releases/tag/v1.0.0
 [v1.1.0]: https://github.com/capcom6/android-sms-gateway/compare/v1.0.0...v1.1.0
 [v1.1.1]: https://github.com/capcom6/android-sms-gateway/compare/v1.1.0...v1.1.1

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ SMS Gateway turns your Android smartphone into an SMS gateway. It's a lightweigh
 - 📦 **Batch webhook events:** Receive batched webhook deliveries when multiple messages arrive at once, reducing the number of requests.
 - 🛑 **Cancel pending messages:** Cancel queued messages before they are sent.
 - ⏳ **Send rate limiting:** Restrict the number of messages sent per period (e.g., per 30 minutes) to avoid operator throttling.
+- 🔍 **Message filtering:** Filter messages by state (Pending, Sent, Delivered, Failed, Cancelled) and type (SMS, Data SMS, MMS).
 - 🖼️ **Send and receive MMS with payloads:** Send images, audio, video, and other media as MMS with inline or URL-referenced attachments. Received attachments are persisted locally and exposed via the API. See [`docs/MMS.md`](docs/MMS.md).
 
 🔒 Security and Privacy:
@@ -116,6 +117,7 @@ SMS Gateway turns your Android smartphone into an SMS gateway. It's a lightweigh
 🔌 Integration:
 
 - 🪝 **Webhooks:** Set up [webhooks](https://docs.sms-gate.app/features/webhooks/) to be triggered on specified events.
+- 📋 **Webhook queue diagnostics:** Inspect webhook queue entries with their status, retry count, last error, and next attempt time.
 
 ### Ideal For
 
@@ -330,7 +332,7 @@ For cloud mode the process is similar, simply change the URL to https://api.sms-
 - [x] Add functionality to modify user credentials.
 - [x] Introduce option to adjust the local server port.
 - [x] Send notifications to an external server when the status of a message changes.
-- [ ] Incorporate scheduling capabilities for dispatching messages at specific times.
+- [x] Incorporate scheduling capabilities for dispatching messages at specific times.
 - [ ] Implement region-based restrictions to prevent international SMS.
 - [x] Provide an API endpoint to retrieve the list of available SIM cards on the device.
 - [x] Include detailed error messages in responses and logs.

--- a/app/src/main/assets/api/swagger.json
+++ b/app/src/main/assets/api/swagger.json
@@ -481,9 +481,15 @@
             ],
             "description": "Present only when `includeContent=true` and the message type is text.",
             "type": "object"
+          },
+          "createdAt": {
+            "description": "Message creation time",
+            "format": "date-time",
+            "type": "string"
           }
         },
         "required": [
+          "createdAt",
           "deviceId",
           "id",
           "recipients",
@@ -1084,9 +1090,15 @@
             ],
             "description": "Present only when `includeContent=true` and the message type is text.",
             "type": "object"
+          },
+          "createdAt": {
+            "description": "Message creation time",
+            "format": "date-time",
+            "type": "string"
           }
         },
         "required": [
+          "createdAt",
           "deviceId",
           "id",
           "recipients",

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/Message.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/Message.kt
@@ -10,6 +10,7 @@ open class Message(
     val isHashed: Boolean,
     val isEncrypted: Boolean,
     val scheduleAt: Date?,
+    val createdAt: Date,
     val textMessage: TextMessage?,
     val dataMessage: DataMessage?,
     val mmsMessage: MmsMessage?,

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
@@ -298,8 +298,9 @@ class MessagesRoutes(
             }
         }
     }
+}
 
-    private fun MessageWithRecipients.toDomain(
+internal fun MessageWithRecipients.toDomain(
         deviceId: String,
         includeContent: Boolean = false
     ): me.capcom.smsgateway.modules.localserver.domain.messages.Message {
@@ -307,6 +308,7 @@ class MessagesRoutes(
             id = message.id,
             deviceId = deviceId,
             state = message.state,
+            createdAt = Date(message.createdAt),
             isHashed = false,
             isEncrypted = message.isEncrypted,
             textMessage = when (includeContent) {
@@ -357,4 +359,3 @@ class MessagesRoutes(
             scheduleAt = message.scheduleAt,
         )
     }
-}

--- a/app/src/test/java/me/capcom/smsgateway/modules/localserver/domain/messages/MessageCreatedAtTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/localserver/domain/messages/MessageCreatedAtTest.kt
@@ -1,0 +1,88 @@
+package me.capcom.smsgateway.modules.localserver.domain.messages
+
+import me.capcom.smsgateway.data.entities.MessageWithRecipients
+import me.capcom.smsgateway.domain.EntitySource
+import me.capcom.smsgateway.domain.ProcessingState
+import me.capcom.smsgateway.modules.localserver.routes.toDomain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.Date
+import me.capcom.smsgateway.data.entities.Message as EntityMessage
+
+class MessageCreatedAtTest {
+
+    private fun message(createdAt: Date): Message = Message(
+        id = "1",
+        deviceId = "device-1",
+        state = ProcessingState.Pending,
+        isHashed = false,
+        isEncrypted = false,
+        scheduleAt = null,
+        createdAt = createdAt,
+        textMessage = null,
+        dataMessage = null,
+        mmsMessage = null,
+        hashedMessage = null,
+        recipients = emptyList(),
+        states = emptyMap(),
+    )
+
+    @Test
+    fun preservesCreatedAt() {
+        val expected = Date(1700000000000L)
+
+        val actual = message(expected).createdAt
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun convertsFromEpochMillisLikeToDomain() {
+        // epoch start, typical (2023), year 2100 - matches Date(Long) used in toDomain
+        val values = listOf(0L, 1700000000000L, 4102444800000L)
+
+        values.forEach { epochMillis ->
+            val actual = message(Date(epochMillis)).createdAt
+
+            assertEquals("epochMillis=$epochMillis", epochMillis, actual.time)
+        }
+    }
+
+    @Test
+    fun createdAtIsIndependentFromScheduleAt() {
+        val createdAt = Date(1700000000000L)
+
+        val actual = message(createdAt)
+
+        assertEquals(createdAt, actual.createdAt)
+        assertNull("scheduleAt must remain null", actual.scheduleAt)
+    }
+
+    @Test
+    fun toDomainMapsEpochMillisToDate() {
+        val entity = EntityMessage(
+            id = "1",
+            withDeliveryReport = false,
+            simNumber = null,
+            validUntil = null,
+            scheduleAt = null,
+            isEncrypted = false,
+            skipPhoneValidation = false,
+            priority = 0,
+            source = EntitySource.Local,
+            content = "",
+            createdAt = 1700000000000L,
+        )
+        val mwr = MessageWithRecipients(
+            message = entity,
+            recipients = emptyList(),
+            states = emptyList(),
+        )
+
+        val result = mwr.toDomain(deviceId = "device-1", includeContent = false)
+
+        assertEquals(1700000000000L, result.createdAt.time)
+        assertEquals(Date(1700000000000L), result.createdAt)
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR exposes each local-server message’s creation timestamp and aligns the bundled API contract with the runtime response.
- Adds non-null `createdAt` mapping from persisted epoch milliseconds to the local-server message model.
- Documents `createdAt` in both applicable OpenAPI response schemas.
- Tests the production conversion path for the new field.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/localserver/domain/messages/Message.kt | Adds the non-null creation timestamp to the local-server message response model. |
| app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt | Maps persisted creation time into the response model and exposes the production mapper for testing. |
| app/src/main/assets/api/swagger.json | Adds required date-time metadata to both message-response schemas, resolving the prior contract omission. |
| app/src/test/java/me/capcom/smsgateway/modules/localserver/domain/messages/MessageCreatedAtTest.kt | Now exercises the production conversion and verifies preservation of the persisted epoch timestamp. |

</details>

<sub>Reviews (9): Last reviewed commit: ["\[docs\] update readme, changelog, etc."](https://github.com/capcom6/android-sms-gateway/commit/efae3258404aab6d0db80af212915b64b90c148c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58105868)</sub>

<!-- /greptile_comment -->