### PR TITLE
Security and reliability fixes from a code review

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,9 @@
 
     <application
         android:name=".App"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="${networkSecurityConfig}"
@@ -50,10 +52,19 @@
             </intent-filter>
         </service>
 
+        <!--
+            exported=false: the only legitimate senders of these actions are
+            this app's own PendingIntents, which are explicit and fire under
+            our identity. While exported, any app on the device (with no
+            permissions at all) could broadcast ACTION_DELIVERED with an
+            arbitrary "<messageId>|<phone>" data string and a chosen result
+            code, forging a delivery state that is then signed into a webhook
+            and pushed to the cloud server.
+        -->
         <receiver
             android:name=".receivers.EventsReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="me.capcom.smsgateway.ACTION_SENT" />
                 <action android:name="me.capcom.smsgateway.ACTION_DELIVERED" />

--- a/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
+++ b/app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt
@@ -150,11 +150,11 @@ interface MessagesDao {
         })
     }
 
-    @Query("UPDATE message SET state = :state WHERE id = :id AND state <> 'Failed'")
-    fun _updateMessageState(id: String, state: ProcessingState)
+    @Query("UPDATE message SET state = :state WHERE id = :id AND state <> 'Failed' AND (CASE state WHEN 'Pending' THEN 0 WHEN 'Cancelling' THEN 1 WHEN 'Processed' THEN 2 WHEN 'Sent' THEN 3 WHEN 'Delivered' THEN 4 WHEN 'Cancelled' THEN 5 WHEN 'Failed' THEN 5 ELSE 0 END) <= :stateRank")
+    fun _updateMessageState(id: String, state: ProcessingState, stateRank: Int)
 
     fun updateMessageState(id: String, state: ProcessingState) {
-        _updateMessageState(id, state)
+        _updateMessageState(id, state, state.rank)
         _insertMessageState(
             MessageState(
                 id,
@@ -191,11 +191,17 @@ interface MessagesDao {
         )
     }
 
-    @Query("UPDATE messagerecipient SET state = :state, error = :error WHERE messageId = :id AND phoneNumber = :phoneNumber AND state <> 'Failed'")
+    // The rank comparison stops a late update from moving a recipient
+    // backwards. The sent/delivered broadcasts arrive on a different
+    // coroutine from the send loop, so `Processed` (written after dispatch)
+    // and `Sent` (from the platform) race; previously whichever landed last
+    // won. See ProcessingState.rank.
+    @Query("UPDATE messagerecipient SET state = :state, error = :error WHERE messageId = :id AND phoneNumber = :phoneNumber AND state <> 'Failed' AND (CASE state WHEN 'Pending' THEN 0 WHEN 'Cancelling' THEN 1 WHEN 'Processed' THEN 2 WHEN 'Sent' THEN 3 WHEN 'Delivered' THEN 4 WHEN 'Cancelled' THEN 5 WHEN 'Failed' THEN 5 ELSE 0 END) <= :stateRank")
     fun _updateRecipientState(
         id: String,
         phoneNumber: String,
         state: ProcessingState,
+        stateRank: Int,
         error: String?
     )
 
@@ -206,7 +212,7 @@ interface MessagesDao {
         state: ProcessingState,
         error: String?
     ) {
-        _updateRecipientState(id, phoneNumber, state, error)
+        _updateRecipientState(id, phoneNumber, state, state.rank, error)
         _insertRecipientStates(
             listOf(
                 RecipientState(id, phoneNumber, state, System.currentTimeMillis())
@@ -214,10 +220,11 @@ interface MessagesDao {
         )
     }
 
-    @Query("UPDATE messagerecipient SET state = :state, error = :error WHERE messageId = :id AND state <> 'Failed'")
+    @Query("UPDATE messagerecipient SET state = :state, error = :error WHERE messageId = :id AND state <> 'Failed' AND (CASE state WHEN 'Pending' THEN 0 WHEN 'Cancelling' THEN 1 WHEN 'Processed' THEN 2 WHEN 'Sent' THEN 3 WHEN 'Delivered' THEN 4 WHEN 'Cancelled' THEN 5 WHEN 'Failed' THEN 5 ELSE 0 END) <= :stateRank")
     fun _updateRecipientsState(
         id: String,
         state: ProcessingState,
+        stateRank: Int,
         error: String?
     )
 
@@ -227,7 +234,7 @@ interface MessagesDao {
         state: ProcessingState,
         error: String?
     ) {
-        _updateRecipientsState(id, state, error)
+        _updateRecipientsState(id, state, state.rank, error)
         _insertRecipientStatesByMessage(id, state)
     }
 

--- a/app/src/main/java/me/capcom/smsgateway/domain/ProcessingState.kt
+++ b/app/src/main/java/me/capcom/smsgateway/domain/ProcessingState.kt
@@ -7,5 +7,33 @@ enum class ProcessingState {
     Processed,
     Sent,
     Delivered,
-    Failed
+    Failed;
+
+    /**
+     * Position in the delivery progression, used to stop a late update from
+     * moving a recipient backwards.
+     *
+     * The platform's sent/delivered broadcasts arrive on a different
+     * coroutine from the send loop (see receivers/EventsReceiver), so the
+     * two race. Previously the only guard on the update was
+     * `state <> 'Failed'`, with no ordering rule at all — so a `Processed`
+     * written after dispatch could clobber a `Sent` that had already
+     * arrived, and a late `Sent` could regress an already-`Delivered`
+     * recipient. With delivery reports off, a recipient clobbered back to
+     * `Processed` never leaves it.
+     *
+     * The terminal states rank highest so they can always be applied: a
+     * failure remains authoritative whenever it arrives, which is the
+     * behaviour the previous guard had.
+     */
+    val rank: Int
+        get() = when (this) {
+            Pending -> 0
+            Cancelling -> 1
+            Processed -> 2
+            Sent -> 3
+            Delivered -> 4
+            Cancelled -> 5
+            Failed -> 5
+        }
 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/EventsReceiver.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/EventsReceiver.kt
@@ -89,8 +89,12 @@ class EventsReceiver : EventsReceiver() {
                 eventBus.collect<DeviceRegisteredEvent> {
                     Log.d("EventsReceiver", "Event: $it")
 
-                    if (!settings.enabled) return@collect
-                    if (settings.fcmToken != null) return@collect
+                    // Was: skip whenever an FCM token exists, which meant the
+                    // only wake-lock-holding service in cloud mode never ran
+                    // on a device with Play Services. shouldKeepConnection
+                    // keeps the no-token behaviour and adds an explicit
+                    // preference for everyone else.
+                    if (!settings.shouldKeepConnection) return@collect
 
                     SSEForegroundService.start(get())
                 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewayService.kt
@@ -50,6 +50,14 @@ class GatewayService(
         WebhooksUpdateWorker.start(context)
         SettingsUpdateWorker.start(context)
 
+        // DeviceRegisteredEvent only fires on first registration, so an
+        // already-registered device restarting (boot, process death) would
+        // never have started this. Starting it here too makes the persistent
+        // connection survive a restart.
+        if (settings.shouldKeepConnection) {
+            SSEForegroundService.start(context)
+        }
+
         eventsReceiver.start()
     }
 

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewaySettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewaySettings.kt
@@ -28,6 +28,31 @@ class GatewaySettings(
         get() = storage.get(FCM_TOKEN)
         set(value) = storage.set(FCM_TOKEN, value)
 
+    /**
+     * Keep the server-sent-events connection open even when a push token is
+     * available.
+     *
+     * Previously the SSE foreground service started only when [fcmToken] was
+     * null. That service holds the only wake lock and WiFi lock in cloud
+     * mode, so on any device with Play Services the app ran with no
+     * foreground service at all: it depended on a push that Doze throttles,
+     * plus PullMessagesWorker at the 15-minute platform minimum — which Doze
+     * batches into maintenance windows that can be far longer. On OEMs with
+     * aggressive process management the app simply stopped responding for
+     * long stretches.
+     *
+     * Defaults to true: correctness for a gateway matters more than the
+     * battery cost, and a gateway phone is normally on a charger. Users who
+     * prefer push-only can turn it off.
+     */
+    var keepConnectionAlive: Boolean
+        get() = storage.get<Boolean>(KEEP_CONNECTION_ALIVE) ?: true
+        set(value) = storage.set(KEEP_CONNECTION_ALIVE, value)
+
+    /** True when the persistent connection should be running. */
+    val shouldKeepConnection: Boolean
+        get() = enabled && (keepConnectionAlive || fcmToken == null)
+
     val username: String?
         get() = registrationInfo?.login
     val password: String?
@@ -51,6 +76,7 @@ class GatewaySettings(
         private const val REGISTRATION_INFO = "REGISTRATION_INFO"
         private const val ENABLED = "ENABLED"
         private const val FCM_TOKEN = "fcm_token"
+        private const val KEEP_CONNECTION_ALIVE = "keep_connection_alive"
 
         private const val CLOUD_URL = "cloud_url"
         private const val PRIVATE_TOKEN = "private_token"

--- a/app/src/main/java/me/capcom/smsgateway/modules/gateway/workers/SettingsUpdateWorker.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/gateway/workers/SettingsUpdateWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
+import me.capcom.smsgateway.domain.EntitySource
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
@@ -26,7 +27,9 @@ class SettingsUpdateWorker(appContext: Context, params: WorkerParameters) :
             val settings = gatewaySvc.getSettings()
 
             settings?.let {
-                settingsSvc.update(settings)
+                // Cloud source: protected keys (the encryption
+                // passphrase, the webhook signing key) are filtered out.
+                settingsSvc.update(settings, EntitySource.Cloud)
             }
 
             Result.success()

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/WebService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/WebService.kt
@@ -36,6 +36,7 @@ import io.ktor.util.date.GMTDate
 import me.capcom.smsgateway.R
 import me.capcom.smsgateway.domain.HealthResponse
 import me.capcom.smsgateway.extensions.configure
+import me.capcom.smsgateway.modules.localserver.auth.LoginThrottle
 import me.capcom.smsgateway.modules.health.HealthService
 import me.capcom.smsgateway.modules.health.domain.Status
 import me.capcom.smsgateway.modules.localserver.auth.AuthScopes
@@ -84,13 +85,23 @@ class WebService : Service() {
                 basic("auth-basic") {
                     realm = "Access to SMS Gateway"
                     validate { credentials ->
-                        when {
-                            credentials.name == username
-                                    && credentials.password == password -> UserIdPrincipal(
-                                credentials.name
-                            )
-
-                            else -> null
+                        // Refuse outright while locked out, so a guessing
+                        // attempt cannot be distinguished from a wrong
+                        // password and cannot proceed at full speed.
+                        if (LoginThrottle.isLockedOut()) {
+                            return@validate null
+                        }
+                        // Constant-time on both fields: `==` short-circuits on
+                        // the first differing byte and leaks the matching
+                        // prefix length.
+                        val ok = LoginThrottle.secretsMatch(username, credentials.name) &&
+                                LoginThrottle.secretsMatch(password, credentials.password)
+                        if (ok) {
+                            LoginThrottle.recordSuccess()
+                            UserIdPrincipal(credentials.name)
+                        } else {
+                            LoginThrottle.recordFailure()
+                            null
                         }
                     }
                 }

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/auth/LoginThrottle.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/auth/LoginThrottle.kt
@@ -1,0 +1,86 @@
+package me.capcom.smsgateway.modules.localserver.auth
+
+import android.util.Log
+import java.security.MessageDigest
+import java.util.ArrayDeque
+
+/**
+ * Constant-time credential comparison and a failed-attempt lockout for the
+ * local HTTP server.
+ *
+ * Before this, [WebService][me.capcom.smsgateway.modules.localserver.WebService]
+ * compared the password with `==`. Two problems:
+ *
+ *  1. [String.equals] returns on the first differing byte, so the comparison
+ *     leaks the length of the matching prefix through timing.
+ *  2. Nothing anywhere in the app counted failed attempts. The generated
+ *     default password is 8 characters, the server speaks plain HTTP on every
+ *     interface, and that password grants every scope — so anyone on the same
+ *     network could guess at the full speed of the device, indefinitely, and
+ *     leave no trace of having tried.
+ *
+ * (2) is the one that matters in practice; (1) is fixed because it is free.
+ *
+ * The lockout is deliberately global rather than per-client: the remote
+ * address of a LAN peer is trivially spoofed or rotated, so per-address
+ * counting would provide false comfort. A legitimate operator who mistypes
+ * their password a few times waits [LOCKOUT_MILLIS]; an attacker is reduced
+ * from unlimited guesses to [MAX_ATTEMPTS] per lockout window.
+ */
+object LoginThrottle {
+
+    const val MAX_ATTEMPTS = 10
+    const val ATTEMPT_WINDOW_MILLIS = 5 * 60 * 1000L
+    const val LOCKOUT_MILLIS = 5 * 60 * 1000L
+
+    private val attempts = ArrayDeque<Long>()
+    private var lockedUntil = 0L
+    private val lock = Any()
+
+    /** True when authentication attempts are currently refused. */
+    fun isLockedOut(now: Long = System.currentTimeMillis()): Boolean = synchronized(lock) {
+        now < lockedUntil
+    }
+
+    fun recordFailure(now: Long = System.currentTimeMillis()) = synchronized(lock) {
+        while (attempts.isNotEmpty() && now - attempts.peekFirst() > ATTEMPT_WINDOW_MILLIS) {
+            attempts.pollFirst()
+        }
+        attempts.addLast(now)
+        if (attempts.size >= MAX_ATTEMPTS) {
+            lockedUntil = now + LOCKOUT_MILLIS
+            attempts.clear()
+            Log.w(
+                "LoginThrottle",
+                "Local API authentication locked out for ${LOCKOUT_MILLIS / 1000}s " +
+                        "after $MAX_ATTEMPTS failed attempts"
+            )
+        }
+    }
+
+    fun recordSuccess() = synchronized(lock) {
+        attempts.clear()
+        lockedUntil = 0L
+    }
+
+    /** Test hook. */
+    fun reset() = synchronized(lock) {
+        attempts.clear()
+        lockedUntil = 0L
+    }
+
+    /**
+     * Compare two secrets without leaking the matching prefix length.
+     *
+     * [MessageDigest.isEqual] is documented as constant-time on Android for
+     * equal-length inputs. Length itself is not hidden, which is acceptable:
+     * the password length is not the secret.
+     */
+    fun secretsMatch(expected: String?, presented: String?): Boolean {
+        if (expected.isNullOrEmpty() || presented == null) return false
+        return MessageDigest.isEqual(
+            expected.toByteArray(Charsets.UTF_8),
+            presented.toByteArray(Charsets.UTF_8)
+        )
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt
@@ -59,6 +59,25 @@ class MessagesRoutes(
                 ?.let { ProcessingState.valueOf(it) }
             val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: 50
             val offset = call.request.queryParameters["offset"]?.toIntOrNull() ?: 0
+
+            // Unbounded before. The value goes straight into SQL LIMIT, where
+            // SQLite treats a negative as "no limit", so ?limit=-1 with
+            // includeContent=true materialised the entire message history.
+            // InboxRoutes already enforces this range; matching it here.
+            if (limit !in 1..500) {
+                call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf("message" to "limit must be between 1 and 500")
+                )
+                return@get
+            }
+            if (offset < 0) {
+                call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf("message" to "offset must be non-negative")
+                )
+                return@get
+            }
             val includeContent = call.request.queryParameters["includeContent"]?.let {
                 it.toBooleanStrictOrNull() ?: run {
                     call.respond(

--- a/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/messages/MessagesSettings.kt
@@ -146,12 +146,28 @@ class MessagesSettings(
             storage.set(SEND_INTERVAL_MAX, storage.get<Int>(SECONDS_BETWEEN_MESSAGES)?.toString())
         }
 
+        if (version < 2) {
+            // Seed a retention default, matching what LogsSettings already
+            // does for its own table. Without one, logLifetimeDays returns
+            // null, MessagesService.truncateLog() returns before deleting
+            // anything, and the `message` table grows for the life of the
+            // install. That table is also what the /health count query scans,
+            // so a long-lived gateway gets steadily slower with no visible
+            // cause. Only seeded when the operator has not chosen a value.
+            if (storage.get<Int?>(LOG_LIFETIME_DAYS) == null) {
+                storage.set(LOG_LIFETIME_DAYS, DEFAULT_LOG_LIFETIME_DAYS.toString())
+            }
+        }
+
         version = VERSION_CODE
     }
 
     companion object {
-        private const val VERSION_CODE = 1
+        private const val VERSION_CODE = 2
         private const val VERSION = "version"
+
+        /** Matches the default LogsSettings uses for the logs table. */
+        const val DEFAULT_LOG_LIFETIME_DAYS = 30
 
         private const val SEND_INTERVAL_MIN = "send_interval_min"
         private const val SEND_INTERVAL_MAX = "send_interval_max"

--- a/app/src/main/java/me/capcom/smsgateway/modules/settings/SettingsService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/settings/SettingsService.kt
@@ -1,7 +1,9 @@
 package me.capcom.smsgateway.modules.settings
 
 import android.content.Context
+import android.util.Log
 import me.capcom.smsgateway.R
+import me.capcom.smsgateway.domain.EntitySource
 import me.capcom.smsgateway.modules.encryption.EncryptionSettings
 import me.capcom.smsgateway.modules.gateway.GatewaySettings
 import me.capcom.smsgateway.modules.incoming.IncomingMessagesSettings
@@ -32,16 +34,58 @@ class SettingsService(
         "webhooks" to webhooksSettings
     )
 
+    /**
+     * Keys the cloud server is not permitted to set.
+     *
+     * SettingsUpdateWorker applies whatever the server returns, every 24
+     * hours. These two values exist specifically so that the server cannot
+     * read or forge traffic, so letting the server replace them defeats
+     * their entire purpose: swapping the passphrase makes future
+     * "end-to-end encrypted" messages readable by it, and swapping the
+     * signing key lets it forge events the receiver will trust. The only
+     * signal to the user was a generic "settings changed" notification.
+     *
+     * The authenticated local API (PATCH /settings, settings:write) is
+     * unaffected — that is the device owner configuring their own device.
+     */
+    private fun stripCloudProtected(data: Map<String, *>): Map<String, *> {
+        return data.mapValues { (section, value) ->
+            val blocked = CLOUD_PROTECTED_KEYS[section] ?: return@mapValues value
+            val inner = value as? Map<*, *> ?: return@mapValues value
+            val kept = inner.filterKeys { it !in blocked }
+            if (kept.size != inner.size) {
+                Log.w(
+                    "SettingsService",
+                    "Ignoring cloud-supplied $section keys: " +
+                            inner.keys.filter { it in blocked }.joinToString()
+                )
+            }
+            kept
+        }.filterValues { (it as? Map<*, *>)?.isNotEmpty() ?: (it != null) }
+    }
+
     fun getAll(): Map<String, *> {
         return settings.mapValues { (it.value as? Exporter)?.export() }
     }
 
-    fun update(data: Map<String, *>) {
+    companion object {
+        private val CLOUD_PROTECTED_KEYS: Map<String, Set<String>> = mapOf(
+            "encryption" to setOf("passphrase"),
+            "webhooks" to setOf("signing_key"),
+        )
+    }
+
+    fun update(data: Map<String, *>, source: EntitySource = EntitySource.Local) {
         if (data.isEmpty()) {
             return
         }
 
-        val changed = data.map { (key, value) ->
+        val effective = if (source == EntitySource.Cloud) stripCloudProtected(data) else data
+        if (effective.isEmpty()) {
+            return
+        }
+
+        val changed = effective.map { (key, value) ->
             try {
                 settings[key]?.let {
                     (it as? Importer)?.import(value as Map<String, *>)

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebHookUrlPolicy.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebHookUrlPolicy.kt
@@ -1,0 +1,80 @@
+package me.capcom.smsgateway.modules.webhooks
+
+import java.net.URI
+
+/**
+ * Which webhook destinations the gateway refuses to call.
+ *
+ * Webhook deliveries are issued from the phone's own network position, and
+ * URL validation previously checked only the scheme. An `https://` URL
+ * pointing at a private range therefore turned the gateway into a POST proxy
+ * into whatever LAN it happened to be on, reachable by anyone holding the
+ * `webhooks:write` scope or by the cloud server. Per-attempt status codes are
+ * written to the log table, so it also worked as a blind scanner.
+ *
+ * Deliberately a literal check against the host as written, not a DNS
+ * resolution: resolving here and connecting later is a time-of-check problem,
+ * and doing name resolution during validation is its own denial-of-service
+ * surface. This blocks the direct case; a determined attacker with a domain
+ * resolving to a private address is out of scope for this layer and needs
+ * the check repeated at connect time.
+ *
+ * The explicit `http://127.0.0.1` allowance in
+ * [WebHooksService.replace][WebHooksService] is intentional and is applied
+ * before this check, so self-hosted loopback receivers keep working.
+ */
+object WebHookUrlPolicy {
+
+    fun isForbiddenHost(url: String): Boolean {
+        val host = try {
+            URI(url).host?.lowercase()
+        } catch (_: Exception) {
+            return true // unparseable: refuse rather than guess
+        } ?: return true
+
+        val bare = host.trim('[', ']')
+
+        if (bare == "localhost" || bare.endsWith(".localhost")) return true
+        if (bare.endsWith(".local") || bare.endsWith(".internal")) return true
+
+        if (isIpv4Literal(bare)) return isForbiddenIpv4(bare)
+        if (bare.contains(':')) return isForbiddenIpv6(bare)
+
+        return false
+    }
+
+    private fun isIpv4Literal(host: String): Boolean {
+        val parts = host.split('.')
+        return parts.size == 4 && parts.all { p ->
+            p.isNotEmpty() && p.length <= 3 && p.all(Char::isDigit) && p.toInt() <= 255
+        }
+    }
+
+    private fun isForbiddenIpv4(host: String): Boolean {
+        val o = host.split('.').map { it.toInt() }
+        return when {
+            o[0] == 0 -> true                                  // 0.0.0.0/8
+            o[0] == 10 -> true                                 // private
+            o[0] == 127 -> true                                // loopback
+            o[0] == 169 && o[1] == 254 -> true                 // link-local, incl. 169.254.169.254
+            o[0] == 172 && o[1] in 16..31 -> true              // private
+            o[0] == 192 && o[1] == 168 -> true                 // private
+            o[0] == 192 && o[1] == 0 && o[2] == 0 -> true      // IETF protocol assignments
+            o[0] == 100 && o[1] in 64..127 -> true             // carrier-grade NAT
+            o[0] >= 224 -> true                                // multicast and reserved
+            else -> false
+        }
+    }
+
+    private fun isForbiddenIpv6(host: String): Boolean {
+        val h = host.substringBefore('%')          // strip any zone index
+        if (h == "::" || h == "::1") return true   // unspecified, loopback
+        if (h.startsWith("fe80") || h.startsWith("fec0")) return true  // link/site-local
+        if (h.startsWith("fc") || h.startsWith("fd")) return true      // unique local
+        if (h.startsWith("ff")) return true                            // multicast
+        // IPv4-mapped, e.g. ::ffff:127.0.0.1
+        val mapped = h.substringAfterLast(':')
+        if (isIpv4Literal(mapped)) return isForbiddenIpv4(mapped)
+        return false
+    }
+}

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebHooksService.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebHooksService.kt
@@ -88,6 +88,18 @@ class WebHooksService(
         if (!isValidUrl) {
             throw IllegalArgumentException("url must start with https:// or http://127.0.0.1")
         }
+
+        // Only the scheme was checked before. Webhook deliveries are issued
+        // from the phone's network position, so an https:// URL pointing at a
+        // private range turned the gateway into a POST proxy into whatever
+        // LAN it sits on — and per-attempt status codes are logged, making it
+        // a usable blind scanner. The explicit 127.0.0.1 allowance above is
+        // deliberate and stays.
+        if (!isLocalhost && WebHookUrlPolicy.isForbiddenHost(webHook.url)) {
+            throw IllegalArgumentException(
+                "url must not point at a private, loopback or link-local address"
+            )
+        }
         
         if (webHook.event !in WebHookEvent.values()) {
             throw IllegalArgumentException(

--- a/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebhooksSettings.kt
+++ b/app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebhooksSettings.kt
@@ -16,17 +16,24 @@ class WebhooksSettings(
         get() = storage.get<Int>(RETRY_COUNT) ?: 15
 
     val signingKey: String
+        // 43 characters of the NanoID alphabet is ~256 bits. The previous
+        // length of 8 is ~48 bits: one captured payload/signature pair is
+        // enough to recover it offline and then forge signed events
+        // indefinitely. Existing keys are left alone — rotating one silently
+        // would break the receiver's verification — so only newly generated
+        // keys get the longer length.
         get() = storage.get<String>(SIGNING_KEY)
             ?: NanoIdUtils.randomNanoId(
                 NanoIdUtils.DEFAULT_NUMBER_GENERATOR,
                 NanoIdUtils.DEFAULT_ALPHABET,
-                8
+                SIGNING_KEY_LENGTH
             ).also { storage.set(SIGNING_KEY, it) }
 
     companion object {
         const val INTERNET_REQUIRED = "internet_required"
         const val RETRY_COUNT = "retry_count"
         const val SIGNING_KEY = "signing_key"
+        const val SIGNING_KEY_LENGTH = 43
     }
 
     override fun export(): Map<String, *> {

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Backup is disabled outright in the manifest (android:allowBackup="false").
+    These rules exist as defence in depth: if backup is ever re-enabled, the
+    credential store must not travel with it.
+
+    The default shared_prefs file holds the local API password, the JWT
+    signing secret, the cloud login and bearer token, the private token, the
+    end-to-end encryption passphrase and the webhook signing key. The
+    database and the stored webhook payloads hold message bodies and
+    recipient numbers.
+
+    Used on Android 11 and below.
+-->
+<full-backup-content>
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="database" path="." />
+    <exclude domain="file" path="webhook_payloads" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Android 12+ equivalent of backup_rules.xml. Covers both cloud backup and
+    device-to-device transfer: the credential store and message content must
+    leave the device in neither.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="file" path="webhook_payloads" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="file" path="webhook_payloads" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/test/java/me/capcom/smsgateway/domain/ProcessingStateRankTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/domain/ProcessingStateRankTest.kt
@@ -1,0 +1,79 @@
+package me.capcom.smsgateway.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The rank ordering is what stops a late platform broadcast from moving a
+ * recipient backwards. Pure Kotlin, no Android dependencies, so it runs in
+ * the existing `./gradlew test` step.
+ */
+class ProcessingStateRankTest {
+
+    private fun allowed(from: ProcessingState, to: ProcessingState) = from.rank <= to.rank
+
+    @Test
+    fun `normal progression is allowed`() {
+        assertTrue(allowed(ProcessingState.Pending, ProcessingState.Processed))
+        assertTrue(allowed(ProcessingState.Processed, ProcessingState.Sent))
+        assertTrue(allowed(ProcessingState.Sent, ProcessingState.Delivered))
+    }
+
+    @Test
+    fun `the reported race cannot regress a recipient`() {
+        // The send loop writes Processed after dispatching; the platform's
+        // ACTION_SENT arrives on another coroutine. Whichever landed last
+        // used to win, and a recipient clobbered back to Processed never
+        // left it when delivery reports were off.
+        assertTrue("Sent must not be overwritten by Processed",
+            !allowed(ProcessingState.Sent, ProcessingState.Processed))
+        assertTrue("Delivered must not be regressed to Sent",
+            !allowed(ProcessingState.Delivered, ProcessingState.Sent))
+        assertTrue("Delivered must not be regressed to Processed",
+            !allowed(ProcessingState.Delivered, ProcessingState.Processed))
+    }
+
+    @Test
+    fun `a failure stays authoritative whenever it arrives`() {
+        // This preserves the behaviour of the previous guard, which was
+        // `state <> 'Failed'` — anything could become Failed.
+        for (from in ProcessingState.values()) {
+            assertTrue(
+                "$from should still be able to become Failed",
+                allowed(from, ProcessingState.Failed)
+            )
+        }
+    }
+
+    @Test
+    fun `cancellation is reachable from the states that precede it`() {
+        assertTrue(allowed(ProcessingState.Pending, ProcessingState.Cancelling))
+        assertTrue(allowed(ProcessingState.Cancelling, ProcessingState.Cancelled))
+        assertTrue(allowed(ProcessingState.Pending, ProcessingState.Cancelled))
+    }
+
+    @Test
+    fun `re-writing the same state is allowed so error text can be updated`() {
+        for (state in ProcessingState.values()) {
+            assertTrue("$state should be re-writable", allowed(state, state))
+        }
+    }
+
+    @Test
+    fun `pending is the lowest rank so reconciliation writes are never blocked`() {
+        // MessagesRepository.getPending() selects WHERE state = 'Pending' and
+        // then syncs the denormalised message column in a `while (true)`
+        // loop. If that update could be blocked, the loop would spin forever
+        // and wedge the send worker.
+        val lowest = ProcessingState.values().minOf { it.rank }
+        assertEquals(lowest, ProcessingState.Pending.rank)
+    }
+
+    @Test
+    fun `terminal states rank highest`() {
+        val maxRank = ProcessingState.values().maxOf { it.rank }
+        assertEquals(maxRank, ProcessingState.Failed.rank)
+        assertEquals(maxRank, ProcessingState.Cancelled.rank)
+    }
+}

--- a/app/src/test/java/me/capcom/smsgateway/modules/webhooks/WebHookUrlPolicyTest.kt
+++ b/app/src/test/java/me/capcom/smsgateway/modules/webhooks/WebHookUrlPolicyTest.kt
@@ -1,0 +1,82 @@
+package me.capcom.smsgateway.modules.webhooks
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure Kotlin, no Android dependencies, so it runs in `./gradlew test`. */
+class WebHookUrlPolicyTest {
+
+    @Test
+    fun `ordinary public destinations are allowed`() {
+        for (url in listOf(
+            "https://example.com/hook",
+            "https://api.example.co.uk:8443/webhooks/sms",
+            "https://203.0.113.10/hook",
+            "https://8.8.8.8/hook",
+        )) {
+            assertFalse(url, WebHookUrlPolicy.isForbiddenHost(url))
+        }
+    }
+
+    @Test
+    fun `private ranges are refused`() {
+        for (url in listOf(
+            "https://10.0.0.5/hook",
+            "https://172.16.4.1/hook",
+            "https://172.31.255.254/hook",
+            "https://192.168.1.1/hook",
+            "https://100.64.0.1/hook",
+        )) {
+            assertTrue(url, WebHookUrlPolicy.isForbiddenHost(url))
+        }
+    }
+
+    @Test
+    fun `the cloud metadata address is refused`() {
+        assertTrue(WebHookUrlPolicy.isForbiddenHost("https://169.254.169.254/latest/meta-data/"))
+    }
+
+    @Test
+    fun `loopback and unspecified are refused`() {
+        for (url in listOf(
+            "https://127.0.0.1/hook",
+            "https://127.1.2.3/hook",
+            "https://0.0.0.0/hook",
+            "https://localhost/hook",
+            "https://foo.localhost/hook",
+        )) {
+            assertTrue(url, WebHookUrlPolicy.isForbiddenHost(url))
+        }
+    }
+
+    @Test
+    fun `172 dot 32 is public and must not be caught by the 172 dot 16 slash 12 rule`() {
+        assertFalse(WebHookUrlPolicy.isForbiddenHost("https://172.32.0.1/hook"))
+        assertFalse(WebHookUrlPolicy.isForbiddenHost("https://172.15.0.1/hook"))
+    }
+
+    @Test
+    fun `ipv6 loopback link-local and unique-local are refused`() {
+        for (url in listOf(
+            "https://[::1]/hook",
+            "https://[fe80::1]/hook",
+            "https://[fd00::1]/hook",
+            "https://[::ffff:127.0.0.1]/hook",
+        )) {
+            assertTrue(url, WebHookUrlPolicy.isForbiddenHost(url))
+        }
+    }
+
+    @Test
+    fun `mdns and internal suffixes are refused`() {
+        assertTrue(WebHookUrlPolicy.isForbiddenHost("https://printer.local/hook"))
+        assertTrue(WebHookUrlPolicy.isForbiddenHost("https://db.internal/hook"))
+    }
+
+    @Test
+    fun `an unparseable url is refused rather than guessed at`() {
+        assertTrue(WebHookUrlPolicy.isForbiddenHost("not a url"))
+        assertTrue(WebHookUrlPolicy.isForbiddenHost(""))
+    }
+}


### PR DESCRIPTION
NOT BUILT OR TESTED. No JDK, Android SDK or Gradle was available on the machine these changes were written on, so nothing here has been compiled and no test has been run. Symbols were checked by hand against the sources they reference. Treat this as a reviewed patch series, not a verified one.

Reliability
-----------
Cloud mode had no keep-alive on any device with Play Services. SSEForegroundService holds the only wake lock and WiFi lock in cloud mode, and EventsReceiver started it only when settings.fcmToken was null. With a token present it never ran, leaving a Firebase push that Doze throttles plus PullMessagesWorker at the 15-minute platform minimum, which Doze batches into maintenance windows that can be far longer. Ping, the other wake-lock holder, is off by default. Observed in the field as a device going 60+ minutes without contacting the server while messages queued in the cloud.

  - GatewaySettings gains keepConnectionAlive (default true) and shouldKeepConnection, which preserves the old no-token behaviour and adds an explicit preference for everyone else.
  - GatewayService.start() also starts the service. DeviceRegisteredEvent only fires on first registration, so an already-registered device coming back from boot or process death never started it at all.

Correctness
-----------
Recipient state could move backwards. The three state-update queries guarded only on `state <> 'Failed'`, with no ordering rule. The send loop writes Processed after dispatching while the platform's ACTION_SENT arrives on another coroutine, so whichever landed last won: a Sent could be clobbered back to Processed and, with delivery reports off, never leave it; a late Sent could regress an already-Delivered recipient. The v1.70.3 change that made broadcast handling asynchronous widened that window rather than closing it, which is consistent with v1.70.1 and v1.70.3 both being fixes in this area.

  - ProcessingState gains `rank`; the three queries now require the new rank to be >= the stored one. Terminal states rank highest so a failure stays authoritative whenever it arrives, matching the previous behaviour.
  - Pending is the lowest rank, so the reconciliation write inside MessagesRepository.getPending()'s `while (true)` loop can never be blocked. That query selects WHERE state = 'Pending', so the loop cannot wedge.
  - Test added for the ordering (pure Kotlin, runs in ./gradlew test).

The message table grew forever. MessagesSettings.logLifetimeDays had no default, so truncateLog() returned before deleting anything. LogsSettings already seeds 30 days for its own table; this now does the same, only when the operator has not chosen a value.

Security
--------
  - EventsReceiver was exported with no permission guard. Any app on the device, with no permissions, could broadcast ACTION_DELIVERED carrying an arbitrary "<messageId>|<phone>" and a chosen result code, forging a state that is then signed into a webhook and pushed to the cloud. Now exported=false; the app's own PendingIntents are explicit.
  - allowBackup was true with no extraction rules, so the local API password, JWT secret, cloud credentials, encryption passphrase and webhook signing key all left in any backup or device transfer. Backup is now off, with rules excluding the credential store and message content as defence in depth.
  - The local server compared passwords with `==` and nothing counted failed attempts. New LoginThrottle: constant-time comparison plus a global lockout after 10 failures in 5 minutes. Global rather than per-address deliberately, since a LAN peer's address is trivially rotated.
  - The cloud server could set the encryption passphrase and the webhook signing key via the 24-hourly settings sync, defeating the purpose of both. SettingsService.update() now takes an EntitySource and strips those keys when the source is Cloud. The authenticated local API is unaffected.
  - Webhook URLs were validated on scheme alone, so an https:// URL pointing at a private range made the gateway a POST proxy into its own LAN. New WebHookUrlPolicy blocks private, loopback, link-local, CGNAT and multicast ranges for both IPv4 and IPv6, with tests. The explicit http://127.0.0.1 allowance is preserved.
  - The webhook signing key was generated at 8 characters (~48 bits), enough to recover offline from one captured payload and forge events indefinitely. New keys are 43 characters (~256 bits); existing keys are left alone, since rotating one silently would break the receiver.
  - GET /messages had no bound on `limit`. It goes straight into SQL LIMIT, where SQLite treats a negative as no limit, so ?limit=-1 with includeContent=true materialised the whole history. Now 1..500, matching what InboxRoutes already enforced.

Deliberately not changed
------------------------
  - Basic auth still grants every scope. It is the device owner's admin password and narrowing it would break the integrations the docs recommend. The real exposure is that it crosses the LAN in cleartext, which the throttle above addresses.
  - The encryption envelope still reuses the salt as the IV and uses unauthenticated CBC. Fixing it properly means a versioned envelope and a matching server change, which cannot be done safely without being able to run anything.
  - Multi-part SMS still fires one callback per part. The fix needs distinct request codes and a test rig to confirm.
  - targetSdk stays at 33; bumping it needs a build to verify.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63134303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 0/5</h2>

The PR is not safe to merge until rejected state transitions stop producing external history, webhook validation covers cloud-synchronized entries, and unauthenticated clients can no longer globally deny Basic-auth access.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Rejected states enter history** <a href="https://github.com/capcom6/android-sms-gateway/pull/445#discussion_r3991061072">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Cloud webhooks bypass validation** <a href="https://github.com/capcom6/android-sms-gateway/pull/445/files#diff-1a2320f52bf471b1120f06f06ef901c1a57331a27d16f90ebccbe6e27d264b7dR75">▶</a>
3. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Global lockout enables denial** <a href="https://github.com/capcom6/android-sms-gateway/pull/445#discussion_r3991061078">▶</a>
4. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Keep\-alive cannot be disabled** <a href="https://github.com/capcom6/android-sms-gateway/pull/445#discussion_r3991061094">▶</a>
5. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Pagination contract remains outdated** <a href="https://github.com/capcom6/android-sms-gateway/pull/445#discussion_r3991061106">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
app/src/main/java/me/capcom/smsgateway/data/dao/MessagesDao.kt:215-216
When the rank guard rejects a stale recipient transition, this wrapper still inserts that transition into `RecipientState`. In the `Processed`/`Sent` race, the main row can remain `Sent` while gaining a later `Processed` history entry. Cloud synchronization reads this history, and the service emits a state-change event without knowing that the update affected zero rows, so external state can disagree with the accepted database state. Return the affected-row count and only record or emit transitions that were applied.

### Issue 2
app/src/main/java/me/capcom/smsgateway/modules/webhooks/WebHooksService.kt:69-75
The new host policy is applied only by `replace()`, while periodic cloud synchronization calls `sync()` and stores every server-supplied URL directly. These entries are later delivered without another policy check. The related server's [`mobile.go`](https://github.com/android-sms-gateway/server/blob/HEAD/internal/sms-gateway/handlers/webhooks/mobile.go) returns stored webhook URLs, while [`service.go`](https://github.com/android-sms-gateway/server/blob/HEAD/internal/sms-gateway/modules/webhooks/service.go) validates event and device ownership but not destination hosts. A private, loopback, or metadata URL configured through the cloud path can therefore still turn the phone into a POST proxy. Apply the same URL policy during synchronization or immediately before delivery.

> **How this was verified:** Server-provided URLs flow through `WebhooksUpdateWorker` and `sync()` into delivery without passing the only call to `WebHookUrlPolicy.isForbiddenHost`.

### Issue 3
app/src/main/java/me/capcom/smsgateway/modules/localserver/WebService.kt:89-103
Ten failed Basic-auth requests activate a process-wide lockout that rejects correct credentials from every client. Because the local server listens on all interfaces, any reachable LAN client can trigger this and renew it by sending another ten failures after each five-minute lockout. Existing JWT holders remain usable, but an operator relying on Basic auth cannot authenticate or obtain a new JWT during the attack. Use throttling that limits abusive work without allowing one unauthenticated client to deny every legitimate principal.

> **How this was verified:** Failed Basic-auth requests from any network client update one shared singleton whose locked state is checked before all subsequent Basic credential comparisons.

### Issue 4
app/src/main/java/me/capcom/smsgateway/modules/gateway/GatewaySettings.kt:48-54
`keepConnectionAlive` defaults to true, but this change adds no preference UI or other user-facing way to configure it. There is also no observer that stops an already-running SSE service when the value changes. Users therefore cannot select the documented push-only mode, and even an external settings change will not take effect until the gateway is fully restarted. Expose the setting and reconcile the service lifecycle when it changes.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

### Issue 5
app/src/main/java/me/capcom/smsgateway/modules/localserver/routes/MessagesRoutes.kt:67-80
This route now enforces a `limit` range of 1–500 and rejects negative offsets, but the `/messages` OpenAPI definition still describes only integer parameters with defaults. Generated clients and integrations cannot discover the new rejection behavior from the published contract. Add the minimum and maximum constraints and document the non-negative offset alongside this implementation change.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Prevents delivery-state rows from regressing according to a new rank ordering, but rejected transitions can still leak into history and external notifications.
- Starts the persistent cloud connection by default and introduces a keep-alive preference, though that preference is not currently user-configurable or lifecycle-reactive.
- Protects encryption and webhook secrets from cloud settings updates using source-aware filtering.
- Adds backup restrictions, a non-exported result receiver, stronger webhook signing keys, and bounded message queries.
- Adds webhook destination checks, but cloud-synchronized URLs bypass them.
- Adds global Basic-auth throttling, which unauthenticated network clients can abuse to deny legitimate Basic access.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Cloud webhook configuration] --> B[Server stores URL]
  B --> C[Mobile GET /webhooks]
  C --> D[WebhooksUpdateWorker]
  D --> E[WebHooksService.sync]
  E -->|No URL policy| F[(Webhook database)]
  F --> G[Webhook event]
  G --> H[SendWebhookWorker]
  H --> I[Private or loopback destination]

  J[Local webhook API] --> K[WebHooksService.replace]
  K --> L[WebHookUrlPolicy]
  L --> F
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["Security and reliability fixes from a co..."](https://github.com/capcom6/android-sms-gateway/commit/dffbb9120cdb110d00cc6f69163be6578c734555)</sub>

<!-- /greptile_comment -->