### PR TITLE
[receiver] add "not exported" flag for registration on API level 33+

### DIFF
--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import android.provider.Telephony.Sms.Intents
 import android.util.Log
 import me.capcom.smsgateway.helpers.SubscriptionsHelper
@@ -77,20 +78,22 @@ class MessagesReceiver : BroadcastReceiver(), KoinComponent {
             val textFilter = IntentFilter().apply {
                 addAction(Intents.SMS_RECEIVED_ACTION)
             }
-            appContext.registerReceiver(
-                INSTANCE,
-                textFilter
-            )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                appContext.registerReceiver(INSTANCE, textFilter, Context.RECEIVER_EXPORTED)
+            } else {
+                appContext.registerReceiver(INSTANCE, textFilter)
+            }
 
             val dataFilter = IntentFilter().apply {
                 addAction(Intents.DATA_SMS_RECEIVED_ACTION)
                 addDataScheme("sms")
                 addDataAuthority("*", "53739")
             }
-            appContext.registerReceiver(
-                INSTANCE,
-                dataFilter
-            )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                appContext.registerReceiver(INSTANCE, dataFilter, Context.RECEIVER_EXPORTED)
+            } else {
+                appContext.registerReceiver(INSTANCE, dataFilter)
+            }
         }
 
         fun unregister(context: Context) {

--- a/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import android.os.Bundle
 import android.provider.Telephony
 import android.util.Log
@@ -101,10 +102,11 @@ class MmsReceiver : BroadcastReceiver(), KoinComponent {
                 addAction(Telephony.Sms.Intents.WAP_PUSH_RECEIVED_ACTION)
                 addDataType("application/vnd.wap.mms-message")
             }
-            appContext.registerReceiver(
-                INSTANCE,
-                filter
-            )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                appContext.registerReceiver(INSTANCE, filter, Context.RECEIVER_EXPORTED)
+            } else {
+                appContext.registerReceiver(INSTANCE, filter)
+            }
         }
 
         fun unregister(context: Context) {

--- a/app/src/main/java/me/capcom/smsgateway/receivers/EventsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/receivers/EventsReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
@@ -58,13 +59,16 @@ class EventsReceiver : BroadcastReceiver(), KoinComponent {
         }
 
         fun register(context: Context) {
-            context.registerReceiver(
-                getInstance(),
-                IntentFilter(ACTION_SENT).apply {
-                    addAction(ACTION_DELIVERED)
+            val filter = IntentFilter(ACTION_SENT)
+                .apply { 
+                    addAction(ACTION_DELIVERED) 
                     addAction(ACTION_MMS_SENT)
                 }
-            )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.registerReceiver(getInstance(), filter, Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                context.registerReceiver(getInstance(), filter)
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates dynamic broadcast-receiver registration flags for Android 13 and later.
- Registers SMS, data-SMS, and MMS telephony receivers as exported.
- Registers the application’s sent and delivered event receiver as not exported.
- Retains legacy registration behavior on earlier Android versions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the scope of the follow-up review.

The current Android 13+ registrations mark all telephony broadcast receivers as exported, so the previously reported SMS, data-SMS, and MMS delivery failure no longer remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/java/me/capcom/smsgateway/modules/receiver/MessagesReceiver.kt | Uses the exported registration overload on Android 13+ for SMS and data-SMS telephony broadcasts, resolving the previously reported delivery issue. |
| app/src/main/java/me/capcom/smsgateway/modules/receiver/MmsReceiver.kt | Uses the exported registration overload on Android 13+ for MMS WAP-push broadcasts, resolving the previously reported delivery issue. |
| app/src/main/java/me/capcom/smsgateway/receivers/EventsReceiver.kt | Uses a not-exported dynamic registration for application status actions on Android 13+. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Register broadcast receivers] --> B{Android 13 or later?}
  B -- No --> C[Use legacy registerReceiver overload]
  B -- Yes --> D[Telephony actions: RECEIVER_EXPORTED]
  B -- Yes --> E[Internal status actions: RECEIVER_NOT_EXPORTED]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["\[receiver\] add &quot;not exported&quot; flag for r..."](https://github.com/capcom6/android-sms-gateway/commit/bf13779752acac232e86fd2b17a0d370e9b1f755) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58472001)</sub>

<!-- /greptile_comment -->